### PR TITLE
Preserves linebreaks in the EscapeJSMacro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.12</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>17.2.1</version>
+    <version>17.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/macros/EscapeJSMacro.java
+++ b/src/main/java/sirius/tagliatelle/macros/EscapeJSMacro.java
@@ -45,7 +45,11 @@ public class EscapeJSMacro implements Macro {
             return "";
         }
 
-        return value.toString().replaceAll("\\r?\\n", " ").replace("\\", "\\\\").replace("'", "\\'");
+        return value.toString()
+                    .replace("\\", "\\\\")
+                    .replaceAll("\\r", "\\\\r")
+                    .replaceAll("\\n", "\\\\n")
+                    .replace("'", "\\'");
     }
 
     @Override

--- a/src/test/resources/templates/js-template.html
+++ b/src/test/resources/templates/js-template.html
@@ -1,1 +1,1 @@
-var jsVariable = '<a class="link" href="#">Test1234</a>';
+var jsVariable = '<a class="link" href="#">Test\'1234\n        567\\89\\\\\n    </a>';

--- a/src/test/resources/templates/js-template.html.pasta
+++ b/src/test/resources/templates/js-template.html.pasta
@@ -1,3 +1,5 @@
 <w:jsTemplate variableName="jsVariable">
-    <a class="link" href="#">Test1234</a>
+    <a class="link" href="#">Test'1234
+        567\89\\
+    </a>
 </w:jsTemplate>


### PR DESCRIPTION
hab in MIO, OX und Sellsite keine Stelle gefunden, wo `escapeJS` nicht so vorkam: `var x = '@escapeJS(blubb)'`

`<w:jsTemplate>` hatte gar keine Usages