### PR TITLE
Escape HTML entities in PDF (flying saucer) sources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.11.2</version>
+    <version>9.11.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/Template.java
+++ b/src/main/java/sirius/tagliatelle/Template.java
@@ -178,7 +178,11 @@ public class Template {
     }
 
     private void setupEscaper(GlobalRenderContext ctx) {
-        if (getEffectiveFileName().endsWith(".html") || getEffectiveFileName().endsWith(".xml")) {
+        // For XML and HTML we obviously use an XML escaper. As we use flying saucer to generate PDFs
+        // which internally renders HTML, we also enable the escaper there.
+        if (getEffectiveFileName().endsWith(".html")
+            || getEffectiveFileName().endsWith(".xml")
+            || getEffectiveFileName().endsWith(".pdf")) {
             ctx.setEscaper(GlobalRenderContext::escapeXML);
         }
     }


### PR DESCRIPTION
If tagliatelle is used to render PDFs, we internally use HTML and
flying saucer to create those. Therefore we have to enable the appropriate
escaper.