### PR TITLE
Forces the 10px width of colorized tables' first column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>14.0</version>
+    <version>14.0.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/assets/wondergem/stylesheets/tables.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/tables.scss
@@ -72,11 +72,13 @@ tfoot {
 
   tr > th:first-child {
     width: 10px;
+    min-width: 10px;
     padding: 0px;
   }
 
   tr > td:first-child {
     width: 10px;
+    min-width: 10px;
     padding: 0px;
   }
 


### PR DESCRIPTION
when there is much content in the other cells, the first cell didn't always get what it deserves 

before:

![image](https://user-images.githubusercontent.com/7695721/37970383-a2fa67ca-31d3-11e8-9d38-7567f1fb7855.png)

after:

![image](https://user-images.githubusercontent.com/7695721/37970405-b038b3d8-31d3-11e8-877f-b923641afb88.png)
