### PR TITLE
Provides the possibility to overwrite the default error handling respons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.12</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>16.2</version>
+    <version>16.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.12</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>16.1.1</version>
+    <version>16.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/services/RawServiceCall.java
+++ b/src/main/java/sirius/web/services/RawServiceCall.java
@@ -13,6 +13,8 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.xml.StructuredOutput;
 import sirius.web.http.WebContext;
 
+import java.nio.channels.ClosedChannelException;
+
 /**
  * RAW encoder for calls to a {@link sirius.web.services.StructuredService}.
  */
@@ -23,9 +25,16 @@ class RawServiceCall extends ServiceCall {
     }
 
     @Override
-    public boolean handle(Throwable error) {
-        ctx.respondWith().error(HttpResponseStatus.INTERNAL_SERVER_ERROR, Exceptions.handle(error));
-        return true;
+    protected void invoke(StructuredService serv) {
+        try {
+            StructuredOutput output = createOutput();
+            serv.call(this, output);
+        } catch (ClosedChannelException ex) {
+            // If the user unexpectedly closes the connection, we do not need to log an error...
+            Exceptions.ignore(ex);
+        } catch (Exception t) {
+            ctx.respondWith().error(HttpResponseStatus.INTERNAL_SERVER_ERROR, handle(t));
+        }
     }
 
     @Override

--- a/src/main/java/sirius/web/services/RawServiceCall.java
+++ b/src/main/java/sirius/web/services/RawServiceCall.java
@@ -23,8 +23,9 @@ class RawServiceCall extends ServiceCall {
     }
 
     @Override
-    public void handle(String errorCode, Throwable error) {
+    public boolean handle(Throwable error) {
         ctx.respondWith().error(HttpResponseStatus.INTERNAL_SERVER_ERROR, Exceptions.handle(error));
+        return true;
     }
 
     @Override

--- a/src/main/java/sirius/web/services/StructuredService.java
+++ b/src/main/java/sirius/web/services/StructuredService.java
@@ -9,7 +9,6 @@
 package sirius.web.services;
 
 import sirius.kernel.async.CallContext;
-import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.xml.StructuredOutput;
 import sirius.web.ErrorCodeException;
@@ -43,18 +42,12 @@ public interface StructuredService {
      *
      * @param call the HTTP request to process
      * @param out  the encoder used to generate the desired output
-     * @param e    {@link Exception} causing an error while processing the request
+     * @param e    {@link HandledException} which caused an error while processing the request
      */
-    default void callOnError(ServiceCall call, StructuredOutput out, Exception e) {
-        HandledException he = Exceptions.createHandled()
-                .error(e)
-                .withSystemErrorMessage("Service call to '%s' failed: %s (%s)",
-                        call.getContext().getRequestedURI())
-                .handle();
-
+    default void handleException(ServiceCall call, StructuredOutput out, HandledException e) {
         out.beginResult();
         try {
-            call.markCallFailed(out, he.getMessage());
+            call.markCallFailed(out, e.getMessage());
             Throwable cause = e.getCause();
 
             while (cause != null && cause.getCause() != null && !cause.getCause().equals(cause)) {

--- a/src/main/java/sirius/web/services/StructuredService.java
+++ b/src/main/java/sirius/web/services/StructuredService.java
@@ -8,7 +8,11 @@
 
 package sirius.web.services;
 
+import sirius.kernel.async.CallContext;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
 import sirius.kernel.xml.StructuredOutput;
+import sirius.web.ErrorCodeException;
 import sirius.web.controller.Routed;
 
 /**
@@ -33,4 +37,45 @@ public interface StructuredService {
      * @throws Exception in case of an error. An appropriate result will be generated in the selected format.
      */
     void call(ServiceCall call, StructuredOutput out) throws Exception;
+
+    /**
+     * Handles the exception caused by handling the incoming call.
+     *
+     * @param call the HTTP request to process
+     * @param out  the encoder used to generate the desired output
+     * @param e    {@link Exception} causing an error while processing the request
+     */
+    default void callOnError(ServiceCall call, StructuredOutput out, Exception e) {
+        HandledException he = Exceptions.createHandled()
+                .error(e)
+                .withSystemErrorMessage("Service call to '%s' failed: %s (%s)",
+                        call.getContext().getRequestedURI())
+                .handle();
+
+        out.beginResult();
+        try {
+            call.markCallFailed(out, he.getMessage());
+            Throwable cause = e.getCause();
+
+            while (cause != null && cause.getCause() != null && !cause.getCause().equals(cause)) {
+                cause = cause.getCause();
+            }
+
+            if (cause == null) {
+                cause = e;
+            }
+
+            out.property("type", cause.getClass().getName());
+
+            if (e instanceof ErrorCodeException) {
+                out.property("code", ((ErrorCodeException) e).getCode());
+            } else {
+                out.property("code", "ERROR");
+            }
+
+            out.property("flow", CallContext.getCurrent().getMDCValue(CallContext.MDC_FLOW));
+        } finally {
+            out.endResult();
+        }
+    }
 }

--- a/src/test/java/sirius/web/service/DefaultErrorService.java
+++ b/src/test/java/sirius/web/service/DefaultErrorService.java
@@ -1,0 +1,15 @@
+package sirius.web.service;
+
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.xml.StructuredOutput;
+import sirius.web.services.ServiceCall;
+import sirius.web.services.StructuredService;
+
+@Register(name = "test/default-error")
+public class DefaultErrorService implements StructuredService {
+    @Override
+    public void call(ServiceCall call, StructuredOutput out) throws Exception {
+        throw Exceptions.createHandled().withSystemErrorMessage("error error error").handle();
+    }
+}

--- a/src/test/java/sirius/web/service/ServiceErrorSpec.groovy
+++ b/src/test/java/sirius/web/service/ServiceErrorSpec.groovy
@@ -1,0 +1,33 @@
+package sirius.web.service
+
+import io.netty.handler.codec.http.HttpResponseStatus
+import sirius.kernel.BaseSpecification
+import sirius.web.http.TestRequest
+
+class ServiceErrorSpec extends BaseSpecification {
+
+    def "default error service handling"() {
+        when:
+        def result = TestRequest.GET("/service/xml/test/default-error").execute()
+        then:
+        result.getStatus() == HttpResponseStatus.OK
+        and:
+        result.xmlContent().queryValue("error").asBoolean()
+        !result.xmlContent().queryValue("success").asBoolean()
+        and:
+        !result.xmlContent().hasProperty("type")
+    }
+
+    def "special error service handling"() {
+        when:
+        def result = TestRequest.GET("/service/xml/test/special-error").execute()
+        then:
+        result.getStatus() == HttpResponseStatus.OK
+        and:
+        !result.xmlContent().queryValue("error").asBoolean()
+        !result.xmlContent().queryValue("success").asBoolean()
+        and:
+        result.xmlContent().queryValue("type").asString() == "special error service"
+
+    }
+}

--- a/src/test/java/sirius/web/service/SpecialErrorService.java
+++ b/src/test/java/sirius/web/service/SpecialErrorService.java
@@ -1,0 +1,25 @@
+package sirius.web.service;
+
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
+import sirius.kernel.xml.StructuredOutput;
+import sirius.web.services.ServiceCall;
+import sirius.web.services.StructuredService;
+
+@Register(name = "test/special-error")
+public class SpecialErrorService implements StructuredService {
+
+    @Override
+    public void call(ServiceCall call, StructuredOutput out) throws Exception {
+        throw Exceptions.createHandled().withSystemErrorMessage("error error error").handle();
+    }
+
+    @Override
+    public void handleException(ServiceCall call, StructuredOutput out, HandledException e) {
+        out.beginResult();
+        out.property("type", "special error service");
+        out.property("message", e.getMessage());
+        out.endResult();
+    }
+}


### PR DESCRIPTION
In case Services need to create error responses using a specific format (e.g.) soap fault, webu, etc.
we need to be able to overwrite the default error handling.

By default nothing changes, which is why i implemented an interface default method rather then changing the interface to an abstract class.