### PR TITLE
Fixes tagliatelle errors in the documentation

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -311,7 +311,7 @@
             /**
              * Checks whether the tokenfield contains any token.
              *
-             * @return true if the tokenfield contains at least one token.
+             * @@return true if the tokenfield contains at least one token.
              */
             hasTokens: function () {
                 return input.hasTokens();
@@ -322,8 +322,8 @@
              *
              * Tokens are equal if they have the same value-property.
              *
-             * @param token the given token
-             * @return true if the token field contains the given token
+             * @@param token the given token
+             * @@return true if the token field contains the given token
              */
             hasToken: function (token) {
                 return input.hasToken(token);
@@ -349,7 +349,7 @@
              *
              * Tokens are equal if they have the same value-property.
              *
-             * @param token the token to remove
+             * @@param token the token to remove
              */
             removeToken: function (token) {
                 input.removeToken(token);
@@ -358,7 +358,7 @@
             /**
              * Get all tokens in the tokenfield.
              *
-             * @return {*} a list of all tokens in the tokenfield.
+             * @@return {*} a list of all tokens in the tokenfield.
              */
             getTokens: function () {
                 return input.getTokens();


### PR DESCRIPTION
Needs double-@ or else `"@return"` and `"@param"` will be interpreted as tagliatelle variables