### PR TITLE
Adds another permission "enabled" which is always granted.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>8.1.1</version>
+    <version>8.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -45,6 +45,12 @@ public class UserInfo extends Composable {
      */
     private static final String DISABLED = "disabled";
 
+    /**
+     * Represents a special permission which is always granted - therefore {@link #hasPermission(String)} will always
+     * return true.
+     */
+    private static final String ENABLED = "enabled";
+
     private String tenantId;
     private String tenantName;
     private String userId;
@@ -290,6 +296,10 @@ public class UserInfo extends Composable {
 
         if (DISABLED.equals(permission)) {
             return false;
+        }
+
+        if (ENABLED.equals(permission)) {
+            return true;
         }
 
         for (String orClause : permission.split(",")) {


### PR DESCRIPTION
This can be used as a better default for permissions configs
(leaving the values empty would yield the same but be less descriptive).