### PR TITLE
Use plain JavaScript for check if input field is focused

### DIFF
--- a/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/autocomplete.html.pasta
@@ -365,7 +365,7 @@
             },
 
             show: function () {
-                if (this.rows.length > 0 && input.element.is(":focus")) {
+                if (this.rows.length > 0 && document.activeElement === input.element.get(0)) {
                     this.update();
                     completions.element.show();
                     this.state = completions.VISIBLE;


### PR DESCRIPTION
The '.is(":focus")' check fails in Safari, when the field was focused via the '.focus()' method.