### PR TITLE
Changes the color of links inside of danger alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.0</version>
+    <version>9.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/assets/wondergem/stylesheets/alerts.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/alerts.scss
@@ -45,9 +45,9 @@ th, td .alert {
 // nested Links
 // --------------------------
 .alert-danger a.link-info {
-  color: #5C0000 !important;
+  color: #F0DFAD;
 }
 
 .alert-danger a.link-info:hover {
-  color: #2f0000 !important;
+  color: #D9C092;
 }


### PR DESCRIPTION
To make them more readable

tags: css
Before:
![screen shot 2017-08-16 at 10 03 32](https://user-images.githubusercontent.com/10437176/29353597-12082d50-826b-11e7-9002-e306ed1f63e0.png)
Now:
![screen shot 2017-08-16 at 10 05 14](https://user-images.githubusercontent.com/10437176/29353610-1b1586e0-826b-11e7-8811-71ba0eafb35f.png)
(Leftmost is hover state)