### PR TITLE
Makes HelpDispatcher able to find a matching template from a URI without file extensions 

### DIFF
--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -16,14 +16,12 @@ import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.tagliatelle.Tagliatelle;
-import sirius.tagliatelle.Template;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
 
 import java.io.File;
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -80,12 +78,10 @@ public class HelpDispatcher implements WebDispatcher {
             }
         } else {
             //search for the matching template
-            Optional<Template> pasta = tagliatelle.resolve(uri + ".pasta");
             StringBuilder sb = new StringBuilder(uri);
-            if (pasta.isPresent()) {
+            sb.append(".html");
+            if (tagliatelle.resolve(uri + ".html.pasta").isPresent()) {
                 sb.append(".pasta");
-            } else {
-                sb.append(".html");
             }
             ctx.respondWith().cached().template(sb.toString());
         }

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 @Register
 public class HelpDispatcher implements WebDispatcher {
 
-    public static final String HELP_PREFIX = "/help";
+    private static final String HELP_PREFIX = "/help";
     private static Pattern startPagePattern = Pattern.compile("^/help/(..)/?$");
 
     @ConfigValue("help.indexTemplate")
@@ -94,13 +94,13 @@ public class HelpDispatcher implements WebDispatcher {
     }
 
     private String getHelpSystemLanguageDirectory(String uri) {
-        String subUri = uri.substring("/help/".length()).split("/")[0];
+        String subUri = uri.substring((HELP_PREFIX + "/").length()).split("/")[0];
         return helpSystemLanguageDirectories.contains(subUri) ? subUri : "";
     }
 
     private String getRequestedURI(WebContext ctx) {
         String uri = ctx.getRequestedURI();
-        if ("/help".equals(uri) || "/help/".equals(uri)) {
+        if (HELP_PREFIX.equals(uri) || (HELP_PREFIX + "/").equals(uri)) {
             return buildHomeURI(null);
         }
         Matcher matcher = startPagePattern.matcher(uri);
@@ -114,7 +114,7 @@ public class HelpDispatcher implements WebDispatcher {
     }
 
     private String buildHomeURI(String lang) {
-        String uri = "/help";
+        String uri = HELP_PREFIX;
         if (Strings.isFilled(lang)) {
             uri = uri + "/" + lang;
         }


### PR DESCRIPTION
 e.g. (help/de/index) renders help/de/index.pasta if available, else it tries help/de/index.html 