### PR TITLE
Revert: "Enables MailsMock to be used by parallized tests" because it didn't work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>11.7</version>
+    <version>11.7.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/test/java/sirius/web/mails/MailsMock.java
+++ b/src/test/java/sirius/web/mails/MailsMock.java
@@ -14,6 +14,7 @@ import sirius.kernel.di.std.Register;
 
 import javax.activation.DataSource;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +22,7 @@ import java.util.Map;
 @Register(classes = Mails.class)
 public class MailsMock extends Mails {
 
-    private ThreadLocal<List<MailSenderMock>> sentMails = new ThreadLocal<>();
+    private List<MailSenderMock> sentMails = Collections.synchronizedList(new ArrayList<>());
 
     @Override
     public MailSender createEmail() {
@@ -35,7 +36,7 @@ public class MailsMock extends Mails {
         @Override
         protected void sendMailAsync(SMTPConfiguration config) {
             this.effectiveConfig = config;
-            getSentMails().add(this);
+            sentMails.add(this);
             Mails.LOG.INFO("eMail to '%s' was not sent but captured, as MailsMock is active...", getReceiverEmail());
         }
 
@@ -89,16 +90,10 @@ public class MailsMock extends Mails {
     }
 
     public List<MailSenderMock> getSentMails() {
-        List<MailSenderMock> list = sentMails.get();
-        if (list == null) {
-            list = new ArrayList<>();
-            sentMails.set(list);
-        }
-        return list;
+        return sentMails;
     }
 
     public MailSenderMock getLastMail() {
-        List<MailSenderMock> list = getSentMails();
-        return list.isEmpty() ? null : list.get(list.size() - 1);
+        return sentMails.get(sentMails.size() - 1);
     }
 }


### PR DESCRIPTION
The mail-sending Thread often isn't the same one (e.g. `web-mvc-5`) as the reading Thread (usually `main`).

Because we cannot know which Thread actually sends the mail, we cannot distinguish the mails this way.
Instead, we need to synchronize all mails-sending tests or do not verify the number of total sent mails.