### PR TITLE
Trims trailing empty cells in excel imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>12.5.2</version>
+    <version>12.5.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/data/XLSProcessor.java
+++ b/src/main/java/sirius/web/data/XLSProcessor.java
@@ -55,7 +55,7 @@ public class XLSProcessor implements LineBasedProcessor {
             current++;
             Row row = iter.next();
             short first = 0;
-            short last = row.getLastCellNum();
+            short last = getLastFilledCell(row);
             List<Object> values = Lists.newArrayList();
             for (int i = first; i <= last; i++) {
                 Cell cell = row.getCell(i);
@@ -65,6 +65,19 @@ public class XLSProcessor implements LineBasedProcessor {
             rowProcessor.handleRow(current, Values.of(values));
             tc.setState(NLS.get("LineBasedProcessor.linesProcessed"), current);
         }
+    }
+
+    private short getLastFilledCell(Row row) {
+        short lastFilled = -1;
+        Iterator<Cell> cellIterator = row.cellIterator();
+        for (short current = 0; cellIterator.hasNext(); current++) {
+            Cell cell = cellIterator.next();
+            Object cellValue = extractCellValue(cell);
+            if (cellValue != null && Strings.isFilled(cellValue)) {
+                lastFilled = current;
+            }
+        }
+        return lastFilled;
     }
 
     private Object extractCellValue(Cell cell) {

--- a/src/main/java/sirius/web/data/XLSProcessor.java
+++ b/src/main/java/sirius/web/data/XLSProcessor.java
@@ -68,14 +68,9 @@ public class XLSProcessor implements LineBasedProcessor {
     }
 
     private short getLastFilledCell(Row row) {
-        short lastFilled = -1;
-        Iterator<Cell> cellIterator = row.cellIterator();
-        for (short current = 0; cellIterator.hasNext(); current++) {
-            Cell cell = cellIterator.next();
-            Object cellValue = extractCellValue(cell);
-            if (cellValue != null && Strings.isFilled(cellValue)) {
-                lastFilled = current;
-            }
+        short lastFilled = row.getLastCellNum();
+        while (lastFilled > -1 && Strings.isEmpty(extractCellValue(row.getCell(lastFilled)))) {
+            lastFilled--;
         }
         return lastFilled;
     }


### PR DESCRIPTION
Necessary, because SmartLineBasedProcessor will throw an exception, if a "Data"-row has more columns than the "Headings"-row. And we don't want that to be caused by empty columns in an excel file.