### PR TITLE
Fix if-handler for static content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.2</version>
+    <version>9.2.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -518,12 +518,20 @@ public class Compiler extends InputProcessor {
      */
     private String consumeStaticBlock() {
         StringBuilder sb = new StringBuilder();
+        Integer numberOfOpenBlocks = 0;
+
         while (!reader.current().isEndOfInput()) {
             if (isAtEscapedAt()) {
                 sb.append(reader.consume().getValue());
                 reader.consume().getValue();
             } else {
-                if (isAtPotentialEndOfStaticBlock()) {
+                if (reader.current().is('{')) {
+                    numberOfOpenBlocks++;
+                } else if (reader.current().is('}')) {
+                    numberOfOpenBlocks--;
+                }
+
+                if (isAtPotentialEndOfStaticBlock(numberOfOpenBlocks)) {
                     return sb.toString();
                 }
 
@@ -549,8 +557,8 @@ public class Compiler extends InputProcessor {
      *
      * @return <tt>true</tt> if the reader points to something of interest to the compiler, <tt>false</tt> otherwise
      */
-    private boolean isAtPotentialEndOfStaticBlock() {
-        if (reader.current().is('}')) {
+    private boolean isAtPotentialEndOfStaticBlock(Integer numberOfOpenBlocks) {
+        if (reader.current().is('}') && numberOfOpenBlocks < 0) {
             return true;
         }
 

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -518,7 +518,7 @@ public class Compiler extends InputProcessor {
      */
     private String consumeStaticBlock() {
         StringBuilder sb = new StringBuilder();
-        Integer numberOfOpenBlocks = 1;
+        int numberOfOpenBlocks = 1;
 
         while (!reader.current().isEndOfInput()) {
             if (isAtEscapedAt()) {

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -518,7 +518,7 @@ public class Compiler extends InputProcessor {
      */
     private String consumeStaticBlock() {
         StringBuilder sb = new StringBuilder();
-        Integer numberOfOpenBlocks = 0;
+        Integer numberOfOpenBlocks = 1;
 
         while (!reader.current().isEndOfInput()) {
             if (isAtEscapedAt()) {
@@ -558,7 +558,7 @@ public class Compiler extends InputProcessor {
      * @return <tt>true</tt> if the reader points to something of interest to the compiler, <tt>false</tt> otherwise
      */
     private boolean isAtPotentialEndOfStaticBlock(Integer numberOfOpenBlocks) {
-        if (reader.current().is('}') && numberOfOpenBlocks < 0) {
+        if (reader.current().is('}') && numberOfOpenBlocks == 0) {
             return true;
         }
 

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -555,6 +555,8 @@ public class Compiler extends InputProcessor {
      * Determines if the reader might be pointing to something interesting and should therefore stop consuming static
      * text to investigate further.
      *
+     * @param numberOfOpenBlocks signals the number of opened blocks (a block is opened via a "{") in the current static
+     *                           block
      * @return <tt>true</tt> if the reader points to something of interest to the compiler, <tt>false</tt> otherwise
      */
     private boolean isAtPotentialEndOfStaticBlock(Integer numberOfOpenBlocks) {


### PR DESCRIPTION
When using @if(){...} containing e.g. a javascript expression or function, the compiler couldn't find the correct ending
of the @if-block, as the first found closing "}" is used to detect the end of the if-block.

Example code:
@if (...) {
    if () {
        ...;
    }
}