### PR TITLE
Tokenfield: Allow removal of all search tokens at once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>14.2.1</version>
+    <version>14.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>14.2</version>
+    <version>14.2.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -49,8 +49,8 @@
             showSpinner: function () {
                 if (input.spinnerElement) {
                     input.spinnerElement.removeClass("hide");
+                    events.onSpinnerShow();
                 }
-
             },
 
             /**
@@ -59,6 +59,7 @@
             hideSpinner: function () {
                 if (input.spinnerElement) {
                     input.spinnerElement.addClass("hide");
+                    events.onSpinnerHide();
                 }
             },
 
@@ -406,6 +407,8 @@
             onShow: Function(),
             onHide: Function(),
             onSelect: Function(),
+            onSpinnerShow: Function(),
+            onSpinnerHide: Function(),
             beforeLoad: Function(),
 
             /**

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -58,8 +58,7 @@
                     // delete the element value because they are tokens now and the value should not be displayed twice
                     this.tokenElement.val("");
 
-                    // this is needed to display the spinner in the same row as the input field
-                    // the spinner holds the class .fa which defines the size to 14
+                    // this is needed to display the token removal icon in the same row as the input field
                     this.element.css("max-width", input.element.width() - 14);
 
 

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -11,7 +11,7 @@
      *
      * Will handle the two different input fields (the actual one and the one the lib generates).
      *
-     * @@type {{eventNames, on, start, getInput, appendTokens, getInputFieldId, hasTokens}}
+     * @@type {{eventNames, on, start, getInput, appendTokens, getInputFieldId, hasTokens, updateTokenRemovalVisibility, hideTokenRemoval, clearTokens}}
      */
     sirius.tokenfield = (function () {
             var input = {
@@ -29,6 +29,9 @@
 
                 value: "",
                 allTokens: undefined,
+
+                tokenRemovalElement: undefined,
+                tokenRemovalTemplate: '<span class="token-removal hide"><i class="fa fa-times fa-lg"></i></span>',
 
                 /**
                  * Keys of the config object are:
@@ -49,14 +52,24 @@
 
                     this.tokenElement = $("#" + this.id + "-tokenfield");
 
+                    this.tokenRemovalElement = $(input.tokenRemovalTemplate);
+                    this.tokenRemovalElement.insertAfter(this.tokenElement);
+
                     // delete the element value because they are tokens now and the value should not be displayed twice
                     this.tokenElement.val("");
+
+                    // this is needed to display the spinner in the same row as the input field
+                    // the spinner holds the class .fa which defines the size to 14
+                    this.element.css("max-width", input.element.width() - 14);
+
 
                     // create initial tokens
                     input.allTokens = [];
                     $.each(this.value.split(tokenfieldConfig.delimiter), function(index, element) {
                         input.allTokens.push({label: element, value: element, initialQueryIdentifier: true});
                     });
+
+                    input.updateTokenRemovalVisibility();
 
                     this.element.on('tokenfield:removedtoken', function (e) {
                         var identifier = e.attrs.value;
@@ -71,6 +84,7 @@
                             return identifier !== token.value;
                         });
 
+                        input.updateTokenRemovalVisibility();
                         events.onRemovedToken(e);
                     });
 
@@ -80,7 +94,12 @@
                         }
                     });
 
-                    $( window ).resize(function(e) {
+                    this.tokenRemovalElement.click(function () {
+                        input.clearTokens();
+                        input.hideTokenRemoval();
+                    });
+
+                    $(window).resize(function (e) {
                         input.resize(e);
                     });
                 },
@@ -102,11 +121,55 @@
                 appendTokens: function (tokens) {
                     this.allTokens = this.allTokens.concat(tokens);
                     this.element.tokenfield("setTokens", this.allTokens);
+
+                    input.updateTokenRemovalVisibility();
                 },
 
-                resize: function(e){
+                resize: function (e) {
                     events.onResize(e);
-                }
+                },
+
+                /**
+                 * Shows a small token removal icon in the input field.
+                 */
+                showTokenRemoval: function () {
+                    if (input.tokenRemovalElement) {
+                        input.tokenRemovalElement.removeClass("hide");
+                    }
+                },
+
+                /**
+                 * Hides the token removal icon.
+                 */
+                hideTokenRemoval: function () {
+                    if (input.tokenRemovalElement) {
+                        input.tokenRemovalElement.addClass("hide");
+                    }
+                },
+
+                hasTokens: function () {
+                    return input.element.tokenfield('getTokens').length > 0;
+                },
+
+                /**
+                 * Cleares the token field of all entries. Also resets the value.
+                 */
+                clearTokens: function () {
+                    input.element.tokenfield("setTokens", []);
+                    input.value = "";
+                },
+
+                /**
+                 * Hides the token removal icon if there are no tokens left, else the icon is shown.
+                 */
+                updateTokenRemovalVisibility: function () {
+                    if (input.hasTokens()) {
+                        input.showTokenRemoval();
+                    }
+                    else {
+                        input.hideTokenRemoval();
+                    }
+                },
             };
 
             var events = {
@@ -152,16 +215,28 @@
                     return input.tokenElement.prop("id");
                 },
 
-                getInputField: function(){
+                getInputField: function () {
                     return input.element;
                 },
 
-                getTokenfieldInputField: function(){
+                getTokenfieldInputField: function () {
                     return input.tokenElement;
                 },
 
                 hasTokens: function () {
-                    return input.element.tokenfield('getTokens').length > 0;
+                    return input.hasTokens();
+                },
+
+                updateTokenRemovalVisibility: function () {
+                    input.updateTokenRemovalVisibility();
+                },
+
+                hideTokenRemoval: function () {
+                    input.hideTokenRemoval();
+                },
+
+                clearTokens: function () {
+                    input.clearTokens();
                 }
             };
         }


### PR DESCRIPTION
Adds an clickable icon to the input field to allow for easier clearing of the tokens.
Until now tokens could only be cleared one by one.
Adds an onSpinnerHide and an onSpinnerShow event to the autocompleter to be able to prevent two icons at once.
Autoformating of some functions.
![bildschirmfoto 2018-04-04 um 13 57 41](https://user-images.githubusercontent.com/6537252/38306313-76713f10-3810-11e8-9d9c-fdd5b8463220.png)
