### PR TITLE
Moves the setCurrentUser Logik into the UserManager

### DIFF
--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -134,6 +134,11 @@ public abstract class GenericUserManager implements UserManager {
         return defaultUser;
     }
 
+    @Override
+    public void bindToUserContext(UserInfo userInfo) {
+        UserContext.get().setCurrentUser(userInfo);
+    }
+
     @Nonnull
     @Override
     public UserInfo findUserForRequest(@Nonnull WebContext ctx) {

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -135,8 +135,8 @@ public abstract class GenericUserManager implements UserManager {
     }
 
     @Override
-    public void bindToUserContext(UserInfo userInfo) {
-        UserContext.get().setCurrentUser(userInfo);
+    public UserInfo verifyUser(UserInfo userInfo) {
+        return userInfo;
     }
 
     @Nonnull

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -24,11 +24,7 @@ import sirius.web.http.WebContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Used to access the current user and scope.
@@ -210,9 +206,9 @@ public class UserContext implements SubContext {
         if (ctx != null && ctx.isValid()) {
             UserManager manager = getUserManager();
             UserInfo user = manager.bindToRequest(ctx);
-            setCurrentUser(user);
+            manager.bindToUserContext(user);
         } else {
-            setCurrentUser(UserInfo.NOBODY);
+            getUserManager().bindToUserContext(UserInfo.NOBODY);
         }
     }
 

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -216,8 +216,11 @@ public class UserContext implements SubContext {
             user = UserInfo.NOBODY;
         }
 
+        // Install the user to perform the verification on a fully populated context
         setCurrentUser(user);
         user = manager.verifyUser(user);
+
+        // Install the effective user - which might be NOBODY to signal that the current user was blocked
         setCurrentUser(user);
     }
 

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -24,7 +24,11 @@ import sirius.web.http.WebContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Used to access the current user and scope.
@@ -203,13 +207,18 @@ public class UserContext implements SubContext {
      * Loads the current user from the given web context.
      */
     private void bindUserToRequest(WebContext ctx) {
+        UserManager manager = getUserManager();
+        UserInfo user;
+
         if (ctx != null && ctx.isValid()) {
-            UserManager manager = getUserManager();
-            UserInfo user = manager.bindToRequest(ctx);
-            manager.bindToUserContext(user);
+            user = manager.bindToRequest(ctx);
         } else {
-            getUserManager().bindToUserContext(UserInfo.NOBODY);
+            user = UserInfo.NOBODY;
         }
+
+        setCurrentUser(user);
+        user = manager.verifyUser(user);
+        setCurrentUser(user);
     }
 
     /**

--- a/src/main/java/sirius/web/security/UserManager.java
+++ b/src/main/java/sirius/web/security/UserManager.java
@@ -29,7 +29,7 @@ public interface UserManager {
      * Tries to find the current user in the current session or by checking the request for valid credentials.
      * <p>
      * It is not safe to access {@link UserContext#getCurrentUser()} within this method.
-     * Use {@link UserManager#bindToUserContext(UserInfo)} instead.
+     * Use {@link UserManager#verifyUser(UserInfo)} instead.
      *
      * @param ctx the request to attach to
      * @return the user found in the session. If no user is available {@link UserInfo#NOBODY} can be used.
@@ -38,15 +38,14 @@ public interface UserManager {
     UserInfo bindToRequest(@Nonnull WebContext ctx);
 
     /**
-     * Handles the binding to the {@link UserContext}.
+     * Called after the user is bound to the request and set as current user.
      * <p>
-     * Can also be used to handle anything which needs to be executed after a successful login.
-     * <p>
-     * After this method is called it is safe to call {@link UserContext#getCurrentUser()}.
+     * Modifications to the user e.g. adding a permission will be saved in the current user again
      *
      * @param userInfo the user info to bind to the {@link UserContext}
+     * @return the (modified) user to be set as current user
      */
-    void bindToUserContext(UserInfo userInfo);
+    UserInfo verifyUser(UserInfo userInfo);
 
     /**
      * Tries to find the current user in the current session. In contrast to {@link #bindToRequest(WebContext)} this

--- a/src/main/java/sirius/web/security/UserManager.java
+++ b/src/main/java/sirius/web/security/UserManager.java
@@ -26,13 +26,27 @@ import javax.annotation.Nullable;
 public interface UserManager {
 
     /**
-     * Tries to find the current user in the current session or by checking the request for valid credentials
+     * Tries to find the current user in the current session or by checking the request for valid credentials.
+     * <p>
+     * It is not safe to access {@link UserContext#getCurrentUser()} within this method.
+     * Use {@link UserManager#bindToUserContext(UserInfo)} instead.
      *
      * @param ctx the request to attach to
      * @return the user found in the session. If no user is available {@link UserInfo#NOBODY} can be used.
      */
     @Nonnull
     UserInfo bindToRequest(@Nonnull WebContext ctx);
+
+    /**
+     * Handles the binding to the {@link UserContext}.
+     * <p>
+     * Can also be used to handle anything which needs to be executed after a successful login.
+     * <p>
+     * After this method is called it is safe to call {@link UserContext#getCurrentUser()}.
+     *
+     * @param userInfo the user info to bind to the {@link UserContext}
+     */
+    void bindToUserContext(UserInfo userInfo);
 
     /**
      * Tries to find the current user in the current session. In contrast to {@link #bindToRequest(WebContext)} this


### PR DESCRIPTION
this methods binds the given user info the the user context and enables us to
extend the logic within the user manager.

This is necessary if we want to execute code after the user was sucessfully logged in
- Fixes: SE-4967