### PR TITLE
Stops autocomplete from closing when scrolling in IE

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -186,7 +186,11 @@
                     }
                 });
 
-                this.element.focusout(function () {
+                this.element.focusout(function (event) {
+                    if ($(event.relatedTarget).hasClass('autocomplete-wrapper')) {
+                       this.focus();
+                       return false;
+                    }
                     completions.hide();
                 });
 


### PR DESCRIPTION
When using the scrollbar in IE, the focus changes from the autocomplete input field to the autocomplete wrapper. In this case we just give the focus back to the input field to prevent focus loss.