### PR TITLE
Tiny css Fix for sub navs

### DIFF
--- a/src/main/resources/default/assets/wondergem/stylesheets/navs.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/navs.scss
@@ -113,6 +113,7 @@ $navbarLinkBackgroundActive:    darken($navbarLinkBackgroundHover, 5%);
 
 .sub-nav > li > a {
   padding-right: 5px;
+  word-break: break-all;
 }
 
 


### PR DESCRIPTION
Prevents ugly sub navs, where the sub-nav text extends past the menu boundary.