### PR TITLE
Uses overflow-wrap instead of word-break to break sub-navs

### DIFF
--- a/src/main/resources/default/assets/wondergem/stylesheets/navs.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/navs.scss
@@ -113,7 +113,8 @@ $navbarLinkBackgroundActive:    darken($navbarLinkBackgroundHover, 5%);
 
 .sub-nav > li > a {
   padding-right: 5px;
-  word-break: break-all;
+  overflow-wrap: break-word;
+  word-wrap: break-word; //legacy IE
 }
 
 


### PR DESCRIPTION
Disregarding Chinese,Japanese and Korean text, overflow-wrap(prior named word-wrap) is always superior. word-break always breaks at the current char and overflow-wrap first looks at break oppurtinities before breaking at the current char as a last resort.

Fixes: SIRI-31