### PR TITLE
Does not move the content text of select2-boxes under the box anymore…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>3.8.4</version>
+        <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>7.3</version>
+    <version>7.3.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>3.8.3</version>
+        <version>3.8.4</version>
     </parent>
     <artifactId>sirius-web</artifactId>
     <version>7.3</version>

--- a/src/main/resources/default/assets/wondergem/stylesheets/plugins.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/plugins.scss
@@ -31,10 +31,6 @@
     background-image: none;
   }
 
-  &-container .select2-selection--single .select2-selection__rendered {
-    white-space: normal;  // Icon to clear selection should be aligned properly
-  }
-
 }
 
 


### PR DESCRIPTION
… if the text was too long

Note to `// Icon to clear selection should be aligned properly`: the clear icon is still on its place

before:
![image](https://cloud.githubusercontent.com/assets/7695721/24443618/9dab9be2-1463-11e7-930e-1b9c2a6ffb05.png)

![image](https://cloud.githubusercontent.com/assets/7695721/24443625/a33062fa-1463-11e7-8fae-1735d62b868e.png)

after:
![image](https://cloud.githubusercontent.com/assets/7695721/24444743/c8a4f6fa-1467-11e7-9187-c3b1c5320c3a.png)

![image](https://cloud.githubusercontent.com/assets/7695721/24444497/dde8dbea-1466-11e7-9ce5-7a67a7655278.png)
