### PR TITLE
Event for clearing tokens in the token field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>14.3</version>
+    <version>14.4</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -156,6 +156,7 @@
                 clearTokens: function () {
                     input.element.tokenfield("setTokens", []);
                     input.value = "";
+                    events.onClearTokens();
                 },
 
                 /**
@@ -174,7 +175,8 @@
             var events = {
                 onEnter: Function(),
                 onRemovedToken: Function(),
-                onResize: Function()
+                onResize: Function(),
+                onClearTokens: Function()
             };
 
             return {


### PR DESCRIPTION
Templates using the tokenfield from Sirius Web might have some own handling of tokens. Therefore there also has to be a possibility to get notice of all tokens being cleared. This is now provided via an event.

Tags: tokenfield