### PR TITLE
Corrects the tokenfield init

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13.5</version>
+    <version>13.5.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -53,8 +53,9 @@
                     this.tokenElement.val("");
 
                     // create initial tokens
+                    input.allTokens = [];
                     $.each(this.value.split(tokenfieldConfig.delimiter), function(index, element) {
-                        this.allTokens = [{label: element, value: element, initialQueryIdentifier: true}];
+                        input.allTokens.push({label: element, value: element, initialQueryIdentifier: true});
                     });
 
                     this.element.on('tokenfield:removedtoken', function (e) {


### PR DESCRIPTION
if no query parameter was set the init would fail and the allTokens array would be undefined
This would lead to an error when calling appendTokens
- Fixes: SE-3862