### PR TITLE
Always render Spinner and TokenRemovalIcon correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>14.4</version>
+    <version>14.4.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -144,6 +144,7 @@
 
                     // this is needed to display the spinner in the same row as the input field
                     // the spinner holds the class .fa which defines the size to 14
+                    // because jquery width rounds up or down we need to make provisions for these cases using a 2px margin
                     input.element.css("max-width", input.element.width() - 16);
                 }
 
@@ -627,7 +628,7 @@
             /**
              * Hides the suggested completions.
              */
-            hide: function(){
+            hide: function () {
                 completions.hideImmediate();
             }
         };

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -144,7 +144,7 @@
 
                     // this is needed to display the spinner in the same row as the input field
                     // the spinner holds the class .fa which defines the size to 14
-                    input.element.css("max-width", input.element.width() - 14);
+                    input.element.css("max-width", input.element.width() - 16);
                 }
 
                 this.element.keyup(function (event) {

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -59,6 +59,8 @@
                     this.tokenElement.val("");
 
                     // this is needed to display the token removal icon in the same row as the input field
+                    // the spinner holds the class .fa which defines the size to 14
+                    // because jquery width rounds up or down we need to make provisions for these cases using a 2px margin
                     this.element.css("max-width", input.element.width() - 16);
 
 

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -59,7 +59,7 @@
                     this.tokenElement.val("");
 
                     // this is needed to display the token removal icon in the same row as the input field
-                    this.element.css("max-width", input.element.width() - 14);
+                    this.element.css("max-width", input.element.width() - 16);
 
 
                     // create initial tokens


### PR DESCRIPTION
Corrects for a possible rounding error mistake of jquery width() which could cause two rows being displayed when there should only be one.
Version bump to 14.4.1