### PR TITLE
Escapes backslashes in the EscapeJSMacro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>12.3.1</version>
+    <version>12.3.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/macros/EscapeJSMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/EscapeJSMacro.java
@@ -45,7 +45,7 @@ public class EscapeJSMacro implements Macro {
             return "";
         }
 
-        return value.toString().replaceAll("\\r?\\n", " ").replace("'", "\\'");
+        return value.toString().replaceAll("\\r?\\n", " ").replace("\\", "\\\\").replace("'", "\\'");
     }
 
     @Override


### PR DESCRIPTION
Single backslashes in strings raised a Javascript Error when they are parsed by `JSON.parse()` or `eval()` 