### PR TITLE
Stores the previous CSRF Token in the Session to ensure a minimal lifetime

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1421,8 +1421,10 @@ public class WebContext implements SubContext {
     private boolean checkCSRFToken() {
         String requestToken = this.get(CSRFHelper.CSRF_TOKEN).asString();
         String sessionToken = getSessionValue(CSRFHelper.CSRF_TOKEN).asString();
-
-        return Strings.isFilled(requestToken) && Strings.areEqual(requestToken, sessionToken);
+        String lastSessionToken = getSessionValue(CSRFHelper.PREVIOUS_CSRF_TOKEN).asString();
+        return Strings.isFilled(requestToken) && (Strings.areEqual(requestToken, sessionToken) || Strings.areEqual(
+                requestToken,
+                lastSessionToken));
     }
 
     /**

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -103,7 +103,9 @@ http {
     sessionSecret = ""
 
     # Specifies the lifetime of CSRF security tokens in a user session before being recomputed.
-    csrfTokenLifetime = 24 hours
+    # The token is guaranteed to be valid for at least this time since we store the last token after recomputing a new one.
+    # For the same reason, the token can be valid for up to double this duration.
+    csrfTokenLifetime = 12 hours
 
     # Should a default crossdomain.xml be served?
     crossdomain.xml.enabled = true

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -17,6 +17,7 @@ import sirius.kernel.commons.Wait;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.HandledException;
+import sirius.web.http.CSRFHelper;
 import sirius.web.http.InputStreamHandler;
 import sirius.web.http.Limited;
 import sirius.web.http.WebContext;
@@ -35,6 +36,9 @@ public class TestController implements Controller {
 
     @Part
     private Tasks tasks;
+
+    @Part
+    private CSRFHelper csrfHelper;
 
     @Override
     public void onError(WebContext ctx, HandledException error) {
@@ -217,8 +221,14 @@ public class TestController implements Controller {
     }
 
     @Routed("/test/provide-security-token")
-    public void provideSecuritytoken(WebContext ctx) {
+    public void provideSecurityToken(WebContext ctx) {
         ctx.respondWith().template("templates/security-token.html.pasta");
+    }
+
+    @Routed("/test/expire-security-token")
+    public void expireSecurityToken(WebContext ctx) {
+        csrfHelper.recomputeCSRFToken(ctx);
+        ctx.respondWith().direct(HttpResponseStatus.OK, "OK");
     }
 
     @Routed(value = "/test/json/async", jsonCall = true)

--- a/src/test/java/sirius/web/http/CSRFTokenSpec.groovy
+++ b/src/test/java/sirius/web/http/CSRFTokenSpec.groovy
@@ -67,6 +67,24 @@ class CSRFTokenSpec extends BaseSpecification {
         c2.getResponseCode() == 200
     }
 
+    def "safePOST() works correctly if expired token is present via POST"() {
+        given:
+        HttpURLConnection c = new URL("http://localhost:9999/test/provide-security-token").openConnection()
+        c.setRequestMethod("GET")
+        c.connect()
+        def token = new String(ByteStreams.toByteArray(c.getInputStream()), Charsets.UTF_8)
+        TestRequest.GET("/test/expire-security-token").execute()
+        
+        when:
+        HttpURLConnection c2 = new URL(
+                "http://localhost:9999/test/fake-delete-data?CSRFToken=" + token).openConnection()
+        c2.setRequestMethod("POST")
+        c2.setRequestProperty(HttpHeaderNames.COOKIE.toString(), c.getHeaderFields().get("set-cookie").get(0))
+        c2.connect()
+        then:
+        c2.getResponseCode() == 200
+    }
+
     def "safePOST() works correctly if wrong token is present via POST"() {
         given:
         HttpURLConnection c = new URL("http://localhost:9999/test/provide-security-token").openConnection()


### PR DESCRIPTION
Previously, with unlucky timing and tabbed browsing a CSRF token provided could be invalid just seconds later. Storing the previous CSRF Token after recomputing ensures that a delivered token stays valid for at least of 1x the duration of http.csrfTokenLifetime and maximum 2x the duration of http.csrfTokenLifetime

Fixes: OX-4581