### PR TITLE
Cleans up the caching used by AssetsDispatcher.

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -78,13 +78,9 @@ public class AssetsDispatcher implements WebDispatcher {
             return false;
         }
 
-        Tuple<String, Boolean> uriAndCacheFlag = getEffectiveURI(ctx);
+        Tuple<String, Integer> uriAndCacheFlag = getEffectiveURI(ctx);
 
-        Response response = ctx.respondWith();
-        if (uriAndCacheFlag.getSecond()) {
-            response.infinitelyCached();
-        }
-
+        Response response = ctx.respondWith().cachedForSeconds(uriAndCacheFlag.getSecond());
         if (tryStaticResource(ctx, uriAndCacheFlag.getFirst(), response)) {
             return true;
         }
@@ -112,15 +108,19 @@ public class AssetsDispatcher implements WebDispatcher {
         return false;
     }
 
-    private Tuple<String, Boolean> getEffectiveURI(WebContext ctx) {
+    private Tuple<String, Integer> getEffectiveURI(WebContext ctx) {
         String uri = ctx.getRequestedURI();
         if (uri.startsWith("/assets/dynamic")) {
             uri = uri.substring(16);
             Tuple<String, String> pair = Strings.split(uri, "/");
-            return Tuple.create("/assets/" + pair.getSecond(), true);
+            return Tuple.create("/assets/" + pair.getSecond(), Response.HTTP_CACHE_INFINITE);
         }
 
-        return Tuple.create(uri, false);
+        if (uri.startsWith("/assets/no-cache")) {
+            return Tuple.create(uri.substring(16), 0);
+        }
+
+        return Tuple.create(uri, Response.HTTP_CACHE);
     }
 
     private boolean tryTagliatelle(WebContext ctx, String uri, Response response) {

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -55,6 +55,8 @@ import java.util.Optional;
 @Register(classes = {AssetsDispatcher.class, WebDispatcher.class})
 public class AssetsDispatcher implements WebDispatcher {
 
+    private static final String ASSETS_PREFIX = "/assets/";
+
     @ConfigValue("http.generated-directory")
     private String cacheDir;
     private File cacheDirFile;
@@ -96,7 +98,7 @@ public class AssetsDispatcher implements WebDispatcher {
             throws URISyntaxException, IOException {
         Optional<Resource> res = resources.resolve(uri);
         if (res.isPresent()) {
-            ctx.enableTiming("/assets/");
+            ctx.enableTiming(ASSETS_PREFIX);
             URL url = res.get().getUrl();
             if ("file".equals(url.getProtocol())) {
                 response.file(new File(url.toURI()));
@@ -113,11 +115,11 @@ public class AssetsDispatcher implements WebDispatcher {
         if (uri.startsWith("/assets/dynamic")) {
             uri = uri.substring(16);
             Tuple<String, String> pair = Strings.split(uri, "/");
-            return Tuple.create("/assets/" + pair.getSecond(), Response.HTTP_CACHE_INFINITE);
+            return Tuple.create(ASSETS_PREFIX + pair.getSecond(), Response.HTTP_CACHE_INFINITE);
         }
 
         if (uri.startsWith("/assets/no-cache")) {
-            return Tuple.create(uri.substring(16), 0);
+            return Tuple.create(ASSETS_PREFIX + uri.substring(17), 0);
         }
 
         return Tuple.create(uri, Response.HTTP_CACHE);

--- a/src/test/java/sirius/web/dispatch/AssetsDispatcherSpec.groovy
+++ b/src/test/java/sirius/web/dispatch/AssetsDispatcherSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.dispatch
+
+import io.netty.handler.codec.http.HttpHeaderNames
+import sirius.kernel.BaseSpecification
+
+class AssetsDispatcherSpec extends BaseSpecification {
+
+    def "proper caching set for all kind of assets and cache-control URIs"(String uri, String header) {
+        expect:
+        URLConnection c = new URL("http://localhost:9999" + uri).openConnection()
+        c.getHeaderField(HttpHeaderNames.CACHE_CONTROL.toString()) == header
+        where:
+        uri                               | header
+        '/assets/test/test.css'           | 'public, max-age=3600'
+        '/assets/test/test.txt'           | 'public, max-age=3600'
+        '/assets/test/test.js'            | 'public, max-age=3600'
+        '/assets/no-cache/test/test.css'  | 'no-cache, max-age=0'
+        '/assets/no-cache/test/test.txt'  | 'no-cache, max-age=0'
+        '/assets/no-cache/test/test.js'   | 'no-cache, max-age=0'
+        '/assets/dynamic/X/test/test.css' | 'public, max-age=615168000'
+        '/assets/dynamic/X/test/test.txt' | 'public, max-age=615168000'
+        '/assets/dynamic/X/test/test.js'  | 'public, max-age=615168000'
+    }
+
+}

--- a/src/test/resources/assets/test/test.js.pasta
+++ b/src/test/resources/assets/test/test.js.pasta
@@ -1,0 +1,1 @@
+@call.getDynamicAssetToken()

--- a/src/test/resources/assets/test/test.scss
+++ b/src/test/resources/assets/test/test.scss
@@ -1,0 +1,3 @@
+a {
+  color: white;
+}

--- a/src/test/resources/assets/test/test.txt
+++ b/src/test/resources/assets/test/test.txt
@@ -1,0 +1,1 @@
+Text file


### PR DESCRIPTION
Currently invoking the dispatcher without any settings, should have applied a no-cache header.
This failed whenever we delivered a file (scss / static file) as this applied a cache setting by itself.

Also it turned out to be quite a bad decision not to cache assets at all.

We now apply the following policy:
- plain URLs (/assets/....) are cached for 1h by default
- dynamic urls (/assets/dynamic/TOKEN/...) are cached FOREVER
  as the token will chance with the next patch / release
- /assets/no-cache/... will not be cached at all.