### PR TITLE
Word-break in Tables

### DIFF
--- a/src/main/resources/default/assets/wondergem/stylesheets/utilities.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/utilities.scss
@@ -62,6 +62,7 @@ img {
 
 .word-wrap {
   word-wrap: break-word;
+  word-break: break-word;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
   -ms-hyphens: auto;


### PR DESCRIPTION
Chrome-Fix: Use also word-break to break long words in Tables