### PR TITLE
Adds a page parameter to the deleteLink

### DIFF
--- a/src/main/resources/default/taglib/w/deleteLink.html.pasta
+++ b/src/main/resources/default/taglib/w/deleteLink.html.pasta
@@ -1,7 +1,12 @@
 <i:arg type="String" name="url" />
 <i:arg type="boolean" name="adminOnly" default="false"/>
+<i:arg type="Page" name="page" default=""/>
 
 <i:pragma name="inline" value="true" />
 <i:pragma name="description" value="Renders a delete/dangerous link within a Wondergem template" />
 
-<i class="fa fa-trash"></i> <a class="link link-danger @if (adminOnly) {admin-link}" href="@url">@i18n("NLS.delete")</a>
+<i class="fa fa-trash"></i>
+<a class="link link-danger @if (adminOnly) {admin-link}"
+   href="@if(page != null) {@url?@page.createQueryString()} else {@url}">
+    @i18n("NLS.delete")
+</a>

--- a/src/test/java/sirius/web/health/SystemControllerSpec.groovy
+++ b/src/test/java/sirius/web/health/SystemControllerSpec.groovy
@@ -47,7 +47,7 @@ class SystemControllerSpec extends BaseSpecification {
         then:
         result.getStatus() == HttpResponseStatus.OK
         result.getType() == TestResponse.ResponseType.TEMPLATE
-        result.getTemplateName() == "/view/system/state.html"
+        result.getTemplateName() == "templates/system/state.html.pasta"
         Value.indexOf(0, result.getTemplateParameters()).get() == Injector.context().getPart(Cluster.class)
     }
 


### PR DESCRIPTION
Default is null and this will not change the behavior
If page is set the query string containing the active facets is appended to the delete url
Fixes also a test of a ported template