### PR TITLE
Content-Disposition filename also gives a UTF-8 encoded Filename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>1.8</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -837,7 +837,7 @@ public class Response {
         addHeaderIfNotExists("Content-Disposition",
                              (download ? "attachment;" : "inline;") + "filename=\"" + name.replaceAll(
                                      "[^A-Za-z0-9\\-_\\.]",
-                                     "_") + ";" + "filename*=UTF-8''" + Strings.urlEncode(name));
+                                     "_") + "\";filename*=UTF-8''" + Strings.urlEncode(name.replace(" ", "_")));
     }
 
     /*

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -835,9 +835,14 @@ public class Response {
      */
     private void setContentDisposition(String name, boolean download) {
         addHeaderIfNotExists("Content-Disposition",
-                             (download ? "attachment;" : "inline;") + "filename=\"" + name.replaceAll(
-                                     "[^A-Za-z0-9\\-_\\.]",
-                                     "_") + "\"");
+                             (download ? "attachment;" : "inline;")
+                             + "filename=\""
+                             + name.replaceAll("[^A-Za-z0-9\\-_\\.]",
+                                               "_")
+                             + "\""
+                             + "filename*=UTF-8''\""
+                             + Strings.urlEncode(name.replace(" ", "_"))
+                             + "\"");
     }
 
     /*

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -835,14 +835,9 @@ public class Response {
      */
     private void setContentDisposition(String name, boolean download) {
         addHeaderIfNotExists("Content-Disposition",
-                             (download ? "attachment;" : "inline;")
-                             + "filename=\""
-                             + name.replaceAll("[^A-Za-z0-9\\-_\\.]",
-                                               "_")
-                             + "\""
-                             + "filename*=UTF-8''\""
-                             + Strings.urlEncode(name.replace(" ", "_"))
-                             + "\"");
+                             (download ? "attachment;" : "inline;") + "filename=\"" + name.replaceAll(
+                                     "[^A-Za-z0-9\\-_\\.]",
+                                     "_") + ";" + "filename*=UTF-8''" + Strings.urlEncode(name));
     }
 
     /*


### PR DESCRIPTION
the "filename*=UTF-8''" notation will be honored by modern browsers and ignored by older browsers, which will use the "filename" value as the fallback.

http://greenbytes.de/tech/tc2231/#attfnboth