### PR TITLE
Sets fixed icon width in tables

### DIFF
--- a/src/main/resources/default/assets/wondergem/stylesheets/tables.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/tables.scss
@@ -135,6 +135,12 @@ tfoot {
 }
 
 
+// Set Icons in Tables to fixed width to ensure proper spacing and avoid using .fa-fw everywhere
+td .fa {
+  width: 1.28571429em;
+  text-align: center;
+}
+
 // Enhance readabilty
 tr.info a {
   color: #4a697d;


### PR DESCRIPTION
Font awesome uses an extra class (.fa-fw) for spacing which we try to avoid so we don't have to change so many templates.