### PR TITLE
Adds missing /system prefix in scope-config breadcrumbs

### DIFF
--- a/src/main/resources/default/templates/system/scope-config.html.pasta
+++ b/src/main/resources/default/templates/system/scope-config.html.pasta
@@ -9,10 +9,10 @@
 
      <i:block name="breadcrumbs">
          <li>
-             <a href="/scope-config">@i18n("ScopeDefaultConfigController.config")</a>
+             <a href="/system/scope-config">@i18n("ScopeDefaultConfigController.config")</a>
          </li>
          <li>
-             <a href="/scope-config/@name">@name</a>
+             <a href="/system/scope-config/@name">@name</a>
          </li>
     </i:block>
 


### PR DESCRIPTION
Adds missing /system prefix in scope-config breadcrumbs.