### PR TITLE
Improves the TestRequest and MailsMock class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>11.6</version>
+    <version>11.7</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/test/java/sirius/web/health/ConsoleServiceSpec.groovy
+++ b/src/test/java/sirius/web/health/ConsoleServiceSpec.groovy
@@ -22,7 +22,7 @@ class ConsoleServiceSpec extends BaseSpecification {
         when:
         UserContext.get().setCurrentUser(UserInfo.Builder.createUser("test")
                 .withPermissions(Collections.singleton(SystemController.PERMISSION_SYSTEM_CONSOLE)).build())
-        def result = TestRequest.POST("/service/xml/system/console", Context.create().set("command", "help")).executeAndBlock()
+        def result = TestRequest.POST("/service/xml/system/console").withParameters(Context.create().set("command", "help")).execute()
         then:
         result.getStatus() == HttpResponseStatus.OK
         result.xmlContent().queryString("error/code") == null

--- a/src/test/java/sirius/web/health/NodeInfoServiceSpec.groovy
+++ b/src/test/java/sirius/web/health/NodeInfoServiceSpec.groovy
@@ -19,7 +19,7 @@ class NodeInfoServiceSpec extends BaseSpecification {
 
     def "/service/xml/system/node-info returns XML"() {
         when:
-        def result = TestRequest.GET("/service/xml/system/node-info").executeAndBlock()
+        def result = TestRequest.GET("/service/xml/system/node-info").execute()
         then:
         result.getStatus() == HttpResponseStatus.OK
         result.getType() == TestResponse.ResponseType.STREAM

--- a/src/test/java/sirius/web/health/SystemControllerSpec.groovy
+++ b/src/test/java/sirius/web/health/SystemControllerSpec.groovy
@@ -21,7 +21,7 @@ class SystemControllerSpec extends BaseSpecification {
 
     def "/system/ok returns 200 OK"() {
         when:
-        def result = TestRequest.GET("/system/ok").executeAndBlock()
+        def result = TestRequest.GET("/system/ok").execute()
         then:
         result.getStatus() == HttpResponseStatus.OK
     }
@@ -31,7 +31,7 @@ class SystemControllerSpec extends BaseSpecification {
         UserContext.get().setCurrentUser(UserInfo.Builder.createUser("test")
                 .withPermissions(Collections.singleton(SystemController.PERMISSION_SYSTEM_CONSOLE)).build())
         when:
-        def result = TestRequest.GET("/system/console").executeAndBlock()
+        def result = TestRequest.GET("/system/console").execute()
         then:
         result.getStatus() == HttpResponseStatus.OK
         result.getType() == TestResponse.ResponseType.TEMPLATE
@@ -43,7 +43,7 @@ class SystemControllerSpec extends BaseSpecification {
         UserContext.get().setCurrentUser(UserInfo.Builder.createUser("test")
                 .withPermissions(Collections.singleton(SystemController.PERMISSION_SYSTEM_STATE)).build())
         when:
-        def result = TestRequest.GET("/system/state").executeAndBlock()
+        def result = TestRequest.GET("/system/state").execute()
         then:
         result.getStatus() == HttpResponseStatus.OK
         result.getType() == TestResponse.ResponseType.TEMPLATE
@@ -53,7 +53,7 @@ class SystemControllerSpec extends BaseSpecification {
 
     def "/system/info renders its template"() {
         when:
-        def result = TestRequest.GET("/system/info").executeAndBlock()
+        def result = TestRequest.GET("/system/info").execute()
         then:
         result.getStatus() == HttpResponseStatus.OK
         result.getType() == TestResponse.ResponseType.TEMPLATE

--- a/src/test/java/sirius/web/http/TestResponse.java
+++ b/src/test/java/sirius/web/http/TestResponse.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Created by {@link TestRequest#execute()} or {@link TestRequest#executeAndBlock()} and represents a response
+ * Created by {@link TestRequest#execute()} or {@link TestRequest#executeAsync()} and represents a response
  * generated for a test request.
  * <p>
  * Provides additional information like {@link #getStatus()} or {@link #getType()} to verify what kind of


### PR DESCRIPTION
+ adds support for all HTTP methods and shortcut method for `DELETE`
+ adds support for URL parameters in request other than GET
+ renames `execute` to `executeAsync` and `executeAndBlock` to `execute` , because `executeAndBlock` is the "normal" behaviour (used in 99.9% of all cases)
+ makes MailsMock thread-safe