### PR TITLE
Custom id for editForm taglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>12.0-rc9</sirius.kernel>
+        <sirius.kernel>12.0-rc14</sirius.kernel>
     </properties>
 
     <dependencies>

--- a/src/main/resources/default/taglib/w/editForm.html.pasta
+++ b/src/main/resources/default/taglib/w/editForm.html.pasta
@@ -1,10 +1,11 @@
 <i:arg type="String" name="url" />
 <i:arg type="String" name="class" default=""/>
+<i:arg type="String" name="id" default="editForm"/>
 
 <i:pragma name="inline" value="true" />
 <i:pragma name="description" value="Renders an editor form within a Wondergem template" />
 
-<form action="@url" method="post" id="editForm" class="edit-form @class">
+<form action="@url" method="post" id="@id" class="edit-form @class">
     <i:render name="body" />
     <input name="CSRFToken" value="@csrf.getCSRFToken(call)" type="hidden"/>
 </form>

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,1 +1,0 @@
-sirius.customizations = ["customized"]

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -1,3 +1,5 @@
 sirius.frameworks {
     web.test-firewall: true
 }
+
+sirius.customizations = ["customized"]


### PR DESCRIPTION
A custom id can now be defined for the editForm in order to make the taglib usable more than once in a template without id clashes.