### PR TITLE
Adds Method to provide a nls key and optionally parameters as a mail subject.

### DIFF
--- a/src/test/java/sirius/web/mails/MailsSpec.groovy
+++ b/src/test/java/sirius/web/mails/MailsSpec.groovy
@@ -9,6 +9,7 @@
 package sirius.web.mails
 
 import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Context
 import sirius.kernel.di.std.Part
 import sirius.kernel.health.HandledException
 
@@ -36,6 +37,20 @@ class MailsSpec extends BaseSpecification {
         mails.createEmail().to("test@", "Invalid").subject("Test eMail").textContent("This is a Test.").send()
         then:
         thrown(HandledException)
+    }
+
+    def "Mails translates subject to correct language"() {
+        when:
+        ((MailsMock) mails).getSentMails().clear()
+        mails.createEmail()
+             .to("test@scireum.de", "Test")
+             .nlsSubject("mail.subject", Context.create().set("nr", "1"))
+             .setLang("fr")
+             .textContent("This is a Test.")
+             .send()
+        then:
+        MailsMock.MailSenderMock mail = ((MailsMock) mails).getLastMail()
+        mail.getSubject() == "Ceci est le test 1."
     }
 
 }

--- a/src/test/resources/test_de.properties
+++ b/src/test/resources/test_de.properties
@@ -1,0 +1,1 @@
+mail.subject=Dies ist Test ${nr}.

--- a/src/test/resources/test_fr.properties
+++ b/src/test/resources/test_fr.properties
@@ -1,0 +1,1 @@
+mail.subject=Ceci est le test ${nr}.


### PR DESCRIPTION
Using .textTemplate()/.htmlTemplate() together with .setLang(), its easy to forget to also translate the String provided to .subject() into the mail's correct language manually. This new method uses the language given in .setLang() automatically.