### PR TITLE
Warns if a resource with different casing is used.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.10.1</version>
+    <version>9.10.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/resources/Resource.java
+++ b/src/main/java/sirius/web/resources/Resource.java
@@ -50,12 +50,29 @@ public class Resource {
         this.path = path;
         this.url = url;
         this.file = determineFile(url);
+
+        if (Sirius.isDev() && file != null) {
+            ensureCaseMatch(path);
+        }
+
         this.consideredConstant = constant;
         this.minLastModified = System.currentTimeMillis();
 
         Objects.requireNonNull(scopeId);
         Objects.requireNonNull(path);
         Objects.requireNonNull(url);
+    }
+
+    private void ensureCaseMatch(String path) {
+        try {
+            String absolutePath = file.getAbsolutePath();
+            String canonicalPath = file.getCanonicalPath();
+            if (!absolutePath.equals(canonicalPath) && absolutePath.equalsIgnoreCase(canonicalPath)) {
+                Resources.LOG.WARN("A resource was found, but only case insensitive: %s vs. %s", path, canonicalPath);
+            }
+        } catch (IOException e) {
+            Exceptions.ignore(e);
+        }
     }
 
     private File determineFile(URL url) {


### PR DESCRIPTION
As OSX matches files case insensitive but linux case sensitive
typos in template names are only found in test or even worse
production systems. Therefore we detect this case and gently warn
the developer.