### PR TITLE
Fixes "Modifies the UserContextHelper so that one can see the actual messages if an assertion fails"

### DIFF
--- a/src/test/java/sirius/web/security/UserContextHelper.groovy
+++ b/src/test/java/sirius/web/security/UserContextHelper.groovy
@@ -47,7 +47,7 @@ class UserContextHelper {
      * @return <tt>true</tt> if the assertion is fulfilled, <tt>false</tt> otherwise
      */
     public static void expectNoErrorMessages(TestResponse response) {
-        assert getUserContext(response).getMessages().all { msg -> msg.getType() != Message.ERROR }
+        assert getUserContext(response).getMessages().every { msg -> msg.getType() != Message.ERROR }
     }
 
     /**


### PR DESCRIPTION
the Groovy method's name is `every`, not `all`