### PR TITLE
Permits to perform "session pinning" with the help of a second cookie.

### DIFF
--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -92,6 +92,11 @@ http {
     # Specifies the name of the cookie which contains the client session
     sessionCookieName = "SIRIUS_SESSION"
 
+    # Determines if sessions should be "pinned" to a client / user-agent by setting an additional
+    # cookie which is stored outside of the session and referenced within it.
+    # This is disabled by default as the "pin" could be misjudged as "tracking" id
+    sessionPinning = false
+
     # Determines the livetime of the client session cookie. If this is zero a "session" cookie is
     # created which will be deleted once the browser is closed.
     sessionCookieTTL = 90 days


### PR DESCRIPTION
This will be stored next to the session (as separate cookie) and also within the session. This greatly protects against
session hijacking (or software bugs with the same effect) as both cookie are never set in the same request / response.

Also, an MD5 and not the pin itself is stored in the session, therefore it is not enough to obtain only one cookie.

Also some tracing and logging was added to help troubleshoot session related bugs.