### PR TITLE
Apparently ACCESS_CONTROL_ALLOW_CREDENTIALS must always be set to true and not just for preflight requests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>9.11.3</version>
+    <version>9.11.4</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -257,6 +257,9 @@ public class Response {
         String requestedOrigin = wc.getHeader(HttpHeaderNames.ORIGIN);
         if (Strings.isFilled(requestedOrigin)) {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, requestedOrigin);
+            if (!response.headers().contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
+                response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+            }
         }
     }
 


### PR DESCRIPTION
However, we only do this, if CORS handling is enabled and also if
no conflicting header has already been set and of course if a CORS
request (origin) is present.