### PR TITLE
Adds SafePost Testrequests with an attached CSRF Token

### DIFF
--- a/src/main/java/sirius/web/http/CSRFHelper.java
+++ b/src/main/java/sirius/web/http/CSRFHelper.java
@@ -27,6 +27,9 @@ public class CSRFHelper {
      */
     public static final String CSRF_TOKEN = "CSRFToken";
 
+    /**
+     * Contains the parameter name of the date at which point the csrf token was last recomputed.
+     */
     public static final String LAST_CSRF_RECOMPUTE = "lastCSRFRecompute";
 
     @ConfigValue("http.csrfTokenLifetime")

--- a/src/main/java/sirius/web/http/CSRFHelper.java
+++ b/src/main/java/sirius/web/http/CSRFHelper.java
@@ -27,7 +27,7 @@ public class CSRFHelper {
      */
     public static final String CSRF_TOKEN = "CSRFToken";
 
-    private static final String LAST_CSRF_RECOMPUTE = "lastCSRFRecompute";
+    public static final String LAST_CSRF_RECOMPUTE = "lastCSRFRecompute";
 
     @ConfigValue("http.csrfTokenLifetime")
     private static Duration csrfTokenLifetime;

--- a/src/test/java/sirius/web/http/CSRFTokenSpec.groovy
+++ b/src/test/java/sirius/web/http/CSRFTokenSpec.groovy
@@ -43,6 +43,13 @@ class CSRFTokenSpec extends BaseSpecification {
         result.getStatus() == HttpResponseStatus.INTERNAL_SERVER_ERROR
     }
 
+    def "safePOST() works correctly if correct token is present via SAFEPOST"() {
+        when:
+        def result = TestRequest.SAFEPOST("/test/fake-delete-data").execute()
+        then:
+        result.getStatus() == HttpResponseStatus.OK
+    }
+
     def "safePOST() works correctly if correct token is present via POST"() {
         given:
         HttpURLConnection c = new URL("http://localhost:9999/test/provide-security-token").openConnection()


### PR DESCRIPTION
Adds a SAFEPOST Request which allows for testing of Requests which require a valid CSRF Token.
Adds a dummy session to the TestRequestClass since a TestRequest itself has no ChannelHandlerContext.
Changes Visibility of LAST_CSRF_RECOMPUTE static string in CSRFHelper.
Adds a CSRFTokenSpec test whether SAFEPOST attaches a valid CSRF Token to the request.