### PR TITLE
Refresh on hidden fields can be disabled

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -64,7 +64,7 @@
                 this.hiddenInputsName = config.hiddenInputsName;
 
                 function refreshHiddenInputs() {
-                    if (input.hiddenInputsName === undefined) {
+                    if (typeof input.hiddenInputsName === "undefined") {
                         return;
                     }
                     $('#' + input.id).parent().find(".hidden-tokenfield-input").remove();

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -64,6 +64,9 @@
                 this.hiddenInputsName = config.hiddenInputsName;
 
                 function refreshHiddenInputs() {
+                    if (input.hiddenInputsName === undefined) {
+                        return;
+                    }
                     $('#' + input.id).parent().find(".hidden-tokenfield-input").remove();
                     input.getTokens().forEach(function (token) {
                         var hiddenInput =

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -64,7 +64,7 @@
                 this.hiddenInputsName = config.hiddenInputsName;
 
                 function refreshHiddenInputs() {
-                    if (typeof input.hiddenInputsName === "undefined") {
+                    if (!input.hiddenInputsName) {
                         return;
                     }
                     $('#' + input.id).parent().find(".hidden-tokenfield-input").remove();


### PR DESCRIPTION
If no name for the hidden input fields is defined, they should not be refreshed as they would be generated with undefinded as name. In addition some products rely on their on logic to handle these input fields.

Tags: tokenfield