### PR TITLE
Provides an easy method to create a new userInfo from an existent one

### DIFF
--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -85,6 +85,25 @@ public class UserInfo extends Composable {
         }
 
         /**
+         * Provides a method to copy everything but the permissions from the given user info.
+         * <p>
+         * Allows as to copy the user info and modify its permissions
+         * (e.g. in the {@link UserManager#verifyUser(UserInfo)})
+         *
+         * @param info the info to copy from
+         * @return the builder itself for fluent method calls
+         */
+        public static Builder withUser(@Nonnull UserInfo info) {
+            return createUser(info.getUserId())
+                    .withLang(info.getLang())
+                    .withUsername(info.getUserName())
+                    .withTenantId(info.getTenantId())
+                    .withTenantName(info.getTenantName())
+                    .withSettingsSupplier(info.settingsSupplier)
+                    .withUserSupplier(info.userSupplier);
+        }
+
+        /**
          * Sets the name of the user.
          *
          * @param name the name of the user.


### PR DESCRIPTION
We will use this to modify the permissions in the userManager.verifyUser method of the current user.

We need to create the userInfo here because we need access to the settingsSupplier and the userSupplier.
- Fixes: SE-5247