### PR TITLE
Removes an unnecessary comment in a rythm template which caused parse exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>8.1</version>
+    <version>8.1.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/view/wondergem/template.html
+++ b/src/main/resources/default/view/wondergem/template.html
@@ -8,13 +8,6 @@
  *@
 @import sirius.web.security.MaintenanceInfo;
 @args String title
-<!--
-  ~ Made with all the love in the world
-  ~ by scireum in Remshalden, Germany
-  ~
-  ~ Copyright by scireum GmbH
-  ~ http://www.scireum.de - info@@scireum.de
-  -->
 
 <html lang="@NLS.getCurrentLang()">
     <head>


### PR DESCRIPTION
namely
```
11:09:13.832 ERROR [web-mvc-3|654ms] rythm - Ein Fehler ist aufgetreten: Failed to render the template 'view/wondergem/error.html': Cannot find extended template by name "view.wondergem.template.html"

Template: default:///view/wondergem/error.html

Relevant template source lines:
-------------------------------------------------
   4: *
   5: *  Copyright by scireum GmbH
   6: *  http://www.scireum.de - info@scireum.de
   7: *@
   8: @args String message
>> 9: @extends(view.wondergem.template.html, title: NLS.get("BasicController.error"))
   10: @render(head) {
   11: <style>
   12:     .breadcrumb {
   13:         display: none;
   14:     }
   15: </style>
```