### PR TITLE
Only report a monitoring error if the cluster is RED because of the c…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13.1.1</version>
+    <version>13.1.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/health/SystemController.java
+++ b/src/main/java/sirius/web/health/SystemController.java
@@ -19,6 +19,7 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Microtiming;
 import sirius.kernel.health.metrics.Metric;
+import sirius.kernel.health.metrics.MetricState;
 import sirius.kernel.health.metrics.Metrics;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.BasicController;
@@ -91,7 +92,9 @@ public class SystemController extends BasicController {
      */
     @Routed("/system/monitor")
     public void monitorNode(WebContext ctx) {
-        ctx.respondWith().direct(HttpResponseStatus.OK, cluster.isAlarmPresent() ? "ERROR" : "OK");
+        ctx.respondWith()
+           .direct(HttpResponseStatus.OK,
+                   cluster.getNodeState() == MetricState.RED && cluster.isAlarmPresent() ? "ERROR" : "OK");
     }
 
     /**


### PR DESCRIPTION
…urrent node.

We add the cluster check so that the node has to be RED for at least two intervals.