### PR TITLE
Fix singleSelect on IE

### DIFF
--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -134,9 +134,7 @@
 
         field.select2({
             allowClear: field.data('optional'),
-            ___if(!call.getUserAgent().isInternetExplorer()) {
-                placeholder: '@i18n("template.html.select2.selection")',
-            }
+            placeholder: '@i18n("template.html.select2.selection")',
             dropdownParent: field.parent(),
             minimumInputLength: 0,
             tags: field.data('dynamic-option'),
@@ -199,9 +197,7 @@
 
             field.select2({
                 allowClear: field.data('optional'),
-                ___if(!call.getUserAgent().isInternetExplorer()) {
-                    placeholder: '@i18n("template.html.select2.selection")',
-                }
+                placeholder: '@i18n("template.html.select2.selection")',
                 dropdownParent: field.parent(),
                 tags: field.data('dynamic-option'),
                 minimumResultsForSearch: 10,


### PR DESCRIPTION
On IE for wondergem singleSelects the selected item could not be deleted. This commit should fix the misbehaviour. The placeholder should only be disabled for autocompletes, not for normal selects.

Tags: IE, select2