### PR TITLE
Fixes the nls support for sent mails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>12.3.3</version>
+    <version>12.3.4</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/mails/MailSender.java
+++ b/src/main/java/sirius/web/mails/MailSender.java
@@ -46,6 +46,8 @@ public class MailSender {
     protected String receiverName;
     protected String subject;
     protected Context context;
+    protected String textTemplate;
+    protected String htmlTemplate;
     protected String text;
     protected String html;
     protected String type;
@@ -191,12 +193,10 @@ public class MailSender {
      * @param context  the context passed to the renderer
      * @return the builder itself
      */
-    public MailSender textTemplate(String template, Context context) {
-        return textContent(templates.generator()
-                                    .useTemplate(template)
-                                    .put("mailContext", this)
-                                    .applyContext(context)
-                                    .generate());
+    public MailSender textTemplate(String template, @Nonnull Context context) {
+        this.textTemplate = template;
+        this.context = context;
+        return this;
     }
 
     /**
@@ -217,12 +217,10 @@ public class MailSender {
      * @param context  the context passed to the renderer
      * @return the builder itself
      */
-    public MailSender htmlTemplate(String template, Context context) {
-        return htmlContent(templates.generator()
-                                    .useTemplate(template)
-                                    .put("mailContext", this)
-                                    .applyContext(context)
-                                    .generate());
+    public MailSender htmlTemplate(String template, @Nonnull Context context) {
+        this.htmlTemplate = template;
+        this.context = context;
+        return this;
     }
 
     /**
@@ -377,6 +375,7 @@ public class MailSender {
                 if (lang != null) {
                     CallContext.getCurrent().setLang(lang);
                 }
+                render();
                 sanitize();
                 check();
                 sendMailAsync(new SMTPConfiguration());
@@ -397,6 +396,23 @@ public class MailSender {
                             .to(Mails.LOG)
                             .error(e)
                             .handle();
+        }
+    }
+
+    private void render() {
+        if (Strings.isFilled(htmlTemplate)) {
+            htmlContent(templates.generator()
+                                 .useTemplate(htmlTemplate)
+                                 .put("mailContext", this)
+                                 .applyContext(context)
+                                 .generate());
+        }
+        if (Strings.isFilled(textTemplate)) {
+            textContent(templates.generator()
+                                 .useTemplate(textTemplate)
+                                 .put("mailContext", this)
+                                 .applyContext(context)
+                                 .generate());
         }
     }
 


### PR DESCRIPTION
The language to use was only set when really sending the mail but rendering happened right when setting the template to use so the generated html and text content was always untranslated.