### PR TITLE
Updates sirius-kernel to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>3.4.4</version>
+    <version>3.5</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>2.13</version>
+            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>LATEST</version>
+            <version>[2.15,)</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Updates sirius-kernel to the latest version

Also removes the LATEST reference to the test-jar as maven is
too intelligent to do this corrently. We now resort to a version range.