### PR TITLE
Resizing of images in Excel export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.8.2</version>
+    <version>9.9</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 


### PR DESCRIPTION
Images can now be resized so images which are wider than the column they should be inserted in get resized to fit in.