### PR TITLE
Makes adding data to the CrunchlogKernel thread-safe

### DIFF
--- a/src/main/java/sirius/web/crunchlog/CrunchlogKernel.java
+++ b/src/main/java/sirius/web/crunchlog/CrunchlogKernel.java
@@ -10,7 +10,6 @@ package sirius.web.crunchlog;
 
 import com.alibaba.fastjson.JSON;
 import com.google.common.base.Charsets;
-import com.google.common.collect.Queues;
 import com.google.common.hash.Hashing;
 import sirius.kernel.Stoppable;
 import sirius.kernel.async.BackgroundLoop;
@@ -39,6 +38,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -73,7 +73,7 @@ public class CrunchlogKernel extends BackgroundLoop implements Command, Stoppabl
     private static final int MAX_FILE_SIZE = 1024 * 1024 * 10;
     private static final int MAX_BUFFERED_LINES = 16 * 1024;
 
-    protected Queue<Context> buffer = Queues.newArrayDeque();
+    protected Queue<Context> buffer = new ArrayBlockingQueue<>(MAX_BUFFERED_LINES);
 
     @ConfigValue("crunchlog.basedir")
     private String baseDirName;

--- a/src/test/java/sirius/web/crunchlog/CrunchlogKernelTest.groovy
+++ b/src/test/java/sirius/web/crunchlog/CrunchlogKernelTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.crunchlog
+
+import sirius.kernel.commons.Context
+import spock.lang.Specification
+
+class CrunchlogKernelTest extends Specification {
+
+    def "test threadsafeness"() {
+        when:
+        CrunchlogKernel kernel = new CrunchlogKernel()
+        Thread[] threads = new Thread[8]
+        for (int i = 0; i < 8; i++) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                void run() {
+                    for (int j = 0; j < 2000; j++) {
+                        kernel.addToBuffer(Context.create().set("id", i + "-" + j));
+                    }
+                }
+            })
+            thread.start()
+            threads[i] = thread
+        }
+        for (int i = 0; i < 8; i++) {
+            threads[i].join()
+        }
+        then:
+        kernel.buffer.size() == 16_000
+    }
+
+}


### PR DESCRIPTION
We are missing Crunchlog-Entries in OX and hope this solves this (OX-4451)