### PR TITLE
Fixed "funny" behaviour of Java annotations API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>2.8.1</version>
+    <version>2.8.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -109,6 +109,8 @@ public class Permissions {
     public static Set<String> computePermissionsFromAnnotations(AnnotatedElement object) {
         if (object.isAnnotationPresent(Permission.class)
             || object.isAnnotationPresent(NotPermission.class)
+            || object.isAnnotationPresent(PermissionList.class)
+            || object.isAnnotationPresent(NotPermissionList.class)
             || object.isAnnotationPresent(LoginRequired.class)) {
             Set<String> result = Sets.newTreeSet();
             for (Permission p : object.getAnnotationsByType(Permission.class)) {


### PR DESCRIPTION
If multiple annoations of a type are present, one has to check for the container annotation, not the type itself (PermissionList instead of Permission)