### PR TITLE
Shorten uri written to TaskContext as job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>11.10.1</version>
+    <version>11.10.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -155,7 +155,7 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
         }
         wc.setCtx(ctx);
         wc.setRequest(req);
-        currentCall.get(TaskContext.class).setSystem("HTTP").setJob(req.uri());
+        currentCall.get(TaskContext.class).setSystem("HTTP").setJob(wc.getRequestedURI());
         return wc;
     }
 


### PR DESCRIPTION
The TraceData in Sirius-Biz saves the origin of a change. This contains the system string from the corresponding task context. As some requests might contain long parameters, this would also be saved. However, as the field has only a size of 150, longer calls with many and long request parameters result in an exception. As the requesrt uri also might contain sensitive data, this is now stripped by only setting the uri without the request parameters in the TaskContext in the WebServerHandler like the ControllerDispatcher already does.