### PR TITLE
Improves security checks.

### DIFF
--- a/src/main/java/sirius/tagliatelle/Tagliatelle.java
+++ b/src/main/java/sirius/tagliatelle/Tagliatelle.java
@@ -258,7 +258,7 @@ public class Tagliatelle {
     }
 
     /**
-     * For security reasons we only include or invoke templates and resources in either /assets or /templates.
+     * For security reasons we only invoke templates that end with .pasta.
      * <p>
      * Otherwise one could customize a template and try to include a configuration file or class file and therefore
      * obtain private data.
@@ -266,12 +266,8 @@ public class Tagliatelle {
      * @param path the path to check
      */
     public static void ensureProperTemplatePath(String path) {
-        String effectiveUri = path.startsWith("/") ? path : "/" + path;
-
-        if (!effectiveUri.startsWith("/templates") && !effectiveUri.startsWith("/assets") && !effectiveUri.startsWith(
-                "/taglib")) {
-            throw new IllegalArgumentException(
-                    "Tagliatelle templates must reside in /templates, /taglib or /assets. Invalid path: " + path);
+        if (path.endsWith(".pasta")) {
+            throw new IllegalArgumentException("Tagliatelle templates must end with '.pasta'. Invalid path: " + path);
         }
     }
 

--- a/src/main/java/sirius/tagliatelle/Tagliatelle.java
+++ b/src/main/java/sirius/tagliatelle/Tagliatelle.java
@@ -266,7 +266,7 @@ public class Tagliatelle {
      * @param path the path to check
      */
     public static void ensureProperTemplatePath(String path) {
-        if (path.endsWith(".pasta")) {
+        if (!path.endsWith(".pasta")) {
             throw new IllegalArgumentException("Tagliatelle templates must end with '.pasta'. Invalid path: " + path);
         }
     }

--- a/src/main/java/sirius/tagliatelle/tags/IncludeTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/IncludeTag.java
@@ -10,7 +10,6 @@ package sirius.tagliatelle.tags;
 
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
-import sirius.tagliatelle.Tagliatelle;
 import sirius.tagliatelle.TemplateArgument;
 import sirius.tagliatelle.emitter.CompositeEmitter;
 import sirius.tagliatelle.emitter.ConstantEmitter;
@@ -63,7 +62,10 @@ public class IncludeTag extends TagHandler {
     @Override
     public void apply(CompositeEmitter targetBlock) {
         String resourcePath = getConstantAttribute(ATTR_NAME).asString();
-        Tagliatelle.ensureProperTemplatePath(resourcePath);
+        if (!resourcePath.startsWith("/assets") && !resourcePath.startsWith("assets/")) {
+            throw new IllegalArgumentException("For security reasons only assets can be included. Invalid path: "
+                                               + resourcePath);
+        }
 
         Optional<Resource> resource = resources.resolve(resourcePath);
         if (!resource.isPresent()) {


### PR DESCRIPTION
Tagliatelle now happily compiles and invokes all .pasta files
as they're obviously meant to be templates.

However, for includes, only /assets is accepted, as this is the
directory(tree) to put files for inclusions anyway..