### PR TITLE
Prohibits keepalive if a response is created before the request (and …

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -239,7 +239,7 @@ public class Response {
         }
 
         // Add keepalive header if required
-        if (responseKeepalive && keepalive && isKeepalive()) {
+        if (responseKeepalive && keepalive && isKeepalive() && wc.requestFullyRead) {
             response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
         } else {
             if (!HttpVersion.HTTP_1_0.equals(wc.getRequest().protocolVersion())) {

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -208,6 +208,11 @@ public class WebContext implements SubContext {
     /*
      * Used by Response - but stored here, since a new Response might be created....
      */
+    protected volatile boolean requestFullyRead;
+
+    /*
+     * Used by Response - but stored here, since a new Response might be created....
+     */
     protected volatile boolean responseCommitted;
 
     /*

--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -300,7 +300,9 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
                 return;
             }
             boolean last = msg instanceof LastHttpContent;
-            if (!last) {
+            if (last) {
+                currentContext.requestFullyRead = true;
+            } else {
                 if (WebServer.chunks.incrementAndGet() < 0) {
                     WebServer.chunks.set(0);
                 }

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -133,6 +133,11 @@ public class TestController implements Controller {
         ctx.respondWith().direct(HttpResponseStatus.OK, String.valueOf(size));
     }
 
+    @Routed(value = "/test/predispatch/abort", preDispatchable = true)
+    public void testPredispatchAbort(WebContext ctx, InputStreamHandler in) throws Exception {
+        ctx.respondWith().direct(HttpResponseStatus.OK, "ABORT");
+    }
+
     @Routed("/test/os")
     public void testOutputStream(WebContext ctx) throws IOException {
         OutputStream out = ctx.respondWith().outputStream(HttpResponseStatus.OK, "text/plain");

--- a/src/test/java/sirius/web/http/WebServerSpec.groovy
+++ b/src/test/java/sirius/web/http/WebServerSpec.groovy
@@ -335,7 +335,7 @@ class WebServerSpec extends BaseSpecification {
         and:
         u.setChunkedStreamingMode(1024)
         and:
-        def testByteArray = "Hello Service".getBytes()
+        def testByteArray = "X".getBytes()
         when:
         u.setRequestMethod("POST")
         u.setDoInput(true)
@@ -343,8 +343,15 @@ class WebServerSpec extends BaseSpecification {
 
         def out = u.getOutputStream()
         // Write some data to ensure the connection happens
-        for (int i = 0; i < 1024; i++) {
-            out.write(testByteArray)
+        try {
+            for (int i = 0; i < 1024; i++) {
+                out.write(testByteArray)
+            }
+        } catch (IOException e) {
+            // An exception might already occur here, if the client deciedes to submit the request the
+            // server will immediatelly close the connection - which is to be expected and totally fine
+            // for the test - we then simply continue...
+            Exceptions.ignore(e)
         }
         out.flush()
 


### PR DESCRIPTION
…its content) has been fully read.

If we respond to a request before it was fully read, we have to give up keepalive and should
actually close the connection, otherwise we might confuse HTTP clients like curl.

This behavior was detected when a pre-dispatched controller tried to prevent an upload
by sending an error which was actually encoded as 200 OK + JSON response. Therefore
neither the HTTP client nor any intermediate proxy saw any need to abort the connection
and the upload of the data continued after the response was received. However, this
confused some client like curl or essentially libcurl.

Fixes: SIRI-47