### PR TITLE
Fix Bug in 'service' of autocomplete

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -621,7 +621,7 @@
                     throw "The event afterLoad must be set.";
                 }
 
-                configured = true;
+                this.configured = true;
 
                 this.uri = config.serviceUri;
 


### PR DESCRIPTION
"configured" was never correctly set, and we check on "configured" before calling the "load"-method (see line 82 of this file). without calling the load method we never request data from the server... -> never show an autocomplete...