### PR TITLE
output the error message when fileUpload / imageUpload fails

### DIFF
--- a/src/main/resources/default/view/wondergem/template-script.html
+++ b/src/main/resources/default/view/wondergem/template-script.html
@@ -231,7 +231,7 @@
             onComplete: function (cmp_id, fileName, responseJSON) {
                 clearMessages();
                 if (responseJSON.error) {
-                    addError(responseJSON.error);
+                    addError(responseJSON.message);
                 } else if (responseJSON.message) {
                     addInfo(responseJSON.message);
                 }
@@ -279,7 +279,7 @@
             onComplete: function (cmp_id, fileName, responseJSON) {
                 clearMessages();
                 if (responseJSON.error) {
-                    addError(responseJSON.error);
+                    addError(responseJSON.message);
                 } else if (responseJSON.message) {
                     if (responseJSON.action) {
                         addInfo(responseJSON.message, responseJSON.action, responseJSON.actionLabel);


### PR DESCRIPTION
Routes with JSONcall=true throwing exception output the error-message in json.message and json.error=true and so should every other json-call.

Through this fix, the Usermessage shown after an upload fails is the actual error message instead of just 'true'.