### PR TITLE
Don't divide Excel column with by 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.4</version>
+    <version>9.4.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -124,7 +124,7 @@ public class ExcelExport {
         protected int getPOIWidth() {
             int widthUnits = EXCEL_COLUMN_WIDTH_FACTOR * (widthInPixel / UNIT_OFFSET_ARRAY.length);
             widthUnits += UNIT_OFFSET_ARRAY[(widthInPixel % UNIT_OFFSET_ARRAY.length)];
-            return widthUnits / 2;
+            return widthUnits;
         }
 
         private static int determinePictureType(String fileName) {


### PR DESCRIPTION
The calculation was correct in the linked stackoverflow. Dividing the width by two will result in distorted or overlapping images. This division was introduced due to wrong values in testing the export.