### PR TITLE
Uses .attr instead of .data to avoid automatic type conversion of .data

### DIFF
--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -613,7 +613,9 @@
         var autocomplete = sirius.createAutocomplete();
 
         autocomplete.on('onBeforeHide', function (selectedRow) {
-            tokenfield.addToken(selectedRow.find('.autocomplete-data').data('autocomplete'));
+            // using .attr() instead of .data() of jQuery, because we do not want automatic type conversion of .data().
+            // e.g. data-autocomplete="123" would be converted to the number 123 by .data("autocomplete").
+            tokenfield.addToken(selectedRow.find('.autocomplete-data').attr('data-autocomplete'));
         });
 
         autocomplete.on('onReady', function ($row) {


### PR DESCRIPTION
The automatic type conversion is leading to errors with data which is only numbers