### PR TITLE
Adds a mini JS hack which is required to use jQuery inside an electron app.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>10.0.1</version>
+    <version>10.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/taglib/w/page.html.pasta
+++ b/src/main/resources/default/taglib/w/page.html.pasta
@@ -11,8 +11,11 @@
 
     <link rel="stylesheet" media="screen" href="/assets/wondergem/wondergem.css"/>
     <link rel="stylesheet" media="screen" href="/assets/wondergem/stylesheets/application.css"/>
-
     <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/assets/images/favicon.ico"/>
+
+    <i:render name="electron-fix">
+        <i:invoke template="/templates/wondergem/page-electron.html.pasta" inline="true"/>
+    </i:render>
 
     <script src="/assets/wondergem/wondergem.js" type="text/javascript"></script>
     <script src="/assets/wondergem/datepicker/js/locales/bootstrap-datepicker.@(lang).js"

--- a/src/main/resources/default/templates/wondergem/page-electron.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-electron.html.pasta
@@ -1,0 +1,16 @@
+<script type="text/javascript">
+    //Setup Electron / Desktop app...
+    var electronRemote = null;
+    var electronIpc = null;
+    try {
+        electronRemote = require('electron').remote;
+        electronIpc = require('electron').ipcRenderer;
+    } catch (e) {
+    }
+
+    // Make jQuery work with electron / npm environments
+    if (typeof module === 'object') {
+        window._module = module;
+        module = undefined;
+    }
+</script>


### PR DESCRIPTION
This shouldn't have andy side effects on non-npm / electron apps and
can also be overwritten by customizing page-electron.html.pasta