### PR TITLE
Proper cleanup of locals after for-loop

### DIFF
--- a/src/main/java/sirius/tagliatelle/compiler/CompilationContext.java
+++ b/src/main/java/sirius/tagliatelle/compiler/CompilationContext.java
@@ -190,6 +190,24 @@ public class CompilationContext {
     }
 
     /**
+     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided.
+     * <p>
+     * Note that this will only reduce the visibility of the variables but not free up the technical stack location. We
+     * only used each stack location once, to greatly simplify inlining.
+     *
+     * @param position the position which caused the popUntil - mainly used for error reporting
+     */
+    public void popUntil(Position position, int localIndex) {
+        if (!stack.isEmpty()) {
+            while (!stack.isEmpty() && stack.get(stack.size() - 1).stackIndex >= localIndex) {
+                stack.remove(stack.size() - 1);
+            }
+        } else {
+            error(position, "Cannot pop from empty stack");
+        }
+    }
+
+    /**
      * Returns the maximum stack depth required when rendering this template.
      *
      * @return the maximal required stack depth to render this template

--- a/src/main/java/sirius/tagliatelle/compiler/ForHandler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/ForHandler.java
@@ -48,7 +48,7 @@ public class ForHandler extends ExpressionHandler {
         compiler.consumeExpectedCharacter('{');
         result.setLocalIndex(compiler.getContext().push(result.getStartOfBlock(), variable, type));
         result.setLoop(compiler.parseBlock(null, "}"));
-        compiler.getContext().pop(compiler.getReader().current());
+        compiler.getContext().popUntil(compiler.getReader().current(), result.getLocalIndex());
         compiler.consumeExpectedCharacter('}');
 
         result.verify(compiler.getContext());

--- a/src/main/java/sirius/tagliatelle/tags/ForTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/ForTag.java
@@ -91,7 +91,7 @@ public class ForTag extends TagHandler {
         result.setLoopStateIndex(loopStateIndex);
         result.verify(getCompilationContext());
         targetBlock.addChild(result);
-        getCompilationContext().pop(getStartOfTag());
+        getCompilationContext().popUntil(getStartOfTag(), localIndex);
     }
 
     @Override

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -302,4 +302,18 @@ class CompilerSpec extends BaseSpecification {
         then:
         basicallyEqual(result, expectedResult)
     }
+
+    def "locals within loops cleanup works"(){
+        given:
+        List<String> list = ["a", "b", "c"]
+        String expectedResult = resources.resolve("templates/local-scope.html").get().getContentAsString()
+        when:
+        def ctx = new CompilationContext(new Template("test", null), null)
+        List<CompileError> errors = new Compiler(ctx, tagliatelle.resolve("templates/local-scope.html.pasta")
+                                                                 .get().getResource().getContentAsString()).compile()
+        then:
+        errors.size() == 0
+        and:
+        basicallyEqual(ctx.getTemplate().renderToString(list), expectedResult)
+    }
 }

--- a/src/test/resources/templates/local-scope.html
+++ b/src/test/resources/templates/local-scope.html
@@ -1,0 +1,12 @@
+a
+b
+c
+a
+b
+c
+a
+b
+c
+a
+b
+c

--- a/src/test/resources/templates/local-scope.html.pasta
+++ b/src/test/resources/templates/local-scope.html.pasta
@@ -1,0 +1,19 @@
+<i:arg type="List" name="iter"/>
+
+<i:for type="String" var="el" items="iter">
+    <i:local name="test" value="5"/>
+   @el
+</i:for>
+
+<i:for type="String" var="el" items="iter">
+    @el
+</i:for>
+
+@for(String el : iter) {
+    <i:local name="test" value="5"/>
+    @el
+}
+
+@for(String el : iter) {
+    @el
+}


### PR DESCRIPTION
This commit changes the cleanup of local variables after a for-loop using the for-handler ('@for') or for-tag('<i:for>').
The problem was, that only the last element was popped of the stack, which only works if the loop just introduced the
loop variable but no additional local variables using '<i:local>'.