### PR TITLE
Use valid default for SMTP protocol

### DIFF
--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -89,16 +89,19 @@ public class SMTPConfiguration {
      * @return a new configuration based on the config files.
      */
     public static SMTPConfiguration fromConfig() {
+
+        SMTPProtocol smtpProtocol = Sirius.getSettings()
+                                          .get("mail.smtp.protocol")
+                                          .getEnum(SMTPProtocol.class)
+                                          .orElseGet(() -> Value.of(Sirius.getSettings()
+                                                                          .get("mail.smtp.protocol")
+                                                                          .toUpperCase())
+                                                                .getEnum(SMTPProtocol.class)
+                                                                .orElse(SMTPProtocol.SMTP));
+
         return new SMTPConfiguration(smtpHost,
                                      smtpPort,
-                                     Sirius.getSettings()
-                                           .get("mail.smtp.protocol")
-                                           .getEnum(SMTPProtocol.class)
-                                           .orElseGet(() -> Value.of(Sirius.getSettings()
-                                                                           .get("mail.smtp.protocol")
-                                                                           .toUpperCase())
-                                                                 .getEnum(SMTPProtocol.class)
-                                                                 .orElse(SMTPProtocol.SMTP)),
+                                     smtpProtocol,
                                      smtpUser,
                                      smtpPassword,
                                      smtpSender,
@@ -122,13 +125,16 @@ public class SMTPConfiguration {
      * @return a new configuration based on the given settings.
      */
     public static SMTPConfiguration fromSettings(Settings settings) {
+
+        SMTPProtocol smtpProtocol = settings.get("mail.protocol")
+                                            .getEnum(SMTPProtocol.class)
+                                            .orElseGet(() -> Value.of(settings.get("mail.protocol").toUpperCase())
+                                                                  .getEnum(SMTPProtocol.class)
+                                                                  .orElse(SMTPProtocol.SMTP));
+
         return new SMTPConfiguration(settings.get("mail.host").getString(),
                                      settings.get("mail.port").getString(),
-                                     settings.get("mail.protocol")
-                                             .getEnum(SMTPProtocol.class)
-                                             .orElseGet(() -> Value.of(settings.get("mail.protocol").toUpperCase())
-                                                                   .getEnum(SMTPProtocol.class)
-                                                                   .orElse(SMTPProtocol.SMTP)),
+                                     smtpProtocol,
                                      settings.get("mail.user").getString(),
                                      settings.get("mail.password").getString(),
                                      settings.get("mail.sender").getString(),

--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -9,7 +9,6 @@
 package sirius.web.mails;
 
 import sirius.kernel.Sirius;
-import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.nls.NLS;
@@ -52,35 +51,54 @@ public class SMTPConfiguration {
     private static boolean smtpUseEnvelopeFrom;
 
     /**
-     * Creates a new configuration based on fixed values.
+     * Creates a new {@link SMTPConfiguration} which can be used to configure
+     * the mail server to use.
      *
-     * @param host                     the mail server host
-     * @param port                     the mail server port
-     * @param protocol                 the mail transport protocol
-     * @param user                     the mail account user
-     * @param password                 the mail account password
-     * @param mailSender               the sender address
-     * @param mailSenderName           the sender name
-     * @param useSenderAndEnvelopeFrom whether to fill the "Sender" and the "Envelope-From" header
+     * @return a {@link SMTPConfiguration} to fill with the settings of the mail
+     * server to use
      */
-    @SuppressWarnings("squid:S00107")
-    @Explain("All settings are needed for a proper SMTP setting")
-    public SMTPConfiguration(String host,
-                             String port,
-                             SMTPProtocol protocol,
-                             String user,
-                             String password,
-                             String mailSender,
-                             String mailSenderName,
-                             boolean useSenderAndEnvelopeFrom) {
+    public static SMTPConfiguration create() {
+        return new SMTPConfiguration();
+    }
+
+    public SMTPConfiguration setHost(String host) {
         this.host = host;
+        return this;
+    }
+
+    public SMTPConfiguration setPort(String port) {
         this.port = port;
+        return this;
+    }
+
+    public SMTPConfiguration setProtocol(SMTPProtocol protocol) {
         this.protocol = protocol;
+        return this;
+    }
+
+    public SMTPConfiguration setUser(String user) {
         this.user = user;
+        return this;
+    }
+
+    public SMTPConfiguration setPassword(String password) {
         this.password = password;
+        return this;
+    }
+
+    public SMTPConfiguration setMailSender(String mailSender) {
         this.mailSender = mailSender;
+        return this;
+    }
+
+    public SMTPConfiguration setMailSenderName(String mailSenderName) {
         this.mailSenderName = mailSenderName;
+        return this;
+    }
+
+    public SMTPConfiguration setUseSenderAndEnvelopeFrom(boolean useSenderAndEnvelopeFrom) {
         this.useSenderAndEnvelopeFrom = useSenderAndEnvelopeFrom;
+        return this;
     }
 
     /**
@@ -89,24 +107,15 @@ public class SMTPConfiguration {
      * @return a new configuration based on the config files.
      */
     public static SMTPConfiguration fromConfig() {
-
-        SMTPProtocol smtpProtocol = Sirius.getSettings()
-                                          .get("mail.smtp.protocol")
-                                          .getEnum(SMTPProtocol.class)
-                                          .orElseGet(() -> Value.of(Sirius.getSettings()
-                                                                          .get("mail.smtp.protocol")
-                                                                          .toUpperCase())
-                                                                .getEnum(SMTPProtocol.class)
-                                                                .orElse(SMTPProtocol.SMTP));
-
-        return new SMTPConfiguration(smtpHost,
-                                     smtpPort,
-                                     smtpProtocol,
-                                     smtpUser,
-                                     smtpPassword,
-                                     smtpSender,
-                                     smtpSenderName,
-                                     smtpUseEnvelopeFrom);
+        return SMTPConfiguration.create()
+                                .setHost(smtpHost)
+                                .setPort(smtpPort)
+                                .setProtocol(asSMTPProtocol(Sirius.getSettings().get("mail.smtp.protocol")))
+                                .setUser(smtpUser)
+                                .setPassword(smtpPassword)
+                                .setMailSender(smtpSender)
+                                .setMailSenderName(smtpSenderName)
+                                .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom);
     }
 
     /**
@@ -125,21 +134,15 @@ public class SMTPConfiguration {
      * @return a new configuration based on the given settings.
      */
     public static SMTPConfiguration fromSettings(Settings settings) {
-
-        SMTPProtocol smtpProtocol = settings.get("mail.protocol")
-                                            .getEnum(SMTPProtocol.class)
-                                            .orElseGet(() -> Value.of(settings.get("mail.protocol").toUpperCase())
-                                                                  .getEnum(SMTPProtocol.class)
-                                                                  .orElse(SMTPProtocol.SMTP));
-
-        return new SMTPConfiguration(settings.get("mail.host").getString(),
-                                     settings.get("mail.port").getString(),
-                                     smtpProtocol,
-                                     settings.get("mail.user").getString(),
-                                     settings.get("mail.password").getString(),
-                                     settings.get("mail.sender").getString(),
-                                     settings.get("mail.senderName").getString(),
-                                     settings.get("mail.useEnvelopeFrom").asBoolean());
+        return SMTPConfiguration.create()
+                                .setHost(settings.get("mail.host").getString())
+                                .setPort(settings.get("mail.port").getString())
+                                .setProtocol(asSMTPProtocol(settings.get("mail.protocol")))
+                                .setUser(settings.get("mail.user").getString())
+                                .setPassword(settings.get("mail.password").getString())
+                                .setMailSender(settings.get("mail.sender").getString())
+                                .setMailSenderName(settings.get("mail.senderName").getString())
+                                .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean());
     }
 
     /**
@@ -243,6 +246,13 @@ public class SMTPConfiguration {
      */
     public boolean isUseSenderAndEnvelopeFrom() {
         return useSenderAndEnvelopeFrom;
+    }
+
+    private static SMTPProtocol asSMTPProtocol(Value setting) {
+        return setting.getEnum(SMTPProtocol.class)
+                      .orElseGet(() -> Value.of(setting.toUpperCase())
+                                            .getEnum(SMTPProtocol.class)
+                                            .orElse(SMTPProtocol.SMTP));
     }
 
     /**

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -351,7 +351,7 @@ mail {
         port = "25"
 
         # Protocol and encryption of the SMTP connection (SMTP, SMTPS or STARTTLS)
-        protocol = "smtp"
+        protocol = "SMTP"
 
         # Username used to authenticate at the SMTP server
         user = ""


### PR DESCRIPTION
The setting value has to be in upper case.

Tags: smtp, configuration