### PR TITLE
Images for Excel export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.3</version>
+    <version>9.4</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -11,16 +11,22 @@ package sirius.web.data;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
+import org.apache.poi.hssf.usermodel.HSSFClientAnchor;
+import org.apache.poi.hssf.usermodel.HSSFPatriarch;
+import org.apache.poi.hssf.usermodel.HSSFPicture;
 import org.apache.poi.hssf.usermodel.HSSFPrintSetup;
 import org.apache.poi.hssf.usermodel.HSSFRichTextString;
 import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.PrintSetup;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
+import sirius.web.http.MimeHelper;
 import sirius.web.http.WebContext;
 
 import java.io.IOException;
@@ -32,6 +38,8 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Generates an Excel file which can be sent as a response for a {@link sirius.web.http.WebContext}
@@ -48,6 +56,117 @@ public class ExcelExport {
     private HSSFCellStyle numeric;
     private HSSFCellStyle borderStyle;
     private HSSFCellStyle normalStyle;
+    private Set<Short> pictureCols = new HashSet<>();
+    private HSSFPatriarch drawing;
+
+    /**
+     * Represents a header column for a column containing images. As images have a certain width, this sets the width
+     * of
+     * the column to the given value.
+     * <p>
+     * The column with has to be set during creation of the header as changing the column width later would result in
+     * distorted images.
+     */
+    public static class ImageHeaderCol {
+
+        private static final short EXCEL_COLUMN_WIDTH_FACTOR = 256;
+        private static final int UNIT_OFFSET_LENGTH = 7;
+        private static final int[] UNIT_OFFSET_MAP = {0, 36, 73, 109, 146, 182, 219};
+
+        private String name;
+        private int widthInPixel;
+
+        /**
+         * Creates a new header column object which can be used to create a column containing images. This has to be
+         * inserted in the header (first row) only once per column as later insertions can result in distorted images.
+         * <p>
+         * The given width in pixels should be the width of the widest image to insert so that it fits in the column.
+         *
+         * @param name         the name of the column to print on the excel sheet
+         * @param widthInPixel the width the column should have in pixels
+         * @return a new image header column object
+         */
+        public static ImageHeaderCol create(String name, int widthInPixel) {
+            ImageHeaderCol col = new ImageHeaderCol();
+            col.name = name;
+            col.widthInPixel = widthInPixel;
+            return col;
+        }
+
+        /**
+         * Returns width of column formatted in POI's unit for pixel width. This is not the exact pixel with but more of
+         * an approximation.
+         * <p>
+         * Adapted from: https://stackoverflow.com/a/31837639
+         *
+         * @return column width formatted for POI
+         */
+        protected int getPOIWidth() {
+            int widthUnits = EXCEL_COLUMN_WIDTH_FACTOR * (widthInPixel / UNIT_OFFSET_LENGTH);
+            widthUnits += UNIT_OFFSET_MAP[(widthInPixel % UNIT_OFFSET_LENGTH)];
+            return widthUnits / 2;
+        }
+    }
+
+    /**
+     * Represents a cell containing an image which should be inserted.
+     */
+    public static class ImageCell {
+        byte[] fileData;
+        int heightInPixel;
+        int pictureType;
+
+        /**
+         * Creates a new cell containing an image which could be inserted into an Excel sheet.
+         * <p>
+         * The height in pixel determines the height of the row containing the image. Currently, only one image is
+         * allowed per row as the changes in height for the row might result in distorted images.
+         * <p>
+         * The filename is needed in order to determine the type of image. POI requires an image type for inserting
+         * images. Only jpeg, png and bmp are supported.
+         *
+         * @param fileData      the data of the picture
+         * @param heightInPixel the height the row containing the image should have
+         * @param fileName      the filename or path to file containing the filename
+         * @return a new image cell object
+         */
+        public static ImageCell create(byte[] fileData, int heightInPixel, String fileName) {
+            ImageCell cell = new ImageCell();
+            int guessedPictureType = determinePictureType(fileName);
+            if (guessedPictureType < 0) {
+                throw Exceptions.handle()
+                                .withSystemErrorMessage("Unknown picture type for file %s: %s (%s)", fileName)
+                                .handle();
+            }
+            cell.pictureType = guessedPictureType;
+            cell.fileData = fileData;
+            cell.heightInPixel = heightInPixel;
+            return cell;
+        }
+
+        /**
+         * Converted height in pixels of row containing the image as POI uses points as unit for row heights.
+         *
+         * @return the height the row should have in points
+         */
+        protected int getHeightInPoints() {
+            return heightInPixel * 72 / 96;
+        }
+
+        private static int determinePictureType(String fileName) {
+            String mimeType = MimeHelper.guessMimeType(fileName);
+            switch (mimeType) {
+                case MimeHelper.IMAGE_PNG:
+                    return Workbook.PICTURE_TYPE_PNG;
+                case MimeHelper.IMAGE_JPEG:
+                    return Workbook.PICTURE_TYPE_JPEG;
+                case "image/bmp":
+                    return Workbook.PICTURE_TYPE_DIB;
+                default:
+                    return -1;
+            }
+        }
+    }
 
     /**
      * Generates a new Export
@@ -117,7 +236,30 @@ public class ExcelExport {
             cell.setCellValue(((BigDecimal) obj).doubleValue());
             return;
         }
+        if (obj instanceof ImageHeaderCol) {
+            cell.setCellValue(new HSSFRichTextString(((ImageHeaderCol) obj).name));
+            sheet.setColumnWidth(columnIndex, ((ImageHeaderCol) obj).getPOIWidth());
+            pictureCols.add((short) columnIndex);
+            return;
+        }
+        if (obj instanceof ImageCell) {
+            addImageCell(row, (ImageCell) obj, columnIndex);
+            return;
+        }
         cell.setCellValue(new HSSFRichTextString(obj.toString()));
+    }
+
+    private void addImageCell(HSSFRow row, ImageCell imageCell, int columnIndex) {
+        row.setHeightInPoints(imageCell.getHeightInPoints());
+        if (drawing == null) {
+            drawing = sheet.createDrawingPatriarch();
+        }
+        int iconIndex = workbook.addPicture(imageCell.fileData, imageCell.pictureType);
+        ClientAnchor anchor = new HSSFClientAnchor();
+        anchor.setCol1(columnIndex);
+        anchor.setRow1(row.getRowNum());
+        HSSFPicture picture = drawing.createPicture(anchor, iconIndex);
+        picture.resize();
     }
 
     /**
@@ -171,7 +313,10 @@ public class ExcelExport {
             try (OutputStream out = stream) {
                 // Make it pretty...
                 for (short col = 0; col < maxCols; col++) {
-                    sheet.autoSizeColumn(col);
+                    // Don't distort images
+                    if (!pictureCols.contains(col)) {
+                        sheet.autoSizeColumn(col);
+                    }
                 }
                 // Add autofilter...
                 sheet.setAutoFilter(new CellRangeAddress(0, rows, 0, maxCols - 1));


### PR DESCRIPTION
It is now possible to render images in exported Excel sheets. As Excel is kind of special in handling images, the height and width of the cell containing the image are set separately.