### PR TITLE
Use totalCount for TaskExecution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.6.1</version>
+    <version>18.6.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>11.4</sirius.kernel>
+        <sirius.kernel>11.5</sirius.kernel>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>11.0</sirius.kernel>
+        <sirius.kernel>11.4</sirius.kernel>
     </properties>
 
     <dependencies>

--- a/src/main/java/sirius/web/tasks/ManagedTaskExecution.java
+++ b/src/main/java/sirius/web/tasks/ManagedTaskExecution.java
@@ -209,12 +209,12 @@ class ManagedTaskExecution implements Runnable, ManagedTaskContext, ManagedTask 
         for (Map.Entry<String, Average> e : timings.entrySet()) {
             if (!Doubles.isZero(e.getValue().getAvg())) {
                 result.add(Tuple.create(e.getKey(),
-                                        e.getValue().getCount()
+                                        e.getValue().getTotalCount()
                                         + " ("
                                         + NLS.toUserString(e.getValue().getAvg())
                                         + "ms)"));
             } else {
-                result.add(Tuple.create(e.getKey(), String.valueOf(e.getValue().getCount())));
+                result.add(Tuple.create(e.getKey(), String.valueOf(e.getValue().getTotalCount())));
             }
         }
 

--- a/src/main/java/sirius/web/tasks/ManagedTaskExecution.java
+++ b/src/main/java/sirius/web/tasks/ManagedTaskExecution.java
@@ -209,12 +209,12 @@ class ManagedTaskExecution implements Runnable, ManagedTaskContext, ManagedTask 
         for (Map.Entry<String, Average> e : timings.entrySet()) {
             if (!Doubles.isZero(e.getValue().getAvg())) {
                 result.add(Tuple.create(e.getKey(),
-                                        e.getValue().getTotalCount()
+                                        e.getValue().getCount()
                                         + " ("
                                         + NLS.toUserString(e.getValue().getAvg())
                                         + "ms)"));
             } else {
-                result.add(Tuple.create(e.getKey(), String.valueOf(e.getValue().getTotalCount())));
+                result.add(Tuple.create(e.getKey(), String.valueOf(e.getValue().getCount())));
             }
         }
 


### PR DESCRIPTION
Executed tasks counted the number of processed lines wrong. They relied on the count of the underlying average which was reseted after reaching its max value. Now the average also has a total count which can be used to count processed lines in jobs.

Tags: jobs