### PR TITLE
Fixes rewriting the URI in the WebContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13.5.1</version>
+    <version>13.5.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -818,8 +818,7 @@ public class WebContext implements SubContext {
      */
     public String getRawRequestedURI() {
         if (rawRequestedURI == null && request != null) {
-            int pathEndPos = request.uri().indexOf('?');
-            rawRequestedURI = pathEndPos < 0 ? request.uri() : request.uri().substring(0, pathEndPos);
+            rawRequestedURI = stripQueryFromURI(request.uri());
         }
         return rawRequestedURI;
     }
@@ -1052,12 +1051,23 @@ public class WebContext implements SubContext {
     }
 
     /**
+     * Strips the query part of a uri.
+     *
+     * @param uri the uri to remove the query string of
+     * @return the uri without the query string
+     */
+    private String stripQueryFromURI(String uri) {
+        int pathEndPos = uri.indexOf('?');
+        return pathEndPos < 0 ? uri : uri.substring(0, pathEndPos);
+    }
+
+    /**
      * Overwrites the uri with the given one.
      * <p>
      * This can be used to control dispatching or to even re-dispatch a request for another destination.
      * <p>
-     * Note however, that only the the <tt>requestedURI</tt> and the <tt>queryString</tt> are overwritten, not the one
-     * of the underlying request.
+     * Note however, that only the the <tt>requestedURI</tt>, <tt>queryString</tt> and the <tt>rawRequestedURI</tt> are
+     * overwritten, not the one of the underlying request.
      *
      * @param uri the new uri to use. The uri and its query string will be parsed and the internal fields are updated
      *            accordingly.
@@ -1067,6 +1077,7 @@ public class WebContext implements SubContext {
         QueryStringDecoder qsd = new QueryStringDecoder(uri, Charsets.UTF_8);
         requestedURI = qsd.path();
         queryString = qsd.parameters();
+        rawRequestedURI = stripQueryFromURI(uri);
 
         return this;
     }
@@ -1086,6 +1097,7 @@ public class WebContext implements SubContext {
             decodeQueryString();
         }
         requestedURI = path;
+        rawRequestedURI = stripQueryFromURI(path);
 
         return this;
     }

--- a/src/test/java/sirius/web/http/WebContextSpec.groovy
+++ b/src/test/java/sirius/web/http/WebContextSpec.groovy
@@ -37,4 +37,31 @@ class WebContextSpec extends BaseSpecification {
         r.getQueryString() == ""
     }
 
+    def "withCustomURI rewrites the uri correctly and removes the existing query string"() {
+        when:
+        TestRequest r = TestRequest.GET("/test?a=a")
+        and:
+        r.withCustomURI("/test%2Ftest?b=b")
+        then:
+        r.getRawRequestedURI() == "/test%2Ftest"
+        and:
+        r.getRequestedURI() == "/test/test"
+        and:
+        !r.get("a").isFilled()
+        and:
+        r.get("b").isFilled()
+    }
+
+    def "withCustomPath rewrites the path correctly without removing the existing query string"() {
+        when:
+        TestRequest r = TestRequest.GET("/test?a=a")
+        and:
+        r.withCustomPath("/test/test")
+        then:
+        r.getRawRequestedURI() == "/test/test"
+        and:
+        r.getRequestedURI() == "/test/test"
+        and:
+        r.get("a").isFilled()
+    }
 }


### PR DESCRIPTION
The ControllerDispatcher uses the raw uri to determine the correct route for a request. Now this raw uri is also updated when withCustomURI or withCustomPath are used to rewrite the request.