### PR TITLE
Routes requests using the unencoded URI

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -80,7 +80,7 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private boolean route(final WebContext ctx, boolean preDispatch) {
-        String uri = ctx.getRequestedURI();
+        String uri = ctx.getRawRequestedURI();
         if (uri.endsWith("/") && !"/".equals(uri)) {
             uri = uri.substring(0, uri.length() - 1);
         }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -121,6 +121,11 @@ public class WebContext implements SubContext {
     private String requestedURI;
 
     /*
+     * The effective request uri (without the query string)
+     */
+    private String rawRequestedURI;
+
+    /*
      * The base url (without the uri, like: http://myhost.com)
      */
     private String baseURL;
@@ -796,15 +801,27 @@ public class WebContext implements SubContext {
     }
 
     /**
-     * Returns the requested URI of the underlying HTTP request, without the query string
+     * Returns the decoded requested URI of the underlying HTTP request, without the query string
      *
-     * @return the uri of the underlying request
+     * @return the decoded uri of the underlying request
      */
     public String getRequestedURI() {
         if (requestedURI == null && request != null) {
             decodeQueryString();
         }
         return requestedURI;
+    }
+    /**
+     * Returns the unencoded requested URI of the underlying HTTP request, without the query string
+     *
+     * @return the unencoded uri of the underlying request
+     */
+    public String getRawRequestedURI() {
+        if (rawRequestedURI == null && request != null) {
+            int pathEndPos = request.uri().indexOf('?');
+            rawRequestedURI = pathEndPos < 0 ? request.uri() : request.uri().substring(0, pathEndPos);
+        }
+        return rawRequestedURI;
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -812,9 +812,9 @@ public class WebContext implements SubContext {
         return requestedURI;
     }
     /**
-     * Returns the unencoded requested URI of the underlying HTTP request, without the query string
+     * Returns the raw undecoded requested URI of the underlying HTTP request, without the query string
      *
-     * @return the unencoded uri of the underlying request
+     * @return the undecoded uri of the underlying request
      */
     public String getRawRequestedURI() {
         if (rawRequestedURI == null && request != null) {


### PR DESCRIPTION
This is as per RFC 3986, Section 2.4 as otherwise data can be intrepted as subcomponent delimiters
Especially %2F was interpreted as "/" which made 'one/t%2Fwo' route to 'one/t/wo'

Routed methods will still get their params decoded