### PR TITLE
Prevents mails being sent to a .local address

### DIFF
--- a/src/main/java/sirius/web/mails/Mails.java
+++ b/src/main/java/sirius/web/mails/Mails.java
@@ -796,6 +796,13 @@ public class Mails implements MetricProvider {
 
         @Override
         public void run() {
+            if (mail.receiverEmail != null && mail.receiverEmail.toLowerCase().endsWith(".local")) {
+                LOG.WARN(
+                        "Not going to send an email to '%s' with subject '%s' as this is a local address. Going to simulate...",
+                        mail.receiverEmail,
+                        mail.subject);
+                mail.simulate = true;
+            }
             determineTechnicalSender();
             Operation op = Operation.create("mail",
                                             () -> "Sending eMail: " + mail.subject + " to: " + mail.receiverEmail,


### PR DESCRIPTION
Prevents mails being sent to a .local address

This can be used for testing purposes. Addresses ending in .local
will not receive mails (but being simulated)...

Patchnote: eMails with .local will no longer receive emails