### PR TITLE
Adds support so resolving generically overloaded methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.5</version>
+    <version>18.5.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/tagliatelle/expression/MethodCall.java
+++ b/src/main/java/sirius/tagliatelle/expression/MethodCall.java
@@ -228,7 +228,20 @@ public class MethodCall extends Call {
     }
 
     private Method findMethod(Class<?> type, String name, Class<?>[] parameterTypes) throws NoSuchMethodException {
-        for (Method m : type.getMethods()) {
+        // First try a regular lookup without coercing of any kind.
+        // This is reasonable, as this takes generic type parameters
+        // into account and selects the proper method...
+        try {
+            Method m = type.getMethod(name, parameterTypes);
+            if (checkSandbox(m)) {
+                return m;
+            }
+        } catch (NoSuchMethodException e) {
+            Exceptions.ignore(e);
+        }
+
+        // Try to find an appropriate method using coercions known to the system...
+        for (Method m: type.getMethods()) {
             if (signatureMatch(m, name, parameterTypes)) {
                 if (checkSandbox(m)) {
                     return m;

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -10,6 +10,7 @@ package sirius.tagliatelle
 
 import parsii.tokenizer.ParseError
 import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Amount
 import sirius.kernel.commons.Strings
 import sirius.kernel.commons.Value
 import sirius.kernel.di.std.Part

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -72,6 +72,18 @@ class CompilerSpec extends BaseSpecification {
         ctx.getTemplate().renderToString(Value.of("test")) == "test"
     }
 
+    def "method overloading works with generics"() {
+        when:
+        def ctx = new CompilationContext(new Template("test", null), null)
+        List<CompileError> errors = new Compiler(ctx, "<i:arg type=\"sirius.tagliatelle.TestObject\" name=\"test\" />" +
+                "<i:arg type=\"sirius.kernel.commons.Amount\" name=\"test1\" />" +
+                "@test.genericTest(test1)").compile()
+        then:
+        errors.size() == 0
+        and:
+        ctx.getTemplate().renderToString(TestObject.INSTANCE, Amount.TEN) == "-10"
+    }
+
     def "vararg detection works with several parameters"() {
         when:
         def ctx = new CompilationContext(new Template("test", null), null)

--- a/src/test/java/sirius/tagliatelle/GenericTestObject.java
+++ b/src/test/java/sirius/tagliatelle/GenericTestObject.java
@@ -1,0 +1,23 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle;
+
+import sirius.kernel.commons.Amount;
+
+public class GenericTestObject<X> {
+
+    public X genericTest(X input) {
+        return input;
+    }
+
+    public Amount genericTest(Amount x) {
+        return x.times(Amount.MINUS_ONE);
+    }
+
+}

--- a/src/test/java/sirius/tagliatelle/TestObject.java
+++ b/src/test/java/sirius/tagliatelle/TestObject.java
@@ -11,14 +11,13 @@ package sirius.tagliatelle;
 import sirius.kernel.commons.Strings;
 
 /**
- * Used to test vararg methods.
+ * Used to test vararg methods and method overloading with generics
  */
-public class TestObject {
+public class TestObject extends GenericTestObject<String> {
 
     public static final TestObject INSTANCE = new TestObject();
 
     public String varArgTest(String input, Object... params) {
         return Strings.apply(input, params);
     }
-
 }


### PR DESCRIPTION
Using a real "getMethod" call takes generic type parameters
into account and selects the proper one. If this approach fails,
we use our own resolver using coercions etc.