### PR TITLE
Properly detect if a session was modified

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -713,13 +713,20 @@ public class WebContext implements SubContext {
         if (session == null) {
             initSession();
         }
+
         if (value == null) {
             String previous = session.remove(key);
-            sessionModified = Strings.isFilled(previous);
+
+            if (Strings.isFilled(previous)) {
+                sessionModified = true;
+            }
         } else {
             String newValue = NLS.toMachineString(value);
             String previous = session.put(key, newValue);
-            sessionModified = !Objects.equals(previous, newValue);
+
+            if (!Objects.equals(previous, newValue)) {
+                sessionModified = true;
+            }
         }
     }
 

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -228,4 +228,12 @@ public class TestController implements Controller {
             out.property("test", "1");
         });
     }
+
+    @Routed("/test/session-test")
+    public void sessionTest(WebContext ctx) {
+        ctx.setSessionValue("test1", "test");
+        ctx.setSessionValue("test2", null);
+
+        ctx.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
 }

--- a/src/test/java/sirius/web/http/WebContextSpec.groovy
+++ b/src/test/java/sirius/web/http/WebContextSpec.groovy
@@ -79,4 +79,16 @@ class WebContextSpec extends BaseSpecification {
         "xx, de;q=0.5, en-gb;q=0.7" | "en"
     }
 
+    def "setSessionValue works as expected"() {
+        when:
+        HttpURLConnection c = new URL("http://localhost:9999/test/session-test").openConnection()
+        c.setRequestMethod("GET")
+        c.connect()
+        then:
+        c.getResponseCode() == 200
+        and:
+        c.getHeaderFields().get("set-cookie").get(0).contains("test1=test")
+        and:
+        !c.getHeaderFields().get("set-cookie").get(0).contains("test2=")
+    }
 }

--- a/src/test/java/sirius/web/http/WebContextSpec.groovy
+++ b/src/test/java/sirius/web/http/WebContextSpec.groovy
@@ -87,8 +87,8 @@ class WebContextSpec extends BaseSpecification {
         then:
         c.getResponseCode() == 200
         and:
-        c.getHeaderFields().get("set-cookie").get(0).contains("test1=test")
+        c.getHeaderFields().get(HttpHeaderNames.SET_COOKIE).get(0).contains("test1=test")
         and:
-        !c.getHeaderFields().get("set-cookie").get(0).contains("test2=")
+        !c.getHeaderFields().get(HttpHeaderNames.SET_COOKIE).get(0).contains("test2=")
     }
 }

--- a/src/test/java/sirius/web/http/WebContextSpec.groovy
+++ b/src/test/java/sirius/web/http/WebContextSpec.groovy
@@ -87,8 +87,8 @@ class WebContextSpec extends BaseSpecification {
         then:
         c.getResponseCode() == 200
         and:
-        c.getHeaderFields().get(HttpHeaderNames.SET_COOKIE).get(0).contains("test1=test")
+        c.getHeaderFields().get(HttpHeaderNames.SET_COOKIE.toString()).get(0).contains("test1=test")
         and:
-        !c.getHeaderFields().get(HttpHeaderNames.SET_COOKIE).get(0).contains("test2=")
+        !c.getHeaderFields().get(HttpHeaderNames.SET_COOKIE.toString()).get(0).contains("test2=")
     }
 }


### PR DESCRIPTION
When setting a session value and determining if this modified the session, we ignored if other values already modified it. This especially happens when setting a value to null that already was null.