### PR TITLE
Always removes pre-compiled templates from the cache directory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/templates/rythm/RythmConfig.java
+++ b/src/main/java/sirius/web/templates/rythm/RythmConfig.java
@@ -13,7 +13,6 @@ import org.rythmengine.Rythm;
 import org.rythmengine.RythmEngine;
 import org.rythmengine.conf.RythmConfigurationKey;
 import sirius.kernel.Lifecycle;
-import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Files;
 import sirius.kernel.di.std.Register;
@@ -76,12 +75,13 @@ public class RythmConfig implements Lifecycle {
                                + Files.toSaneFileName(CallContext.getNodeName()).orElse("node")
                                + "_rythm");
         tmpDir.mkdirs();
-        if (Sirius.isDev()) {
-            if (tmpDir.listFiles() != null) {
-                for (File file : tmpDir.listFiles()) {
-                    if (file.getName().endsWith(".java") || file.getName().endsWith(".rythm")) {
-                        file.delete();
-                    }
+
+        // Delete all templates on startup to force a clean recompile - otherwise *SOMETIMES* old
+        // templates might get used :-/
+        if (tmpDir.listFiles() != null) {
+            for (File file : tmpDir.listFiles()) {
+                if (file.getName().endsWith(".java") || file.getName().endsWith(".rythm")) {
+                    file.delete();
                 }
             }
         }


### PR DESCRIPTION
Always removes pre-compiled templates from the cache directory.

Sometimes rythm doesn’t recompile changed templates, therefore
a startup should provide a clean environment.