### PR TITLE
Fixes incorrect css class reference for tasks in warning state

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>11.8.4</version>
+    <version>11.8.5</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/tasks/ManagedTask.java
+++ b/src/main/java/sirius/web/tasks/ManagedTask.java
@@ -32,7 +32,7 @@ public interface ManagedTask {
      * Enuemrates possible states of a task.
      */
     enum State {
-        SCHEDULED("label-info"), RUNNING("label-success"), WARNINGS("label-warn"), TERMINATED("label-default");
+        SCHEDULED("label-info"), RUNNING("label-success"), WARNINGS("label-warning"), TERMINATED("label-default");
 
         private final String labelClass;
 


### PR DESCRIPTION
Now uses the correct css class for Tasks that are in the warning State.
Bumps the version.