### PR TITLE
Separates the response time from the time to first byte.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.10</version>
+    <version>9.10.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/health/console/HTTPCommand.java
+++ b/src/main/java/sirius/web/health/console/HTTPCommand.java
@@ -79,6 +79,7 @@ public class HTTPCommand implements Command {
             output.apply("%-20s %10d", "Client Errors", WebServer.getClientErrors());
             output.apply("%-20s %10d", "Server Errors", WebServer.getServerErrors());
             output.apply("%-20s %10s", "Avg. Response Time", NLS.toUserString(WebServer.getAvgResponseTime()) + " ms");
+            output.apply("%-20s %10s", "Avg. TTFB", NLS.toUserString(WebServer.getAvgTimeToFirstByte()) + " ms");
             output.separator();
         }
     }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -258,7 +258,7 @@ public class WebContext implements SubContext {
     /*
      * If longCall is set to true (by the user), the idle-state handler is disabled for this request.
      */
-    private boolean longCall;
+    private volatile boolean longCall;
 
     /*
      * If set, will be supplied with all incoming content (instead of buffering on disk or in memory)
@@ -269,7 +269,13 @@ public class WebContext implements SubContext {
      * Contains the timestamp this request was dispatched. (Will not be filled in predispatch, as we only
      * want to measure how long it takes to generate an "average" result, not how long an upload took....
      */
-    protected long started = 0;
+    protected volatile long started = 0;
+
+    /*
+     * Contains the timestamp this request was commited (a response was created).
+     * This can be used to actually measure the server performance and not the download speed of clients.
+     */
+    protected volatile long committed = 0;
 
     /*
      * Caches the content size as the "readableBytes" value changes once a stream is on it.

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -56,8 +56,9 @@ http {
     # Maximal size of an upload which can be sent to the server
     maxUploadSize = 5G
 
-    # Maximal tolerated response time in millis. Everything that takes longer, will be logged. Use 0 to disable.
-    maxResponseTime = 2500
+    # Maximal tolerated time it takes to generate a response in millis. Everything that takes longer, will be logged.
+    # Use 0 to disable.
+    maxTimeToFirstByte = 2500
 
     # Maximal size of structured data (XML / JSON) which is accepted by the server. As this data is completely held
     # in memory, this value should not be too large.
@@ -233,8 +234,13 @@ health {
 
         # Average response time in milliseconds
         http-response-time.gray = 250
-        http-response-time.warning = 500
-        http-response-time.error = 2000
+        http-response-time.warning = 1000
+        http-response-time.error = 0
+
+        # Average time to first byte in milliseconds
+        http-response-ttfb.gray = 250
+        http-response-ttfb.warning = 500
+        http-response-ttfb.error = 1000
 
         # Number of server sided sessions currently open
         http-sessions.gray = 100


### PR DESCRIPTION
Otherwise we might complain about long running requests due
to slow (mobile) clients.

Also, we now use the correct CallContext when reporting the error and
made some shared variables volatile.