### PR TITLE
Autocomplete Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>11.21</version>
+    <version>11.22</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -1,34 +1,11 @@
 <script type="text/javascript">
     window.sirius = window.sirius || {};
 
-    sirius.keys = (function(){
-        // fix physical keyboard bug on iPad that returns keyCode 0 on keyup
-        var map = {
-            "Backspace": 8,
-            "Tab": 9,
-            "Enter": 13,
-            "Control": 17,
-            "Escape": 27,
-            " ": 32,
-            "ArrowUp": 38,
-            "ArrowDown": 40,
-            ",": 188
-        };
+    function asFunction(possibleFunction) {
+        return typeof possibleFunction === "function" ? possibleFunction : Function();
+    }
 
-        return {
-            KEY_ENTER: 13,
-            KEY_ARROW_UP: 38,
-            KEY_ARROW_DOWN: 40,
-
-            enableKeyUpIpadSupport: function(event){
-                if (event.keyCode === 0 && event.key) {
-                    event.keyCode = event.which = map[event.key];
-                }
-            }
-        }
-    }());
-
-    sirius.autocomplete = (function () {
+    sirius.createAutocomplete = (function () {
         var anchor = {
             name: "autocomplete-anchor",
             element: undefined,
@@ -154,12 +131,12 @@
             VISIBLE: 1,
             state: undefined,
 
-            init: function () {
-                var wrapper = "<div id='autocomplete-wrapper' class='well autocomplete-wrapper'></div>";
+            init: function (config) {
+                var wrapper = "<div class='well autocomplete-wrapper autocomplete-wrapper-js' {{#id}}id='{{id}}'{{/id}}></div>";
 
                 this.state = completions.HIDDEN;
 
-                this.element = $(wrapper);
+                this.element = $(Mustache.render(wrapper, config));
                 this.element.width(anchor.element.outerWidth());
                 this.element.offset({
                     top: anchor.element.offset().top + anchor.element.height(),
@@ -223,7 +200,6 @@
                 if (completions.state === completions.HIDDEN) {
                     return;
                 }
-                completions.state = completions.HIDDEN;
 
                 window.setTimeout(function () {
                     /*
@@ -275,7 +251,7 @@
             update: function () {
                 this.element.empty();
 
-                if (this.rows.length < 1){
+                if (this.rows.length < 1) {
                     completions.hideImmediate();
                     return;
                 }
@@ -311,7 +287,10 @@
                     return;
                 }
 
-                events.onSelect(selectedElement);
+                if (events.onSelect(selectedElement) !== true) {
+                    completions.hideImmediate();
+                }
+
             }
         };
 
@@ -404,10 +383,6 @@
             }
         };
 
-        function asFunction(possibleFunction) {
-            return typeof possibleFunction === "function" ? possibleFunction : Function();
-        }
-
         return {
             eventNames: function () {
                 return Object.keys(events);
@@ -421,6 +396,13 @@
                 }
             },
 
+            config: undefined,
+            init: function (config) {
+                if (config) {
+                    this.config = config;
+                }
+            },
+
             /**
              * Method to initialize and start the autocompleter.
              *
@@ -431,16 +413,17 @@
                     throw "The event afterLoad must be set.";
                 }
 
+                this.init(config);
 
-                service.init(config.service);
+                service.init(this.config.service);
 
-                input.name = config.inputField;
+                input.name = this.config.inputField;
 
                 input.init();
-                anchor.init(config.anchor);
-                completions.init();
+                anchor.init(this.config.anchor);
+                completions.init(this.config.completions || {});
 
-                completions.setTemplates(config.templates);
+                completions.setTemplates(this.config.templates);
 
                 input.element.focus();
                 events.onReady();
@@ -466,7 +449,13 @@
 
             focus: function () {
                 input.element.focus();
+            },
+
+            isVisible: function () {
+                return completions.state === completions.VISIBLE;
             }
         };
-    }());
+    });
+
+    sirius.autocomplete = sirius.createAutocomplete();
 </script>

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -6,6 +6,13 @@
     }
 
     sirius.createAutocomplete = (function () {
+
+        /**
+         * Small object which defines some properties (width & position) of the completion div.
+         *
+         * The anchor can be the same as the input field but it is not necessary.
+         * @@type {{name: string, element: undefined, init: init}}
+         */
         var anchor = {
             name: "autocomplete-anchor",
             element: undefined,
@@ -23,16 +30,43 @@
             }
         };
 
+        /**
+         * Represents the input field of the autocomplete.
+         *
+         * Events on the input field like onChange are defined here.
+         *
+         * @@type {{name: string, element: undefined, spinnerElement: undefined, spinnerTemplate: string, showSpinner: showSpinner, hideSpinner: hideSpinner, onChange: onChange, onNonInputKeys: onNonInputKeys, init: init}}
+         */
         var input = {
             name: "autocomplete-input",
             element: undefined,
+            spinnerElement: undefined,
+            spinnerTemplate: '<span class="autocomplete-spinner hide"><i class="fa fa-spinner fa-spin"></i></span>',
 
             /**
-             * This method gets called each time the user input is changed
+             * Shows a small spinner in the input field whenever the service loads data.
+             */
+            showSpinner: function () {
+                if (input.spinnerElement) {
+                    input.spinnerElement.removeClass("hide");
+                }
+
+            },
+
+            /**
+             * Hides the spinner.
+             */
+            hideSpinner: function () {
+                if (input.spinnerElement) {
+                    input.spinnerElement.addClass("hide");
+                }
+            },
+
+            /**
+             * This method gets called each time the user input is changed.
              */
             onChange: function () {
                 var value = this.element.val();
-                completions.rows = [];
 
                 events.beforeLoad(value);
                 service.load(value);
@@ -54,6 +88,10 @@
                 }
 
                 if (event.keyCode === sirius.keys.KEY_ARROW_DOWN) {
+                    if (!completions.isVisible()) {
+                        completions.show();
+                    }
+
                     if (completions.selectedRow === undefined) {
                         completions.hoverRow(completions.element.find(".autocomplete-row-js").first())
                     } else {
@@ -67,15 +105,24 @@
                     return true;
                 }
 
-                if (event.keyCode === sirius.keys.KEY_ARROW_UP && completions.selectedRow !== undefined) {
-                    var prevRow = completions.selectedRow.prevAll(".autocomplete-row-js").first();
+                if (event.keyCode === sirius.keys.KEY_ARROW_UP) {
+                    if (completions.selectedRow !== undefined) {
+                        var prevRow = completions.selectedRow.prevAll(".autocomplete-row-js").first();
 
-                    completions.unHoverRow(completions.selectedRow);
+                        completions.unHoverRow(completions.selectedRow);
 
-                    if (prevRow.length) {
-                        completions.hoverRow(prevRow);
+                        if (prevRow.length) {
+                            completions.hoverRow(prevRow);
+                        }
+                    } else {
+                        completions.hideImmediate();
                     }
 
+                    return true;
+                }
+
+                if (event.keyCode === sirius.keys.KEY_ESC) {
+                    completions.hideImmediate();
                     return true;
                 }
 
@@ -84,8 +131,22 @@
                 return false;
             },
 
-            init: function () {
+
+            /**
+             * Initializes the input field.
+             *
+             */
+            init: function (config) {
                 this.element = $("#" + this.name);
+
+                if (config && !config.noSpinner) {
+                    input.spinnerElement = $(input.spinnerTemplate);
+                    input.spinnerElement.insertAfter(input.element);
+
+                    // this is needed to display the spinner in the same row as the input field
+                    // the spinner holds the class .fa which defines the size to 14
+                    input.element.css("max-width", input.element.width() - 14);
+                }
 
                 this.element.keyup(function (event) {
                     sirius.keys.enableKeyUpIpadSupport(event);
@@ -96,7 +157,7 @@
                 });
 
                 this.element.keydown(function (event) {
-                    if (completions.selectedRow === undefined && event.keyCode !== sirius.keys.KEY_ARROW_DOWN) {
+                    if (!completions.isVisible()) {
                         return;
                     }
 
@@ -121,6 +182,11 @@
             }
         };
 
+        /**
+         * Represents autocomplete suggestions html element.
+         *
+         * Handles the events & actions on the different rows in the element.
+         */
         var completions = {
             element: undefined,
             selectedRow: undefined,
@@ -129,19 +195,22 @@
 
             HIDDEN: 0,
             VISIBLE: 1,
+            SOON_TO_BE_HIDDEN: 2,
             state: undefined,
 
+            /**
+             * Initializes the completions element.
+             *
+             * Keys of the config object are:
+             * - id: the id of the autocomplete wrapper div
+             */
             init: function (config) {
                 var wrapper = "<div class='well autocomplete-wrapper autocomplete-wrapper-js' {{#id}}id='{{id}}'{{/id}}></div>";
 
                 this.state = completions.HIDDEN;
 
                 this.element = $(Mustache.render(wrapper, config));
-                this.element.width(anchor.element.outerWidth());
-                this.element.offset({
-                    top: anchor.element.offset().top + anchor.element.height(),
-                    left: anchor.element.offset().left
-                });
+                this.rePosition();
 
                 this.element.click(function (element) {
                     completions.select($(element.target));
@@ -152,6 +221,19 @@
                 $("body").append(this.element);
             },
 
+            rePosition: function () {
+                this.element.width(anchor.element.outerWidth());
+                this.element.offset({
+                    top: anchor.element.offset().top + anchor.element.height(),
+                    left: anchor.element.offset().left
+                });
+            },
+
+            /**
+             * Adds the hoverRow && unHoverRow events to the given autocompletion row.
+             *
+             * @@param $row the row element or a child element or a autocompletion row.
+             */
             addHoverRowEvent: function ($row) {
                 $row.find(".autocomplete-row-js").hover(function () {
                     completions.hoverRow($row);
@@ -174,8 +256,10 @@
             },
 
             unHoverRow: function ($row) {
+                if ($row) {
+                    $row.removeClass("autocomplete-selected-element");
+                }
                 completions.selectedRow = undefined;
-                $row.removeClass("autocomplete-selected-element");
             },
 
             setTemplates: function (templates) {
@@ -189,9 +273,9 @@
             show: function () {
                 if (this.rows.length > 0) {
                     completions.selectedRow = undefined;
-                    this.state = completions.VISIBLE;
                     this.update();
                     completions.element.show();
+                    this.state = completions.VISIBLE;
                     events.onShow();
                 }
             },
@@ -200,6 +284,8 @@
                 if (completions.state === completions.HIDDEN) {
                     return;
                 }
+
+                completions.state = completions.SOON_TO_BE_HIDDEN;
 
                 window.setTimeout(function () {
                     /*
@@ -226,9 +312,15 @@
                     return;
                 }
                 completions.state = completions.HIDDEN;
+                completions.unHoverRow(completions.selectedRow);
 
                 completions.element.hide();
+                input.hideSpinner();
                 events.onHide();
+            },
+
+            isVisible: function () {
+                return completions.state === completions.VISIBLE;
             },
 
             /**
@@ -317,8 +409,11 @@
         var service = {
             uri: undefined,
             minSize: 1,
+            delay: 400,
 
             responseCache: {},
+            lastLoadTriggered: undefined,
+            loading: false,
 
             /**
              * Provides the request object to be sent to the autocomplete service.
@@ -332,10 +427,27 @@
                 return {query: inputValue};
             },
 
+            isLoading: function () {
+                return service.loading;
+            },
+
             load: function (value) {
+                service.lastLoadTriggered = Date.now();
+                service.loading = true;
+                input.showSpinner();
+
+                setTimeout(function () {
+                    if (service.lastLoadTriggered + service.delay <= Date.now()) {
+                        service.loadImmediate(value);
+                    }
+                }, service.delay)
+            },
+
+            loadImmediate: function (value) {
                 var request = this.getRequest(value);
                 if (request.query === undefined || request.query.length < this.minSize) {
                     completions.hide();
+                    input.hideSpinner();
                     return;
                 }
 
@@ -357,6 +469,9 @@
 
             afterLoad: function (request) {
                 completions.rows = service.responseCache[request.query]
+                service.loading = false;
+
+                input.hideSpinner();
 
                 if (completions.rows.length > 0) {
                     completions.update();
@@ -366,6 +481,14 @@
                 }
             },
 
+            /**
+             * Keys of the config object are:
+             * - serviceUri: the uri of the autocompletion service
+             * - minSize: the minimal length of the input field value before a service request is created
+             * - getRequest: function to build the request object
+             * - cache: object to be used for caching
+             * - delay: the delay time for a service call
+             */
             init: function (config) {
                 if (config.serviceUri === undefined) {
                     throw "ServiceUri required";
@@ -380,6 +503,12 @@
                 if (typeof config.getRequest === "function") {
                     this.getRequest = config.getRequest;
                 }
+
+                if (typeof config.cache === "object") {
+                    this.responseCache = config.cache;
+                }
+
+                this.delay = config.delayTime || this.delay;
             }
         };
 
@@ -406,7 +535,12 @@
             /**
              * Method to initialize and start the autocompleter.
              *
-             * @@param config
+             * Keys of the config object are:
+             * - service: the config object of the service
+             * - inputField: the input field id to autocomplete
+             * - anchor: the id of the anchor div
+             * - completions: the config object of the completions
+             * - templates: the row templates
              */
             start: function (config) {
                 if (events.afterLoad === undefined) {
@@ -419,7 +553,7 @@
 
                 input.name = this.config.inputField;
 
-                input.init();
+                input.init(this.config.input);
                 anchor.init(this.config.anchor);
                 completions.init(this.config.completions || {});
 
@@ -438,7 +572,7 @@
             setInput: function (value, silent) {
                 input.element.val(value);
 
-                if (silent !== true) {
+                if (!silent) {
                     input.onChange();
                 }
             },
@@ -452,7 +586,11 @@
             },
 
             isVisible: function () {
-                return completions.state === completions.VISIBLE;
+                return completions.isVisible();
+            },
+
+            rePosition: function(){
+                return completions.rePosition();
             }
         };
     });

--- a/src/main/resources/default/templates/wondergem/scripts/event-keys.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/event-keys.html.pasta
@@ -5,9 +5,12 @@
         return typeof possibleFunction === "function" ? possibleFunction : Function();
     }
 
+    /**
+     * Bundles some functions and constants for jquery press key events.
+     */
     sirius.keys = (function () {
         // fix physical keyboard bug on iPad that returns keyCode 0 on keyup
-        var map = {
+        var ipadFixMap = {
             "Backspace": 8,
             "Tab": 9,
             "Enter": 13,
@@ -39,6 +42,7 @@
             KEY_TAB: 9,
             KEY_ENTER: 13,
             KEY_SHIFT: 16,
+            KEY_ESC: 27,
             KEY_ARROW_UP: 38,
             KEY_ARROW_DOWN: 40,
 
@@ -59,7 +63,7 @@
 
             enableKeyUpIpadSupport: function (event) {
                 if (event.keyCode === 0 && event.key) {
-                    event.keyCode = event.which = map[event.key];
+                    event.keyCode = event.which = ipadFixMap[event.key];
                 }
             },
 
@@ -67,6 +71,9 @@
                 return e || event;
             },
 
+            /**
+             * Helper method which will call all browser & event specific helper functions.
+             */
             browserFixes: function (e) {
                 e = this.enableInternetExplorer(e);
                 this.enableKeyUpIpadSupport(e);
@@ -102,6 +109,8 @@
 
             /**
              * Checks if one or multiple keyCodes are pressed.
+             *
+             * This method can be used to check for custom defined short cuts (e.g. shift and enter).
              *
              * @@param keyCodes can be a string representation of the keyCode or an array of strings
              * @@return {boolean} true if all requested keyCodes are pressed, false otherwise

--- a/src/main/resources/default/templates/wondergem/scripts/event-keys.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/event-keys.html.pasta
@@ -1,0 +1,126 @@
+<script type="text/javascript">
+    window.sirius = window.sirius || {};
+
+    function asFunction(possibleFunction) {
+        return typeof possibleFunction === "function" ? possibleFunction : Function();
+    }
+
+    sirius.keys = (function () {
+        // fix physical keyboard bug on iPad that returns keyCode 0 on keyup
+        var map = {
+            "Backspace": 8,
+            "Tab": 9,
+            "Enter": 13,
+            "Control": 17,
+            "Escape": 27,
+            " ": 32,
+            "ArrowUp": 38,
+            "ArrowDown": 40,
+            ",": 188
+        };
+
+        /**
+         * Holds information about all pressed keys.
+         *
+         * If a key is pressed pressedKeys[keyCode] is set to true, else false.
+         * If the key was never pressed at all pressedKeys[keyCode] is undefined
+         */
+        var pressedKeys = {};
+
+
+        var events = {
+            keyDown: Function(),
+            keyUp: Function()
+        };
+
+
+        return {
+            KEY_BACKSPACE: 8,
+            KEY_TAB: 9,
+            KEY_ENTER: 13,
+            KEY_SHIFT: 16,
+            KEY_ARROW_UP: 38,
+            KEY_ARROW_DOWN: 40,
+
+            KEY_SEMICOLON: 186,
+            KEY_COMMA: 188,
+
+            eventNames: function () {
+                return Object.keys(events);
+            },
+
+            on: function (name, callback) {
+                if (this.eventNames().includes(name)) {
+                    events[name] = asFunction(callback);
+                } else {
+                    throw "Callback " + name + " is no valid event."
+                }
+            },
+
+            enableKeyUpIpadSupport: function (event) {
+                if (event.keyCode === 0 && event.key) {
+                    event.keyCode = event.which = map[event.key];
+                }
+            },
+
+            enableInternetExplorer: function (e) {
+                return e || event;
+            },
+
+            browserFixes: function (e) {
+                e = this.enableInternetExplorer(e);
+                this.enableKeyUpIpadSupport(e);
+
+                return e;
+            },
+
+            /**
+             * Register event listeners to detect multiple pressed keys
+             *
+             * every pressed key is saved within the map object
+             * to detected if a key is pressed simple check for map[$keyCode]
+             *
+             * @@param $element which should listen to the key down / key up events
+             * @@return object of pressed key
+             */
+            registerMultipleKeyListener: function ($element) {
+                $element.keydown(function (e) {
+                    e = sirius.keys.browserFixes(e);
+
+                    pressedKeys[e.keyCode] = true;
+                    events.keyDown(e);
+                });
+
+                $element.keyup(function (e) {
+                    e = sirius.keys.browserFixes(e);
+
+                    pressedKeys[e.keyCode] = false;
+                    events.keyUp(e);
+                });
+
+            },
+
+            /**
+             * Checks if one or multiple keyCodes are pressed.
+             *
+             * @@param keyCodes can be a string representation of the keyCode or an array of strings
+             * @@return {boolean} true if all requested keyCodes are pressed, false otherwise
+             */
+            isPressed: function (keyCodes) {
+                if (typeof keyCodes !== "object") {
+                    return pressedKeys[keyCodes] || false;
+                }
+
+                var allKeysPressed = true;
+                $.each(keyCodes, function (index, keyCode) {
+                    if (pressedKeys[keyCode] !== true) {
+                        allKeysPressed = false;
+                        return false;
+                    }
+                });
+
+                return allKeysPressed;
+            }
+        }
+    }());
+</script>

--- a/src/main/resources/default/templates/wondergem/scripts/polyfill.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/polyfill.html.pasta
@@ -1,0 +1,50 @@
+<script type="text/javascript">
+    /**
+     * polyfill for the date.now method
+     * see: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date/now
+     */
+    if (!Date.now) {
+        Date.now = function now() {
+            return new Date().getTime();
+        };
+    }
+
+    /**
+     * polyfill for the array.includes method
+     * see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
+     */
+    if (!Array.prototype.includes) {
+        Array.prototype.includes = function (searchElement /*, fromIndex*/) {
+            'use strict';
+            if (this == null) {
+                throw new TypeError('Array.prototype.includes called on null or undefined');
+            }
+
+            var O = Object(this);
+            var len = parseInt(O.length, 10) || 0;
+            if (len === 0) {
+                return false;
+            }
+            var n = parseInt(arguments[1], 10) || 0;
+            var k;
+            if (n >= 0) {
+                k = n;
+            } else {
+                k = len + n;
+                if (k < 0) {
+                    k = 0;
+                }
+            }
+            var currentElement;
+            while (k < len) {
+                currentElement = O[k];
+                if (searchElement === currentElement ||
+                    (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
+                    return true;
+                }
+                k++;
+            }
+            return false;
+        };
+    }
+</script>

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -6,6 +6,13 @@
     }
 
 
+    /**
+     * Provides a simple api to use the tokenfield lib.
+     *
+     * Will handle the two different input fields (the actual one and the one the lib generates).
+     *
+     * @@type {{eventNames, on, start, getInput, appendTokens, getInputFieldId, hasTokens}}
+     */
     sirius.tokenfield = (function () {
             var input = {
                 id: undefined,
@@ -23,6 +30,11 @@
                 value: "",
                 allTokens: undefined,
 
+                /**
+                 * Keys of the config object are:
+                 * - id (of the input field)
+                 * - tokenfield: the tokenfield config object: see http://sliptree.github.io/bootstrap-tokenfield/
+                 */
                 init: function (config) {
                     this.id = config.id;
 
@@ -42,6 +54,7 @@
                     this.element.on('tokenfield:removedtoken', function (e) {
                         var identifier = e.attrs.value;
                         $('input[data-identifier="' + identifier + '"]').remove();
+
 
                         events.onRemovedToken(e);
                     });
@@ -117,6 +130,10 @@
 
                 getInputFieldId: function () {
                     return input.tokenElement.prop("id");
+                },
+
+                hasTokens: function () {
+                    return input.element.tokenfield('getTokens').length > 0;
                 }
             };
         }

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -1,6 +1,11 @@
 <script>
     window.sirius = window.sirius || {};
 
+    function asFunction(possibleFunction) {
+        return typeof possibleFunction === "function" ? possibleFunction : Function();
+    }
+
+
     sirius.tokenfield = (function () {
             var input = {
                 id: undefined,
@@ -76,11 +81,6 @@
                 onEnter: Function(),
                 onRemovedToken: Function()
             };
-
-            function asFunction(possibleFunction) {
-                return typeof possibleFunction === "function" ? possibleFunction : Function();
-            }
-
 
             return {
                 eventNames: function () {


### PR DESCRIPTION
Bugfixes and Documentation
- Polyfills for better IE support
- adds a spinner option which indicates the waiting for response status of the autocomplete service
- adds multiple autocomplete instances per page option (including a shared cache)
- fixes a bug related to the autocomplete.hide method
- moves sirius.keys into own template file
