### PR TITLE
Date Frame Taglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13</version>
+    <version>13.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/macros/ParseUserStringMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/ParseUserStringMacro.java
@@ -1,0 +1,58 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle.macros;
+
+import sirius.kernel.di.std.Register;
+import sirius.kernel.nls.NLS;
+import sirius.tagliatelle.Tagliatelle;
+import sirius.tagliatelle.expression.Expression;
+import sirius.tagliatelle.rendering.LocalRenderContext;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+@Register
+public class ParseUserStringMacro implements Macro {
+
+    @Override
+    public Class<?> getType() {
+        return Object.class;
+    }
+
+    @Override
+    public void verifyArguments(List<Expression> args) {
+        if (args.size() != 2
+            || !Tagliatelle.isAssignable(args.get(0).getType(), Class.class)
+            || !Tagliatelle.isAssignableTo(args.get(1).getType(), String.class)) {
+            throw new IllegalArgumentException(
+                    "Expected the first argument to be a class and the second argument to be a string");
+        }
+    }
+
+    @Override
+    public Object eval(LocalRenderContext ctx, Expression[] args) {
+        return NLS.parseUserString((Class) args[0].eval(ctx), (String) args[1].eval(ctx));
+    }
+
+    @Override
+    public boolean isConstant(Expression[] args) {
+        return true;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Parses the given user string into the desired object if possible";
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "parseUserString";
+    }
+}

--- a/src/main/java/sirius/tagliatelle/macros/ParseUserStringMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/ParseUserStringMacro.java
@@ -17,6 +17,12 @@ import sirius.tagliatelle.rendering.LocalRenderContext;
 import javax.annotation.Nonnull;
 import java.util.List;
 
+/**
+ * Parses the given user string into the desired object.
+ * <p>
+ *
+ * @see NLS#parseUserString(Class, String)
+ */
 @Register
 public class ParseUserStringMacro implements Macro {
 

--- a/src/main/resources/default/taglib/w/dateFrame.html.pasta
+++ b/src/main/resources/default/taglib/w/dateFrame.html.pasta
@@ -1,0 +1,12 @@
+<i:arg name="showFrom" type="String" default=""/>
+<i:arg name="showUntil" type="String" default=""/>
+
+<i:pragma name="inline" value="true" />
+<i:pragma name="description" value="Provides an easy taglib to show certain parts only in a limited date frame" />
+
+<i:local name="isShowFromMatched" value="@!isFilled(showFrom) || !today.isBefore(parseUserString(java.time.LocalDate.class, showFrom).as(java.time.LocalDate.class))"/>
+<i:local name="isShowUntilMatched" value="@!isFilled(showUntil) || !today.isAfter(parseUserString(java.time.LocalDate.class, showUntil).as(java.time.LocalDate.class))"/>
+
+<i:if test="@isShowFromMatched && isShowUntilMatched">
+    <i:render name="body"/>
+</i:if>


### PR DESCRIPTION
This taglib allows to show its content only for a certain time e.g. for information which is valid only for a certain time. Furthermore a macro for calling NLS.parseUserString was created for easy handling of the dateFrame taglib.