### PR TITLE
Fixes a java.util.MissingFormatArgumentException …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-web</artifactId>
-    <version>18.10</version>
+    <version>18.10.1</version>
     <name>SIRIUS web</name>
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 

--- a/src/main/java/sirius/web/http/WebsocketHandler.java
+++ b/src/main/java/sirius/web/http/WebsocketHandler.java
@@ -45,7 +45,7 @@ public class WebsocketHandler extends ChannelDuplexHandler {
         if (e instanceof SSLHandshakeException || e.getCause() instanceof SSLHandshakeException) {
             SSLWebServerInitializer.LOG.FINE(e);
         } else if (e instanceof ClosedChannelException || e instanceof IOException || e instanceof DecoderException) {
-            WebServer.LOG.FINE("Received an error for a websocket: %s - %s", NLS.toUserString(e));
+            WebServer.LOG.FINE("Received an error for a websocket: %s", NLS.toUserString(e));
         } else {
             Exceptions.handle()
                       .to(WebServer.LOG)


### PR DESCRIPTION
…when handling Exceptions in Websocket connections

Original error:

```
17:39:25.793 WARN  [netty-13|4605ms] io.netty.channel.AbstractChannelHandlerContext - An exception 'java.util.MissingFormatArgumentException: Format specifier '%s'' [enable DEBUG level for full stacktrace] was thrown by a user handler's exceptionCaught() method while handling the following exception:
java.io.IOException: Connection reset by peer
    at...
```