### PR TITLE
Disables the system state messages in testing environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>6.8</version>
+    <version>6.8.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -11,6 +11,7 @@ package sirius.web.security;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
+import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.SubContext;
 import sirius.kernel.commons.Strings;
@@ -329,7 +330,7 @@ public class UserContext implements SubContext {
      * @return a list of messages to be shown to the user
      */
     public List<Message> getMessages() {
-        if (cluster.getClusterState() == MetricState.RED && getUser().hasPermission(PERMISSION_SYSTEM_NOTIFY_STATE)) {
+        if (cluster.getClusterState() == MetricState.RED && getUser().hasPermission(PERMISSION_SYSTEM_NOTIFY_STATE) && !Sirius.isStartedAsTest()) {
             Message systemStateWarning = Message.error(Strings.apply("System state is %s (Cluster state is %s)",
                                                                      cluster.getNodeState(),
                                                                      cluster.getClusterState()))


### PR DESCRIPTION
Tests sometimes failed because they expected no [Messages](http://sirius-lib.net/apidocs/sirius-web/sirius/web/controller/Message.html) to be present in the response, but got some `System state is ...`-Messages

![image](https://cloud.githubusercontent.com/assets/7695721/23467316/00aff5fc-fe9e-11e6-8d55-022c4b507b34.png)
