### PR TITLE
Introduce messages of type success

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>13.7.2</version>
+    <version>13.8</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -78,7 +78,7 @@ public class Message {
     /**
      * Returns the type of the message
      *
-     * @return the type (one of {@link #INFO}, {@link #WARN}, {@link #ERROR})
+     * @return the type (one of {@link #SUCCESS}, {@link #INFO}, {@link #WARN}, {@link #ERROR})
      */
     public String getType() {
         return type;

--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -18,6 +18,11 @@ import sirius.web.security.UserContext;
 public class Message {
 
     /**
+     * Declares a message as success.
+     */
+    public static final String SUCCESS = "alert-success";
+
+    /**
      * Declares a message as information.
      */
     public static final String INFO = "alert-info";
@@ -136,6 +141,16 @@ public class Message {
     @Override
     public String toString() {
         return messageText;
+    }
+
+    /**
+     * Factory method to create a success message
+     *
+     * @param message the message content
+     * @return a new message with the given content and SUCCESS as type
+     */
+    public static Message success(String message) {
+        return new Message(message, null, SUCCESS);
     }
 
     /**


### PR DESCRIPTION
Until now, only info, warn and error messages could be created via the Message class. However, sometimes it is needed to create a success message. To avoid creating these messages manually, this message type is now introduced for the Message class.