### PR TITLE
Call "onRemovedToken" handler when removing tokens programmatically

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -282,8 +282,9 @@
                 });
                 input.element.tokenfield("setTokens", newTokens);
 
+                var event = {attrs: tokenToRemove};
                 events.onRemovedToken.forEach(function (handler) {
-                    handler();
+                    handler(event);
                 });
             },
 

--- a/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/tokenfield.html.pasta
@@ -111,7 +111,7 @@
                 listeners.unshift(listeners.pop());
 
                 this.tokenElement.focusin(function () {
-                    setTimeout(function(){
+                    setTimeout(function () {
                         input.resizeInputField();
                     });
                 });
@@ -281,6 +281,10 @@
                     return tokenToRemove.value !== token.value;
                 });
                 input.element.tokenfield("setTokens", newTokens);
+
+                events.onRemovedToken.forEach(function (handler) {
+                    handler();
+                });
             },
 
             /**


### PR DESCRIPTION
That we did not do this before, led to the underlying "select"-tag not being refreshed for w:xxxSelect when removing a token by clicking on an autocomplete entry