### PR TITLE
Adds parameter to the i18n macro

### DIFF
--- a/src/test/java/sirius/tagliatelle/I18nMacroSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/I18nMacroSpec.groovy
@@ -1,0 +1,41 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle
+
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+import sirius.tagliatelle.compiler.CompilationContext
+import sirius.tagliatelle.compiler.Compiler
+import sirius.web.resources.Resources
+
+class I18nMacroSpec extends BaseSpecification {
+
+    @Part
+    private static Tagliatelle tagliatelle
+
+    @Part
+    private static Resources resources
+
+    def "basic tests"() {
+        given:
+        Template template = new Template("test", null)
+        def ctx = new CompilationContext(template, null)
+        new Compiler(ctx, input).compile()
+        expect:
+        template.renderToString() == output
+        where:
+        input                                    | output
+        "@i18n('I18nMacroSpec.test')"            | "test"
+        "@i18n('I18nMacroSpec.multipleTest', 0)" | "first"
+        "@i18n('I18nMacroSpec.multipleTest', 1)" | "second"
+        "@i18n('I18nMacroSpec.multipleTest', 2)" | "third"
+        "@i18n('', 2)"                           | ""
+        "@i18n('')"                              | ""
+    }
+}

--- a/src/test/resources/test_de.properties
+++ b/src/test/resources/test_de.properties
@@ -1,1 +1,3 @@
 mail.subject=Dies ist Test ${nr}.
+I18nMacroSpec.multipleTest = first | second | third
+I18nMacroSpec.test = test


### PR DESCRIPTION
NLS.get() supports a 'numeric' parameter which can be used to switch e.g. between singulara and plural version of a translation key.