### PR TITLE
 Fixes select2 inside modals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.9.2</version>
+    <version>18.9.3</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.9.1</version>
+    <version>18.9.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -126,6 +126,7 @@
         field.select2({
             allowClear: field.data('optional'),
             placeholder: '@i18n("template.html.select2.selection")',
+            dropdownParent: field.parent(),
             minimumInputLength: 0,
             templateResult: function (result) {
                 if (typeof result === 'undefined') {
@@ -187,6 +188,7 @@
             field.select2({
                 allowClear: field.data('optional'),
                 placeholder: '@i18n("template.html.select2.selection")',
+                dropdownParent: field.parent(),
                 minimumResultsForSearch: 10,
                 width: '100%',
                 language: select2Translations,


### PR DESCRIPTION
Default behavior of select2 is to attach the dropdown to the body. But because modals block events on the body, the search field can't be used anymore. Fixes this by attaching the dropdown to the parent of the original select element.