### PR TITLE
Fixes a url for fontawesome in legacy templates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.4.1</version>
+    <version>9.4.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/view/wondergem/template.html
+++ b/src/main/resources/default/view/wondergem/template.html
@@ -15,7 +15,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>@title - @product</title>
         <link rel="stylesheet" media="screen" href="@prefix/assets/wondergem/bootstrap/css/bootstrap.min.css" />
-        <link rel="stylesheet" media="screen" href="@prefix/assets/wondergem/font-awesome/css/font-awesome.min.css">
+        <link rel="stylesheet" media="screen" href="@prefix/assets/wondergem/font-awesome/css/font-awesome.css">
         <link rel="stylesheet" media="screen" href="@prefix/assets/wondergem/fileupload/fileuploader.css" />
         <link rel="stylesheet" media="screen" href="@prefix/assets/wondergem/select2/select2.min.css" />
         <link rel="stylesheet" media="screen" href="@prefix/assets/wondergem/datepicker/css/datepicker.css" />


### PR DESCRIPTION
In legacy templates (rythm) we still included the minified css.
As we now use a single js and css with all libraries, we use the non
minified version as we hat to fix some relative paths.