### PR TITLE
Fixes a bug where the click event is not triggered

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>12.3.2</version>
+    <version>12.3.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -82,8 +82,6 @@
             onNonInputKeys: function (event) {
                 if (event.keyCode === sirius.keys.KEY_ENTER || event.keyCode === sirius.keys.KEY_TAB) {
                     completions.select(completions.selectedRow);
-                    input.element.blur();
-                    completions.hide();
                     return true;
                 }
 
@@ -216,7 +214,6 @@
 
                 this.element.on("mouseup.sirius-autocomplete", ".autocomplete-row-js", function () {
                     completions.select($(this));
-                    completions.hideImmediate();
                 });
 
                 $("body").append(this.element);
@@ -378,25 +375,29 @@
              * Called if a row of the autocomplete is selected.
              *
              * Retrieves the actual row element associated with the selected $element
-             * and calls events.onSelect(selectedRow)
+             * and calls events.onSelect(selectedRow).
+             *
+             * Will call events.onSelect() if no valid current row was selected.
              *
              * @@param $element the element that was selected
              */
             select: function ($element) {
-                if ($element === undefined) {
-                    return;
+                var result = false;
+
+                if ($element) {
+                    var selectedElement = $element.closest(".autocomplete-row-js");
+                    if (selectedElement.length) {
+                        result = events.onSelect(selectedElement);
+                    } else {
+                        result = events.onSelect();
+                    }
+                } else {
+                    result = events.onSelect();
                 }
 
-                var selectedElement = $element.closest(".autocomplete-row-js");
-                if (!selectedElement.length) {
-                    // don't do anything if no element with the row class was found
-                    return;
-                }
-
-                if (events.onSelect(selectedElement) !== true) {
+                if (!result) {
                     completions.hideImmediate();
                 }
-
             }
         };
 

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -213,9 +213,9 @@
                 this.element = $(Mustache.render(wrapper, config));
                 this.rePosition();
 
-                this.element.click(function (element) {
-                    completions.select($(element.target));
 
+                this.element.on("mouseup.sirius-autocomplete", ".autocomplete-row-js", function () {
+                    completions.select($(this));
                     completions.hideImmediate();
                 });
 

--- a/src/main/resources/default/templates/wondergem/scripts/event-keys.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/event-keys.html.pasta
@@ -91,14 +91,14 @@
              * @@return object of pressed key
              */
             registerMultipleKeyListener: function ($element) {
-                $element.keydown(function (e) {
+                $element.on("keydown.sirius-keys", function (e) {
                     e = sirius.keys.browserFixes(e);
 
                     pressedKeys[e.keyCode] = true;
                     events.keyDown(e);
                 });
 
-                $element.keyup(function (e) {
+                $element.on("keyup.sirius-keys", function (e) {
                     e = sirius.keys.browserFixes(e);
 
                     pressedKeys[e.keyCode] = false;


### PR DESCRIPTION
The bug happend only on some mobile devices because clicking on a completions element would
trigger a scroll event of the page before the click event was triggered.
The following click event would hold the completions div as target instead of the selected row.