### PR TITLE
Proper cleanup of locals after if-else blocks

### DIFF
--- a/src/main/java/sirius/tagliatelle/compiler/CompilationContext.java
+++ b/src/main/java/sirius/tagliatelle/compiler/CompilationContext.java
@@ -190,9 +190,7 @@ public class CompilationContext {
     }
 
     /**
-     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided. In
-     * contrast to {@link #popUntil(Position, int)} this method does generate a {@link ParseError} when the stack
-     * is already empty.
+     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided.
      * <p>
      * Note that this will only reduce the visibility of the variables but not free up the technical stack location. We
      * only used each stack location once, to greatly simplify inlining.
@@ -206,22 +204,6 @@ public class CompilationContext {
             }
         } else {
             error(position, "Cannot pop from empty stack");
-        }
-    }
-
-    /**
-     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided. In
-     * contrast to {@link #popUntil(Position, int)} this method does not generate a {@link ParseError} when the stack
-     * is already empty.
-     * <p>
-     * Note that this will only reduce the visibility of the variables but not free up the technical stack location. We
-     * only used each stack location once, to greatly simplify inlining.
-     *
-     * @param position the position which caused the popUntil - mainly used for error reporting
-     */
-    public void tryPopUntil(Position position, int localIndex) {
-        while (!stack.isEmpty() && stack.get(stack.size() - 1).stackIndex >= localIndex) {
-            stack.remove(stack.size() - 1);
         }
     }
 

--- a/src/main/java/sirius/tagliatelle/compiler/CompilationContext.java
+++ b/src/main/java/sirius/tagliatelle/compiler/CompilationContext.java
@@ -190,7 +190,9 @@ public class CompilationContext {
     }
 
     /**
-     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided.
+     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided. In
+     * contrast to {@link #popUntil(Position, int)} this method does generate a {@link ParseError} when the stack
+     * is already empty.
      * <p>
      * Note that this will only reduce the visibility of the variables but not free up the technical stack location. We
      * only used each stack location once, to greatly simplify inlining.
@@ -204,6 +206,22 @@ public class CompilationContext {
             }
         } else {
             error(position, "Cannot pop from empty stack");
+        }
+    }
+
+    /**
+     * Pops locals off the stack as long as their <tt>stackIndex</tt> is greater or equal than the one provided. In
+     * contrast to {@link #popUntil(Position, int)} this method does not generate a {@link ParseError} when the stack
+     * is already empty.
+     * <p>
+     * Note that this will only reduce the visibility of the variables but not free up the technical stack location. We
+     * only used each stack location once, to greatly simplify inlining.
+     *
+     * @param position the position which caused the popUntil - mainly used for error reporting
+     */
+    public void tryPopUntil(Position position, int localIndex) {
+        while (!stack.isEmpty() && stack.get(stack.size() - 1).stackIndex >= localIndex) {
+            stack.remove(stack.size() - 1);
         }
     }
 

--- a/src/main/java/sirius/tagliatelle/emitter/ConditionalEmitter.java
+++ b/src/main/java/sirius/tagliatelle/emitter/ConditionalEmitter.java
@@ -29,6 +29,7 @@ public class ConditionalEmitter extends Emitter {
     protected Expression conditionExpression;
     protected Emitter whenTrue = ConstantEmitter.EMPTY;
     protected Emitter whenFalse = ConstantEmitter.EMPTY;
+    private int localIndex;
 
     /**
      * Creates a new emitter for the given position.
@@ -80,6 +81,27 @@ public class ConditionalEmitter extends Emitter {
         if (whenFalse != null) {
             this.whenFalse = whenFalse;
         }
+    }
+
+    /**
+     * Contains the stack index being written to.
+     *
+     * @return the target index to write to
+     */
+    public int getLocalIndex() {
+        return localIndex;
+    }
+
+    /**
+     * Updates the stack index being written to.
+     * <p>
+     * When inlining a template, the stack has to be transferred to the callee and therefore the
+     * stack indices might change.
+     *
+     * @param localIndex the new stack index to use
+     */
+    public void setLocalIndex(int localIndex) {
+        this.localIndex = localIndex;
     }
 
     @Override

--- a/src/main/java/sirius/tagliatelle/tags/ElseTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/ElseTag.java
@@ -51,9 +51,17 @@ public class ElseTag extends TagHandler {
     }
 
     @Override
+    public void beforeBody() {
+        if (!checkParentHandler()) {
+            return;
+        }
+
+        ((IfTag) getParentHandler()).clearLocalsFromStack();
+    }
+
+    @Override
     public void apply(CompositeEmitter targetBlock) {
-        if (!(getParentHandler() instanceof IfTag)) {
-            getCompilationContext().error(getStartOfTag(), "i:else must be defined within i:if!");
+        if (!checkParentHandler()) {
             return;
         }
 
@@ -61,5 +69,14 @@ public class ElseTag extends TagHandler {
         if (body != null) {
             getParentHandler().addBlock("else", body);
         }
+    }
+
+    private boolean checkParentHandler() {
+        if (!(getParentHandler() instanceof IfTag)) {
+            getCompilationContext().error(getStartOfTag(), "i:else must be defined within i:if!");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/sirius/tagliatelle/tags/ElseTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/ElseTag.java
@@ -22,6 +22,8 @@ import java.util.List;
  */
 public class ElseTag extends TagHandler {
 
+    private static final String EMPTY_STRING = "";
+
     /**
      * Creates new tags of the given type (name).
      */
@@ -50,6 +52,8 @@ public class ElseTag extends TagHandler {
         }
     }
 
+    private int localIndex;
+
     @Override
     public void beforeBody() {
         if (!checkParentHandler()) {
@@ -57,6 +61,7 @@ public class ElseTag extends TagHandler {
         }
 
         ((IfTag) getParentHandler()).clearLocalsFromStack();
+        localIndex = getCompilationContext().push(getStartOfTag(), EMPTY_STRING, String.class);
     }
 
     @Override
@@ -69,6 +74,8 @@ public class ElseTag extends TagHandler {
         if (body != null) {
             getParentHandler().addBlock("else", body);
         }
+
+        getCompilationContext().popUntil(getStartOfTag(), localIndex);
     }
 
     private boolean checkParentHandler() {

--- a/src/main/java/sirius/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/IfTag.java
@@ -22,6 +22,8 @@ import java.util.List;
  */
 public class IfTag extends TagHandler {
 
+    private static final String EMPTY_STRING = "";
+
     /**
      * Creates new tags of the given type (name).
      */
@@ -53,6 +55,13 @@ public class IfTag extends TagHandler {
         }
     }
 
+    private int localIndex;
+
+    @Override
+    public void beforeBody() {
+        localIndex = getCompilationContext().push(getStartOfTag(), EMPTY_STRING, String.class);
+    }
+
     @Override
     public void apply(CompositeEmitter targetBlock) {
         ConditionalEmitter result = new ConditionalEmitter(getStartOfTag());
@@ -60,6 +69,7 @@ public class IfTag extends TagHandler {
         result.setWhenTrue(getBlock("body"));
         result.setWhenFalse(getBlock("else"));
         targetBlock.addChild(result);
+        getCompilationContext().tryPopUntil(getStartOfTag(), localIndex);
     }
 
     @Override
@@ -69,5 +79,13 @@ public class IfTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    /**
+     * Clears all local variables created by this if-tag from the stack. This is mainly needed, as <i:if></i:if>
+     * can contain a <i:else></i:else> and we have to clear the locals before entering the else-block.
+     */
+    public void clearLocalsFromStack() {
+        getCompilationContext().popUntil(getStartOfTag(), localIndex);
     }
 }

--- a/src/main/java/sirius/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/IfTag.java
@@ -69,6 +69,7 @@ public class IfTag extends TagHandler {
         result.setWhenTrue(getBlock("body"));
         result.setWhenFalse(getBlock("else"));
         targetBlock.addChild(result);
+        // these might have already been popped of the stack if a <i:else> is present
         getCompilationContext().tryPopUntil(getStartOfTag(), localIndex);
     }
 

--- a/src/main/java/sirius/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/IfTag.java
@@ -69,8 +69,10 @@ public class IfTag extends TagHandler {
         result.setWhenTrue(getBlock("body"));
         result.setWhenFalse(getBlock("else"));
         targetBlock.addChild(result);
-        // these might have already been popped of the stack if a <i:else> is present
-        getCompilationContext().tryPopUntil(getStartOfTag(), localIndex);
+        if (getBlock("else") == null) {
+            // if a else-block is present, the corresponding handler already popped the locals off the stack
+            getCompilationContext().popUntil(getStartOfTag(), localIndex);
+        }
     }
 
     @Override

--- a/src/test/java/sirius/tagliatelle/LocalScopeSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/LocalScopeSpec.groovy
@@ -1,0 +1,164 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle
+
+import parsii.tokenizer.ParseError
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+import sirius.tagliatelle.compiler.CompilationContext
+import sirius.tagliatelle.compiler.CompileError
+import sirius.tagliatelle.compiler.CompileException
+import sirius.tagliatelle.compiler.Compiler
+import sirius.web.resources.Resources
+
+class LocalScopeSpec extends BaseSpecification{
+
+    @Part
+    private static Tagliatelle tagliatelle
+
+    @Part
+    private static Resources resources
+
+    @Part
+    private static TestHelper test
+
+    def "locals within loops cleanup works"() {
+        given:
+        List<String> list = ["a", "b", "c"]
+        String expectedResult = resources.resolve("templates/local-scope.html").get().getContentAsString()
+        when:
+        def ctx = new CompilationContext(new Template("test", null), null)
+        List<CompileError> errors = new Compiler(ctx, tagliatelle.resolve("templates/local-scope.html.pasta")
+                                                                 .get().getResource().getContentAsString()).compile()
+        then:
+        errors.size() == 0
+        and:
+        test.basicallyEqual(ctx.getTemplate().renderToString(list), expectedResult)
+    }
+
+    def "failing access out of scope for loops works"() {
+        given:
+        List<String> list = ["a", "b", "c"]
+        List<CompileError> errors
+        when:
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, tagliatelle.resolve("templates/out-of-scope.html.pasta")
+                                         .get().getResource().getContentAsString()).compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 4
+        errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(0).toString().contains("Unknown variable test")
+        errors.get(1).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(1).toString().contains("Unknown variable el")
+        errors.get(2).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(2).toString().contains("Unknown variable test")
+        errors.get(3).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(3).toString().contains("Unknown variable el")
+    }
+
+    def "failing access out of scope for if works"(){
+        when:
+        List<CompileError> errors
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, "<i:if test=\"1 == 1\"><i:local name=\"test\" value=\"1\"/></i:if>@test " +
+                    "@if(1 == 1){<i:local name=\"test\" value=\"1\"/>} @test").compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 2
+        errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(0).toString().contains("Unknown variable test")
+        errors.get(1).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(1).toString().contains("Unknown variable test")
+    }
+
+    def "failing access out of scope for else works"(){
+        when:
+        List<CompileError> errors
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, "<i:if test=\"1 == 1\"><i:else><i:local name=\"test\" value=\"1\"/></i:else></i:if>@test").compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 1
+        errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(0).toString().contains("Unknown variable test")
+    }
+
+    def "failing access out of scope for render works"(){
+        when:
+        List<CompileError> errors
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, "<e:scope>@outer</e:scope>").compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 1
+        errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(0).toString().contains("Unknown variable outer")
+    }
+
+    def "failing access out of scope for invoke works"(){
+        when:
+        List<CompileError> errors
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, "<i:invoke template=\"/templates/invoke-scope.html.pasta\"/>@invokeLocal").compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 1
+        errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(0).toString().contains("Unknown variable invokeLocal")
+    }
+
+    def "failing access out of scope for include works"(){
+        when:
+        List<CompileError> errors
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, "<i:include name=\"/templates/invoke-scope.html.pasta\"/>@invokeLocal").compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 2
+        errors.get(1).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(1).toString().contains("Unknown variable invokeLocal")
+    }
+
+    def "failing access out of scope for if/else works"(){
+        when:
+        List<CompileError> errors
+        try {
+            def ctx = new CompilationContext(new Template("test", null), null)
+            new Compiler(ctx, "<i:if test=\"1 == 1\"><i:local name=\"test\" value=\"1\"/><i:else>@test</i:else></i:if>" +
+                    "@if (\"1 == 1\"){<i:local name=\"test\" value=\"1\"/>}else{@test}").compile()
+        } catch (CompileException err) {
+            errors = err.getErrors()
+        }
+        then:
+        errors.size() == 2
+        errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(0).toString().contains("Unknown variable test")
+        errors.get(1).getError().getSeverity() == ParseError.Severity.ERROR
+        errors.get(1).toString().contains("Unknown variable test")
+    }
+}

--- a/src/test/java/sirius/tagliatelle/TestHelper.java
+++ b/src/test/java/sirius/tagliatelle/TestHelper.java
@@ -1,0 +1,19 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle;
+
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Register;
+
+@Register(classes = TestHelper.class)
+public class TestHelper {
+    public boolean basicallyEqual(String left, String right) {
+        return Strings.areEqual(left.replaceAll("\\s", ""), right.replaceAll("\\s", ""));
+    }
+}

--- a/src/test/resources/taglib/e/scope.html.pasta
+++ b/src/test/resources/taglib/e/scope.html.pasta
@@ -1,0 +1,3 @@
+<i:local name="outer" value="1"/>
+test
+<i:render name="body"/>

--- a/src/test/resources/templates/invoke-scope.html.pasta
+++ b/src/test/resources/templates/invoke-scope.html.pasta
@@ -1,0 +1,1 @@
+<i:local name="invokeLocal" value="1"/>


### PR DESCRIPTION
This commit changes the cleanup of local variables after a if-else using the if-handler ('@if') or if-tag('<i:if>').
The problem was, no elements were popped of the stack, when leaving such a block.