### PR TITLE
Sets Header 'Vary: origin' when using automatic CORS handling

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -257,7 +257,8 @@ public class Response {
         if (!WebContext.corsAllowAll || response.headers().contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)) {
             return;
         }
-
+        
+        response.headers().set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
         String requestedOrigin = wc.getHeader(HttpHeaderNames.ORIGIN);
         if (Strings.isFilled(requestedOrigin)) {
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, requestedOrigin);


### PR DESCRIPTION
To let caches know when they have to re-retrieve a resource.

Example:

**Without vary: origin**

Browser Request Resource 1 with Header 'origin: a'
Response has 'access-control-allow-origin: a' and Browser caches this response.
Browser Request Resource 1 with Header 'origin: b'
Browser takes Response from cache and wont display the resource, since it still has  'access-control-allow-origin: a'.

**With vary: origin**
Browser Request Resource 1 with Header 'origin: a'
Browser sends Request to Server
Response has 'access-control-allow-origin: a' and Browser caches this response for origin a.
Browser Request Resource 1 with Header 'origin: b'
Browser sees response in cache has 'vary: origin' and was requested with another origin, so won't use it
Browser sends Request to Server
Response has 'access-control-allow-origin: b' and caches this response for origin b.


More Info can be found here:
https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches
https://stackoverflow.com/a/25329887/1638390