### PR TITLE
Does not preserve the TestRequest's DispatcherPipeline between multip…

### DIFF
--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -67,7 +67,7 @@ public class TestRequest extends WebContext implements HttpRequest {
     private boolean preDispatch;
     private List<Cookie> testCookies = Lists.newArrayList();
     protected Promise<TestResponse> testResponsePromise = new Promise<>();
-    private static DispatcherPipeline pipeline;
+    private DispatcherPipeline pipeline;
     private Map<String, String> testSession;
 
     protected TestRequest() {


### PR DESCRIPTION
…le Sirius run instances

This caused problems when executing tests from the `ScenarioSuite`, because it started Sirius multiple times after another in a single java process. The static `pipeline` field was preserved between this Sirius run instances including all Controllers and their Parts (e.g. `Mongo`, `Elastic`, ...). Accessing this parts then failed, because the underlying MongoDB client of this `Mongo` instance was already closed.

An alternative solution would be to clear the `pipeline` in a `Stoppable` handler. This way, the pipeline didn't need to be recreated for each TestRequest, but only for each Scenario.