### PR TITLE
Provides a macro to fetch all enum values of a given enum class.

### DIFF
--- a/src/main/java/sirius/tagliatelle/macros/EnumValuesMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/EnumValuesMacro.java
@@ -35,8 +35,9 @@ public class EnumValuesMacro implements Macro {
             if (type.isEnum()) {
                 return;
             }
-            throw new IllegalArgumentException("Expected an enum class as parameter.");
         }
+
+        throw new IllegalArgumentException("Expected an enum class as parameter.");
     }
 
     @Override

--- a/src/main/java/sirius/tagliatelle/macros/EnumValuesMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/EnumValuesMacro.java
@@ -1,0 +1,59 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle.macros;
+
+import sirius.kernel.di.std.Register;
+import sirius.tagliatelle.expression.ConstantClass;
+import sirius.tagliatelle.expression.Expression;
+import sirius.tagliatelle.rendering.LocalRenderContext;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Returns all values of a given enum class.
+ */
+@Register
+public class EnumValuesMacro implements Macro {
+
+
+    @Override
+    public Class<?> getType() {
+        return List.class;
+    }
+
+    @Override
+    public void verifyArguments(List<Expression> args) {
+        if (args.size() == 1 && (args.get(0) instanceof ConstantClass)) {
+            Class<?> type =(Class<?>) args.get(0).eval(null);
+            if (type.isEnum()) {
+                return;
+            }
+            throw new IllegalArgumentException("Expected an enum class as parameter.");
+        }
+    }
+
+    @Override
+    public Object eval(LocalRenderContext ctx, Expression[] args) {
+        Class<?> type =(Class<?>) args[0].eval(ctx);
+        return Arrays.asList(type.getEnumConstants());
+    }
+
+    @Override
+    public boolean isConstant(Expression[] args) {
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "enumValues";
+    }
+}

--- a/src/main/java/sirius/tagliatelle/macros/EnumValuesMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/EnumValuesMacro.java
@@ -23,7 +23,6 @@ import java.util.List;
 @Register
 public class EnumValuesMacro implements Macro {
 
-
     @Override
     public Class<?> getType() {
         return List.class;
@@ -32,7 +31,7 @@ public class EnumValuesMacro implements Macro {
     @Override
     public void verifyArguments(List<Expression> args) {
         if (args.size() == 1 && (args.get(0) instanceof ConstantClass)) {
-            Class<?> type =(Class<?>) args.get(0).eval(null);
+            Class<?> type = (Class<?>) args.get(0).eval(null);
             if (type.isEnum()) {
                 return;
             }
@@ -42,7 +41,7 @@ public class EnumValuesMacro implements Macro {
 
     @Override
     public Object eval(LocalRenderContext ctx, Expression[] args) {
-        Class<?> type =(Class<?>) args[0].eval(ctx);
+        Class<?> type = (Class<?>) args[0].eval(ctx);
         return Arrays.asList(type.getEnumConstants());
     }
 

--- a/src/main/java/sirius/tagliatelle/macros/InlineResourceMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/InlineResourceMacro.java
@@ -10,7 +10,6 @@ package sirius.tagliatelle.macros;
 
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
-import sirius.kernel.nls.Formatter;
 import sirius.tagliatelle.Tagliatelle;
 import sirius.tagliatelle.expression.Expression;
 import sirius.tagliatelle.rendering.LocalRenderContext;
@@ -34,7 +33,7 @@ public class InlineResourceMacro implements Macro {
 
     @Override
     public Class<?> getType() {
-        return Formatter.class;
+        return String.class;
     }
 
     @Override


### PR DESCRIPTION
We need this, as .values() is a static method, which we cannot invoke
in Tagliatelle due to security considerations.