### PR TITLE
SIRI-61: Fixes autocomplete-wrapper getting position:relative style attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2</version>
     </parent>
     <artifactId>sirius-web</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>

--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -256,7 +256,6 @@
                 this.state = completions.HIDDEN;
 
                 this.element = $(Mustache.render(wrapper, config));
-                this.rePosition();
 
 
                 this.element.on("mouseup.sirius-autocomplete", ".autocomplete-row-js", function () {


### PR DESCRIPTION
When repostioning the autocomplete-wrapper during init, the wrapper might still have 'position: static'. jQuery adds position:relative to static elements when .offset(x) is called on them.
Since reposition is called anyway when the wrapper is shown, we don't actually need to reposition the wrapper during init.

> The .offset() setter method allows us to reposition an element. The element's border-box position is specified relative to the document. If the element's position style property is currently static, it will be set to relative to allow for this repositioning.