### PR TITLE
Implements a method to get the current selection of the autocomplete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>12.0.1</version>
+    <version>12.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -285,7 +285,7 @@
             },
 
             show: function () {
-                if (this.rows.length > 0) {
+                if (this.rows.length > 0 && input.element.is(":focus")) {
                     completions.selectedRow = undefined;
                     this.update();
                     completions.element.show();
@@ -605,6 +605,26 @@
 
             rePosition: function () {
                 return completions.rePosition();
+            },
+
+            /**
+             * Getter for the currently selected row.
+             *
+             * A selected row is a row of the suggested completions. It is selected by the arrow keys on the keyboard
+             * or by hovering over the row with the mouse pointer.
+             *
+             * If no completions are shown no row can be selected and the return value is undefined.
+             * @@returns jquery object representing the selected row or undefined if non is selected
+             */
+            getCurrentSelection: function () {
+                return this.isVisible() ? completions.selectedRow : undefined;
+            },
+
+            /**
+             * Hides the suggested completions.
+             */
+            hide: function(){
+                completions.hideImmediate();
             }
         };
     });


### PR DESCRIPTION
Also fixes a bug where the completions are shown even though the associated input field already lost its focus
Also adds a hide Method the library user can actually call.
- Fixes: SE-3401