### PR TITLE
Resets completion filter when focused input field is clicked

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -210,6 +210,15 @@
                 });
 
                 this.element.click(function () {
+                    if (completions.isVisible()) {
+                        return;
+                    }
+                    if (localSource.configured) {
+                        localSource.load($(this).val());
+                    }
+                    if (service.configured && service.minSize === 0) {
+                        service.load($(this).val());
+                    }
                     completions.show();
                 });
             }


### PR DESCRIPTION
Selecting an autocomplete suggestion via the keyboard keeps the input field focused so the user can keep typing.
Clinking inside the field after selecting a filtered suggestion reopened the previously filtered completions again without resetting the filter.
This is now done by executing the same code as when the input field gains focus when the field is clicked and the completions are not already visible.

Fixes: OX-5120