### PR TITLE
Recompute CSRF tokens in advance

### DIFF
--- a/src/main/java/sirius/web/http/CSRFHelper.java
+++ b/src/main/java/sirius/web/http/CSRFHelper.java
@@ -35,9 +35,6 @@ public class CSRFHelper {
     @ConfigValue("http.csrfTokenLifetime")
     private static Duration csrfTokenLifetime;
 
-    @ConfigValue("http.csrfTokenAutoRenew")
-    private static Duration csrfTokenAutoRenew;
-
     /**
      * Returns the CSRF security-token of the current session. Internally recomputes the token if outdated.
      *
@@ -45,25 +42,9 @@ public class CSRFHelper {
      * @return the CSRF security-token to protect sensitive links.
      */
     public String getCSRFToken(WebContext ctx) {
-        return getCSRFToken(ctx, true);
-    }
-
-    /**
-     * Returns the CSRF security-token of the current session. Internally recomputes the token if outdated.
-     * <p>
-     * In checks, the parameter autoRenew should be set to false as autoRenew uses {@link CSRFHelper#csrfTokenAutoRenew} which
-     * might be earlier than the {@link CSRFHelper#csrfTokenLifetime real lifetime} of the token. If autoRenew
-     * is set to true the tokens are renewed after the set time to avoid the token expiring while
-     * staying on one site. Therefore the token is renewed in advance
-     *
-     * @param ctx       the request to read the token from
-     * @param autoRenew whether the token should be recomputed in advance
-     * @return the CSRF security-token to protect sensitive links.
-     */
-    public String getCSRFToken(WebContext ctx, boolean autoRenew) {
         Value lastCSRFRecompute = ctx.getSessionValue(LAST_CSRF_RECOMPUTE);
 
-        if (isCSRFTokenOutdated(lastCSRFRecompute.asLong(-1L), autoRenew)) {
+        if (isCSRFTokenOutdated(lastCSRFRecompute.asLong(-1L))) {
             ctx.setSessionValue(CSRF_TOKEN, UUID.randomUUID().toString());
             ctx.setSessionValue(LAST_CSRF_RECOMPUTE, Value.of(Instant.now().toEpochMilli()).asString());
         }
@@ -71,15 +52,8 @@ public class CSRFHelper {
         return ctx.getSessionValue(CSRF_TOKEN).asString();
     }
 
-    private boolean isCSRFTokenOutdated(long lastCSRFRecompute, boolean autoRenew) {
-        return Duration.between(Instant.ofEpochMilli(lastCSRFRecompute), Instant.now()).toMinutes() > getTokenLifetime(
-                autoRenew);
-    }
-
-    private long getTokenLifetime(boolean autoRenew) {
-        if (autoRenew) {
-            return csrfTokenAutoRenew.toMinutes();
-        }
-        return csrfTokenLifetime.toMinutes();
+    private boolean isCSRFTokenOutdated(long lastCSRFRecompute) {
+        return Duration.between(Instant.ofEpochMilli(lastCSRFRecompute), Instant.now()).compareTo(csrfTokenLifetime)
+               > 0;
     }
 }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1614,7 +1614,7 @@ public class WebContext implements SubContext {
 
     private boolean checkCSRFToken() {
         String requestToken = this.get(CSRFHelper.CSRF_TOKEN).asString();
-        String sessionToken = csrfHelper.getCSRFToken(this);
+        String sessionToken = csrfHelper.getCSRFToken(this, false);
 
         return Strings.isFilled(requestToken) && Strings.areEqual(requestToken, sessionToken);
     }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1614,7 +1614,7 @@ public class WebContext implements SubContext {
 
     private boolean checkCSRFToken() {
         String requestToken = this.get(CSRFHelper.CSRF_TOKEN).asString();
-        String sessionToken = csrfHelper.getCSRFToken(this, false);
+        String sessionToken = getSessionValue(CSRFHelper.CSRF_TOKEN).asString();
 
         return Strings.isFilled(requestToken) && Strings.areEqual(requestToken, sessionToken);
     }

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -101,10 +101,6 @@ http {
     # Specifies the lifetime of CSRF security tokens in a user session before being recomputed.
     csrfTokenLifetime = 24 hours
 
-    # Specifies the lifetime of CSRF security tokens in a user session before being recomputed
-    # in advance to avoid the token's being expired while staying on one page.
-    csrfTokenAutoRenew = 23 hour
-
     # Should a default crossdomain.xml be served?
     crossdomain.xml.enabled = true
 

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -101,6 +101,10 @@ http {
     # Specifies the lifetime of CSRF security tokens in a user session before being recomputed.
     csrfTokenLifetime = 24 hours
 
+    # Specifies the lifetime of CSRF security tokens in a user session before being recomputed
+    # in advance to avoid the token's being expired while staying on one page.
+    csrfTokenAutoRenew = 23 hour
+
     # Should a default crossdomain.xml be served?
     crossdomain.xml.enabled = true
 


### PR DESCRIPTION
Currently the CSRF tokens can expire by staying on a page for a few minutes in the time window they expire. A request in this scenario would submit an expired CSRF token which can cause errors. Therefore CSRF tokens will now be recomputed in advance to avoid them expiring while staying a few minutes on a site.

Tags: csrf