### PR TITLE
Implements second macro calling syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13.1.2</version>
+    <version>13.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -357,7 +357,7 @@ public class Compiler extends InputProcessor {
     }
 
     /**
-     * Processes an expression started with an {@literal @}.
+     * Processes an expression started with an {@literal @} or with "___"
      *
      * @param block the block to append the expression or the parsed emitters to
      * @return <tt>true</tt> if an expression was parsed, <tt>false</tt> otherwise

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -346,13 +346,24 @@ public class Compiler extends InputProcessor {
     }
 
     /**
+     * Evaluates if the current char marks the start of an expression.
+     * <p>
+     * If the current char is '@' or this and the next 2 chars all equal to '_' the current char marks the start of an expression.
+     *
+     * @return <tt>true</tt> if the current char could mark an expression, <tt>false</tt> otherwise
+     */
+    private boolean isPotentialExpression() {
+        return reader.current().is('@') || (reader.current().is('_') && reader.next().is('_') && reader.next(2).is('_'));
+    }
+
+    /**
      * Processes an expression started with an {@literal @}.
      *
      * @param block the block to append the expression or the parsed emitters to
      * @return <tt>true</tt> if an expression was parsed, <tt>false</tt> otherwise
      */
     private boolean processExpression(CompositeEmitter block) {
-        if (!reader.current().is('@')) {
+        if (!isPotentialExpression()) {
             return false;
         }
 
@@ -596,7 +607,7 @@ public class Compiler extends InputProcessor {
             return true;
         }
 
-        if (reader.current().is('@')) {
+        if (isPotentialExpression()) {
             return true;
         }
 

--- a/src/main/java/sirius/tagliatelle/compiler/EvalExpressionHandler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/EvalExpressionHandler.java
@@ -30,7 +30,12 @@ public class EvalExpressionHandler extends ExpressionHandler {
 
     @Override
     public Emitter process(Compiler compiler) {
-        compiler.getReader().consume();
+        if (compiler.getReader().current().is('_')) {
+            compiler.getReader().consume(3);
+        } else {
+            compiler.getReader().consume();
+        }
+
         return new ExpressionEmitter(compiler.getReader().current(), compiler.parseExpression(false));
     }
 }

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -218,4 +218,13 @@ class CompilerSpec extends BaseSpecification {
         basicallyEqual(result, expectedResult)
     }
 
+    def "different macro call syntax"() {
+        given:
+        String expectedResult = resources.resolve("templates/macroSyntax.html").get().getContentAsString()
+        when:
+        String result = tagliatelle.resolve("templates/macroSyntax.html.pasta").get().renderToString()
+        then:
+        basicallyEqual(result, expectedResult)
+    }
+
 }

--- a/src/test/resources/templates/macroSyntax.html
+++ b/src/test/resources/templates/macroSyntax.html
@@ -1,0 +1,2 @@
+Hello World
+Hello World

--- a/src/test/resources/templates/macroSyntax.html.pasta
+++ b/src/test/resources/templates/macroSyntax.html.pasta
@@ -1,0 +1,2 @@
+@toUserString("Hello World")
+___toUserString("Hello World")


### PR DESCRIPTION
this allows us to call ___macroName instead of @macroName
Necessary is this to use tagliatelle macros within js.pasta files without destroying the code
with the intellij code format