### PR TITLE
Adds Access-Control-Allow-Credentials: true as CORS header

### DIFF
--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -303,6 +303,7 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
         String requestHeaders = currentRequest.headers().get(HttpHeaders.Names.ACCESS_CONTROL_REQUEST_HEADERS);
         currentContext.respondWith()
                       .setHeader(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS, "GET,PUT,POST,DELETE")
+                      .setHeader(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true")
                       .setHeader(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS,
                                  requestHeaders == null ? "" : requestHeaders)
                       .status(HttpResponseStatus.OK);


### PR DESCRIPTION
Adds Access-Control-Allow-Credentials: true as CORS header

If the default facility handles CORS requests, we also allow credentials, as
this is required when making ajax calls while relying on cookies. Otherwise
cookies will be omitted from the call.