### PR TITLE
Adds Tokens to tokenfield from autocomplete without rendering them in the tokenfield

### DIFF
--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -612,12 +612,8 @@
         var tokenfield = sirius.createTokenfield();
         var autocomplete = sirius.createAutocomplete();
 
-        autocomplete.on('onHoverRow', function ($row) {
-            autocomplete.getInput().val($row.find('.autocomplete-data').data('autocomplete'));
-        });
-
-        autocomplete.on('onUnhoverRow', function ($row) {
-            autocomplete.getInput().val('');
+        autocomplete.on('onBeforeHide', function (selectedRow) {
+            tokenfield.addToken(suggestions.getTokenForValue(selectedRow.find('.autocomplete-data').data('autocomplete')));
         });
 
         autocomplete.on('onReady', function ($row) {

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -395,6 +395,11 @@
                     return;
                 }
                 completions.state = completions.HIDDEN;
+                if(completions.selectedRow) {
+                    events.onBeforeHide.forEach(function (handler) {
+                        handler(completions.selectedRow);
+                    });
+                }
                 completions.unHoverRow(completions.selectedRow);
 
                 completions.element.hide();
@@ -491,6 +496,7 @@
             onReady: [],
             onShow: [],
             onHide: [],
+            onBeforeHide: [],
 
             /**
              * Handle the selection of a row element.

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -134,7 +134,7 @@
             },
 
             /**
-             * Adds a list of tokens to the already existing once.
+             * Adds a list of tokens to the already existing ones.
              *
              * @@param tokens array of tokens to be added
              */
@@ -142,6 +142,14 @@
                 $.each(tokens, function (i, token) {
                     input.element.tokenfield('createToken', token);
                 });
+            },
+            /**
+             * Adds a single token to the already existing ones.
+             *
+             * @@param token the token to be added
+             */
+            addToken: function (token) {
+                input.element.tokenfield('createToken', token);
             },
 
             resize: function (e) {
@@ -297,6 +305,10 @@
 
             appendTokens: function (tokens) {
                 input.appendTokens(tokens);
+            },
+
+            addToken: function (token) {
+                input.addToken(token);
             },
 
             getInputFieldId: function () {


### PR DESCRIPTION
Previously, tokens were added because the tokenField lost focus and the *selectedRow*s value was written to the tokenField, which creates the token for this value when it loses value.
Without a total rewrite, we now add the token by hand just before the autocomplete gets hidden and we have a *selectedRow*