### PR TITLE
Clear tokens before adding the initial selection

### DIFF
--- a/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
+++ b/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
@@ -225,6 +225,10 @@ var multiSelect = function (args) {
         }
     }
 
+    // clear tokens before appending the initial selection, because clicking back in the browser will add the old inputs
+    // into the input-fields and this adds the tokens, but without the correct labels, so clear those incorrect tokens
+    tokenfield.clearTokens();
+
     tokenfield.appendTokens(suggestions.getInitialSelection());
     updateSelectObject();
 


### PR DESCRIPTION
Because browser-back-button already adds some tokens, but with wrong labels