### PR TITLE
Handle client-side connection-closes better

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.12</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>17.2</version>
+    <version>17.2.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -927,6 +927,7 @@ public class Response {
                 return;
             }
             if (!ctx.channel().isWritable()) {
+                ctx.channel().close();
                 return;
             }
             if (HttpMethod.HEAD.equals(wc.getRequest().method()) || HttpResponseStatus.NOT_MODIFIED.equals(status)) {

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -721,6 +721,7 @@ public class Response {
      * Signals an internal server error if one of the response method fails.
      */
     protected void internalServerError(String debugMessage, Throwable t) {
+        noKeepalive();
         WebServer.LOG.FINE(t);
         if (!(t instanceof ClosedChannelException)) {
             if (t instanceof HandledException) {
@@ -739,9 +740,6 @@ public class Response {
                           .handle();
                 error(HttpResponseStatus.INTERNAL_SERVER_ERROR, Exceptions.handle(WebServer.LOG, t));
             }
-        }
-        if (!ctx.channel().isOpen()) {
-            ctx.channel().close();
         }
     }
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -698,7 +698,7 @@ public class Response {
     }
 
     protected void installChunkedWriteHandler() {
-        if (ctx.channel().pipeline().get(ChunkedWriteHandler.class) == null) {
+        if (ctx.channel().pipeline().get(ChunkedWriteHandler.class) == null && ctx.channel().isOpen()) {
             ctx.channel().pipeline().addBefore("handler", "chunkedWriter", new ChunkedWriteHandler());
         }
     }


### PR DESCRIPTION
When the client closes the connection while we try to respond with assets, the channel is closed, the handlers are removed and we can not add a ChunkedWriteHandler before our default handler "handler"