### PR TITLE
Easier item method for Page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.0</version>
+    <version>18.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.1</version>
+    <version>18.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.2</version>
+    <version>18.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -86,12 +86,16 @@ public class Page<E> {
      * the supplied {@link Limit} as this method does also is able to determine whether
      * this page {@link Page#withHasMore(boolean) has more items to show} which are currently
      * not being displayed.
+     * <p>
+     * Using the supplied limit e.g. via {@link Limit#asPredicate()} for slicing the provided list results
+     * in a list of size {@link Page#pageSize} + 1 for easier handling whether there are more elements to
+     * determine if there is another page.
      *
      * @param itemsSupplier the supplier to supply items to the current page limited by the provided limit
      * @return the page itself for fluent method calls
      */
     public Page<E> withLimitedItemsSupplier(Function<Limit, List<E>> itemsSupplier) {
-        Limit supplierLimit = getCurrentLimit();
+        Limit supplierLimit = new Limit(getStart() - 1, getPageSize() + 1);
         List<E> suppliedItems = itemsSupplier.apply(supplierLimit);
         if (suppliedItems.size() > supplierLimit.getMaxItems() - 1) {
             more = true;
@@ -515,19 +519,5 @@ public class Page<E> {
      */
     public int getPageSize() {
         return pageSize;
-    }
-
-    /**
-     * Returns the current set {@link Limit} for this page based on the start set via {@link Page#withStart(int)}
-     * and size of the page set via {@link Page#withPageSize(int)} or their default values if not being set.
-     * <p>
-     * Using this limit e.g. via {@link Limit#asPredicate()} for slicing a list would return a list of size
-     * {@link Page#pageSize} + 1 for easier handling whether there are more elements to determine if there is
-     * another page.
-     *
-     * @return the current set limit for the page
-     */
-    public Limit getCurrentLimit() {
-        return new Limit(getStart() - 1, getPageSize() + 1);
     }
 }

--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -10,6 +10,7 @@ package sirius.web.controller;
 
 import com.google.common.collect.Lists;
 import sirius.kernel.cache.ValueComputer;
+import sirius.kernel.commons.Limit;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.nls.NLS;
@@ -18,6 +19,7 @@ import sirius.web.http.WebContext;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -72,6 +74,30 @@ public class Page<E> {
     public Page<E> withItems(List<E> items) {
         this.items = items;
         return this;
+    }
+
+    /**
+     * Easy method for supplying items the page contains to avoid boiler code.
+     * <p>
+     * The supplier provides the {@link Limit} of the current page for easy iteration
+     * over a result set.
+     * <p>
+     * This method should be supplied with a {@link List} which size was determined by
+     * the supplied {@link Limit} as this method does also is able to determine whether
+     * this page {@link Page#withHasMore(boolean) has more items to show} which are currently
+     * not being displayed.
+     *
+     * @param itemsSupplier the supplier to supply items to the current page limited by the provided limit
+     * @return the page itself for fluent method calls
+     */
+    public Page<E> withLimitedItemsSupplier(Function<Limit, List<E>> itemsSupplier) {
+        Limit supplierLimit = getCurrentLimit();
+        List<E> suppliedItems = itemsSupplier.apply(supplierLimit);
+        if (suppliedItems.size() > supplierLimit.getMaxItems() - 1) {
+            more = true;
+            suppliedItems.remove(suppliedItems.size() - 1);
+        }
+        return withItems(suppliedItems);
     }
 
     /**
@@ -363,9 +389,9 @@ public class Page<E> {
     }
 
     private boolean addQueryToQueryString(String field,
-                                         String value,
-                                         StringBuilder queryStringBuilder,
-                                         Monoflop ampersandPlaced) {
+                                          String value,
+                                          StringBuilder queryStringBuilder,
+                                          Monoflop ampersandPlaced) {
         if (PARAM_QUERY.equals(field)) {
             queryStringBuilder.append(ampersandPlaced.firstCall() ? "" : "&");
             queryStringBuilder.append("query=");
@@ -382,9 +408,9 @@ public class Page<E> {
     }
 
     private boolean addStartToQueryString(String field,
-                                         String value,
-                                         StringBuilder queryStringBuilder,
-                                         Monoflop ampersandPlaced) {
+                                          String value,
+                                          StringBuilder queryStringBuilder,
+                                          Monoflop ampersandPlaced) {
         queryStringBuilder.append(ampersandPlaced.firstCall() ? "" : "&");
         queryStringBuilder.append("start=");
         if (PARAM_START.equals(field)) {
@@ -397,9 +423,9 @@ public class Page<E> {
     }
 
     private boolean createQueryStringForFacets(String field,
-                                              String value,
-                                              StringBuilder queryStringBuilder,
-                                              Monoflop ampersandPlaced) {
+                                               String value,
+                                               StringBuilder queryStringBuilder,
+                                               Monoflop ampersandPlaced) {
         boolean fieldFound = false;
         for (Facet f : getFacets()) {
             if (Strings.areEqual(field, f.getName())) {
@@ -489,5 +515,15 @@ public class Page<E> {
      */
     public int getPageSize() {
         return pageSize;
+    }
+
+    /**
+     * Returns the current set {@link Limit} for this page based on the start set via {@link Page#withStart(int)}
+     * and size of the page set via {@link Page#withPageSize(int)} or their default values if not being set.
+     *
+     * @return the current set limit for the page
+     */
+    public Limit getCurrentLimit() {
+        return new Limit(getStart() - 1, getPageSize() + 1);
     }
 }

--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -95,7 +95,7 @@ public class Page<E> {
         List<E> suppliedItems = itemsSupplier.apply(supplierLimit);
         if (suppliedItems.size() > supplierLimit.getMaxItems() - 1) {
             more = true;
-            suppliedItems.remove(suppliedItems.size() - 1);
+            suppliedItems = suppliedItems.subList(0, supplierLimit.getMaxItems() - 1);
         }
         return withItems(suppliedItems);
     }

--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -520,6 +520,10 @@ public class Page<E> {
     /**
      * Returns the current set {@link Limit} for this page based on the start set via {@link Page#withStart(int)}
      * and size of the page set via {@link Page#withPageSize(int)} or their default values if not being set.
+     * <p>
+     * Using this limit e.g. via {@link Limit#asPredicate()} for slicing a list would return a list of size
+     * {@link Page#pageSize} + 1 for easier handling whether there are more elements to determine if there is
+     * another page.
      *
      * @return the current set limit for the page
      */

--- a/src/test/java/sirius/web/controller/PageSpec.groovy
+++ b/src/test/java/sirius/web/controller/PageSpec.groovy
@@ -65,4 +65,22 @@ class PageSpec extends Specification {
         limitPage.getItems().get(0) == "1"
     }
 
+    def "withLimitedItemsSupplier() with a list smaller than the page size does not crash"() {
+        given:
+        def limitPage = new Page<>().withPageSize(5)
+        def elementsList = new ArrayList()
+        elementsList.add("1")
+        elementsList.add("2")
+        elementsList.add("3")
+        when:
+        limitPage.withLimitedItemsSupplier{limit -> elementsList}
+        then:
+        limitPage.getItems().size() == 3
+        and:
+        limitPage.hasMore() == false
+        and:
+        limitPage.getItems().get(2) == "3"
+        limitPage.getItems().get(0) == "1"
+    }
+
 }

--- a/src/test/java/sirius/web/controller/PageSpec.groovy
+++ b/src/test/java/sirius/web/controller/PageSpec.groovy
@@ -43,4 +43,26 @@ class PageSpec extends Specification {
         return new Facet("", field, value, null)
     }
 
+    def "withLimitedItemsSupplier() removes elements which exceed the page size"() {
+        given:
+        def limitPage = new Page<>().withPageSize(5)
+        def elementsList = new ArrayList()
+        elementsList.add("1")
+        elementsList.add("2")
+        elementsList.add("3")
+        elementsList.add("4")
+        elementsList.add("5")
+        elementsList.add("6")
+        elementsList.add("7")
+        when:
+        limitPage.withLimitedItemsSupplier{limit -> elementsList}
+        then:
+        limitPage.getItems().size() == 5
+        and:
+        limitPage.hasMore() == true
+        and:
+        limitPage.getItems().get(4) == "5"
+        limitPage.getItems().get(0) == "1"
+    }
+
 }


### PR DESCRIPTION
The code in the new Page item method was used many times as boilerplate code. To avoid this the code is now used in the class itself.

Tags: page