### PR TITLE
Fixes a bug when creating the query string and sends the Content-Disposition header in TestRequests 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13.3</version>
+    <version>13.3.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -395,7 +395,8 @@ public class TestRequest extends WebContext implements HttpRequest {
     protected void build() {
         // append GET parameters to URI
         String queryString = generateQueryString(parameters);
-        this.testUri = this.testUri + (Strings.isFilled(queryString) ? "?" + queryString : "");
+        this.testUri =
+                this.testUri + (Strings.isFilled(queryString) ? (testUri.contains("?") ? "&" : "?") + queryString : "");
 
         // send resource in body
         if (resource != null && (testMethod.equals(HttpMethod.PATCH) || testMethod.equals(HttpMethod.POST) || testMethod

--- a/src/test/java/sirius/web/http/TestResponse.java
+++ b/src/test/java/sirius/web/http/TestResponse.java
@@ -354,6 +354,10 @@ public class TestResponse extends Response {
         if (Strings.isFilled(contentType)) {
             addHeaderIfNotExists(HttpHeaderNames.CONTENT_TYPE, contentType);
         }
+        if (name != null) {
+            setContentDisposition(name, download);
+        }
+
         return new ByteArrayOutputStream() {
             @Override
             public void close() throws IOException {


### PR DESCRIPTION
```
OXOMITestRequest.POST("/page?param1=value1")
                .withParameter("param2", "value2")
```

Before: `/page?param1=value1?value2=value2`

After: `/page?param1=value1&value2=value2`

-----

The `Content-Disposition` header can now be tested:

`assert response.headers().get(HttpHeaders.CONTENT_DISPOSITION) == "attachment;filename=\"catalogs.xls\";filename*=UTF-8''catalogs.xls"`