### PR TITLE
Removes the check for the "Origin" header in a CORS pre-flight request.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>12.5.3</version>
+    <version>12.5.4</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -16,7 +16,6 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -306,12 +305,7 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
             return false;
         }
 
-        HttpHeaders headers = currentRequest.headers();
-        if (!headers.contains(HttpHeaderNames.ORIGIN)) {
-            return false;
-        }
-
-        return headers.contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
+        return currentRequest.headers().contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
     }
 
     private void channelReadRequest(ChannelHandlerContext ctx, HttpRequest msg) {


### PR DESCRIPTION
Firefox seems to omit this header in some cases and since it is
an otherwise unused OPTIONS request and must contain another CORS
header, we're pretty sure it is a preflight request.