### PR TITLE
Clear tokenfield correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.9.1</version>
+    <version>18.9.2</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -158,6 +158,7 @@
                 clearTokens: function () {
                     input.element.tokenfield("setTokens", []);
                     input.value = "";
+                    input.allTokens = [];
                     events.onClearTokens();
                 },
 


### PR DESCRIPTION
On tokenfield.clearTokens the allTokens array should be cleared as well as it contains all currently set tokens. If not resetted, after adding a token to the tokenfield would lead to the previous tokens plus the added token instead of the added token alone.

Tags: tokenfield