### PR TITLE
Remove query string for Fontawsome

### DIFF
--- a/src/main/resources/default/assets/wondergem/font-awesome/css/font-awesome.css
+++ b/src/main/resources/default/assets/wondergem/font-awesome/css/font-awesome.css
@@ -6,8 +6,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.eot?v=4.5.0');
-  src: url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0') format('embedded-opentype'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.woff2?v=4.5.0') format('woff2'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.woff?v=4.5.0') format('woff'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.ttf?v=4.5.0') format('truetype'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular') format('svg');
+  src: url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.eot');
+  src: url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.eot') format('embedded-opentype'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.woff2') format('woff2'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.woff') format('woff'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.ttf') format('truetype'), url('/assets/wondergem/font-awesome/fonts/fontawesome-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Some browsers (namely IE 11) sometimes do not load fonts if they are served with a query string.

Tags: ie, font, fontawsome