### PR TITLE
Attaches session even if some permission is missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>8.8</version>
+    <version>8.8.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -155,6 +155,12 @@ public class ControllerDispatcher implements WebDispatcher {
                 return;
             }
 
+            // If a user authenticated during this call...bind to session!
+            UserContext userCtx = UserContext.get();
+            if (userCtx.getUser().isLoggedIn()) {
+                userCtx.attachUserToSession();
+            }
+
             String missingPermission = route.checkAuth(user);
             if (missingPermission != null) {
                 handlePermissionError(ctx, route, missingPermission);
@@ -174,12 +180,6 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private void executeRoute(WebContext ctx, Route route, List<Object> params) throws Exception {
-        // If a user authenticated during this call...bind to session!
-        UserContext userCtx = UserContext.get();
-        if (userCtx.getUser().isLoggedIn()) {
-            userCtx.attachUserToSession();
-        }
-
         if (route.isJSONCall()) {
             executeJSONCall(ctx, route, params);
         } else {

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -156,9 +156,8 @@ public class ControllerDispatcher implements WebDispatcher {
             }
 
             // If a user authenticated during this call...bind to session!
-            UserContext userCtx = UserContext.get();
-            if (userCtx.getUser().isLoggedIn()) {
-                userCtx.attachUserToSession();
+            if (user.isLoggedIn()) {
+                UserContext.get().attachUserToSession();
             }
 
             String missingPermission = route.checkAuth(user);


### PR DESCRIPTION
As long as the user is logged in.

Up to know it was not possible to call a route without the necessary permission, log in and save the login information into the session.
As soon as the user left the 403 Page (or reloaded) the login was lost.