### PR TITLE
Adds a fallback for composites based on the ScopeInfo directly instead of the inner scope object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>7.1</version>
+    <version>7.1.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -54,9 +54,8 @@ public class ScopeInfo extends Composable {
      * If no distinct scope is recognized by the current <tt>ScopeDetector</tt> or if no detector is installed,
      * this scope is used.
      */
-    public static final ScopeInfo DEFAULT_SCOPE = new ScopeInfo(DEFAULT_SCOPE_ID,
-                                                                DEFAULT_SCOPE_ID,
-                                                                DEFAULT_SCOPE_ID, null, null, null);
+    public static final ScopeInfo DEFAULT_SCOPE =
+            new ScopeInfo(DEFAULT_SCOPE_ID, DEFAULT_SCOPE_ID, DEFAULT_SCOPE_ID, null, null, null);
 
     private String scopeId;
     private String scopeType;
@@ -172,7 +171,7 @@ public class ScopeInfo extends Composable {
     @Override
     public boolean is(@Nonnull Class<?> type) {
         Transformable userObject = getScopeObject(Transformable.class);
-        if (userObject != null&& userObject.is(type)) {
+        if (userObject != null && userObject.is(type)) {
             return true;
         }
         return super.is(type);

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -172,8 +172,8 @@ public class ScopeInfo extends Composable {
     @Override
     public boolean is(@Nonnull Class<?> type) {
         Transformable userObject = getScopeObject(Transformable.class);
-        if (userObject != null) {
-            return userObject.is(type);
+        if (userObject != null&& userObject.is(type)) {
+            return true;
         }
         return super.is(type);
     }
@@ -183,7 +183,10 @@ public class ScopeInfo extends Composable {
     public <A> Optional<A> tryAs(@Nonnull Class<A> adapterType) {
         Transformable userObject = getScopeObject(Transformable.class);
         if (userObject != null) {
-            return userObject.tryAs(adapterType);
+            Optional<A> result = userObject.tryAs(adapterType);
+            if (result.isPresent()) {
+                return result;
+            }
         }
         return super.tryAs(adapterType);
     }


### PR DESCRIPTION
Adds a fallback for composites based on the ScopeInfo directly instead of the inner scope object

This is required by SellSite which attaches some components to the ScopeInfo, which is
not changed when the inner scope object (Shop) is refreshed