### PR TITLE
Updates to the latest kernel and implements proper fork behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>2.16</version>
+            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>[2.15,)</version>
+            <version>[3.0,)</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.1</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>4.0</version>
+    <version>4.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1715,6 +1715,13 @@ public class WebContext implements SubContext {
     }
 
     @Override
+    public SubContext fork() {
+        // There is no reasonable way to clone this context. So we simply return the original instance as there
+        // is only one request to answer anyway.
+        return this;
+    }
+
+    @Override
     public void detach() {
         // Detaching the context from the current thread has no consequences as
         // a request cann be passed on to another thread...

--- a/src/main/java/sirius/web/security/ScopeDefaultConfigController.java
+++ b/src/main/java/sirius/web/security/ScopeDefaultConfigController.java
@@ -25,8 +25,16 @@ import java.util.List;
 @Register(classes = Controller.class)
 public class ScopeDefaultConfigController extends BasicController {
 
+    /**
+     * Describes the permission required to view the default scope config.
+     */
     public static final String PERMISSION_VIEW_SCOPE_DEFAULT_CONFIG = "permission-view-scope-default-config";
 
+    /**
+     * Shows the default scope config for the first of the known default config file.
+     *
+     * @param ctx the current request
+     */
     @DefaultRoute
     @Permission(PERMISSION_VIEW_SCOPE_DEFAULT_CONFIG)
     @Routed("/system/scope-config")
@@ -39,6 +47,12 @@ public class ScopeDefaultConfigController extends BasicController {
         config(ctx, files.get(0));
     }
 
+    /**
+     * Shows the default scope config for the given config file.
+     *
+     * @param ctx  the current request
+     * @param name the name of the config file
+     */
     @Permission(PERMISSION_VIEW_SCOPE_DEFAULT_CONFIG)
     @Routed("/system/scope-config/:1")
     public void config(WebContext ctx, String name) {

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -477,6 +477,18 @@ public class UserContext implements SubContext {
     }
 
     @Override
+    public SubContext fork() {
+        // We return a copy which keeps the same user and scope - but which can be change independently.
+        // Otherwise a UserContext.runAs(...) which forks a task, would run into trouble as the
+        // context is immediatelly switched back.
+        UserContext child = new UserContext();
+        child.currentUser = currentUser;
+        child.currentScope = currentScope;
+
+        return child;
+    }
+
+    @Override
     public void detach() {
         // No action needed when this is detached from the current thread...
     }


### PR DESCRIPTION
Updates to the latest kernel and implements proper fork behaviour

A UserContext must not be shared between two threads as this
leads to intransparent behaviour, if one thread switches the user.
Therefore a copy is created, so that they initially share the same user
but can change it independently.