### PR TITLE
Firefox fix for fileuploaderjs

### DIFF
--- a/src/main/resources/default/assets/wondergem/fileupload/fileuploader.js
+++ b/src/main/resources/default/assets/wondergem/fileupload/fileuploader.js
@@ -335,10 +335,11 @@ qq.FileUploaderBasic.prototype = {
                 self._options.onProgress(id, fileName, loaded, total);
             },
             onComplete: function (id, fileName, result) {
-                if (self._filesInProgress <= 1) {
+                self._onComplete(id, fileName, result);
+
+                if (self._filesInProgress === 0) {
                     self._options.onComplete(id, fileName, result);
                 }
-                self._onComplete(id, fileName, result);
             },
             onCancel: function (id, fileName) {
                 self._onCancel(id, fileName);


### PR DESCRIPTION
Corrects onComplete handler in Fileuploader.js, self._onComplete has to be run first or else firefox fires _options.onComplete too soon. Does not change functionality elsewhere