### PR TITLE
Also blur input field of SingleSelect after adding a token

### DIFF
--- a/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
+++ b/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
@@ -192,7 +192,7 @@ var multiSelect = function (args) {
 
     if (args.maxItems === 1) {
         tokenfield.on('onCreatedToken', function (token) {
-            tokenfield.getTokenfieldInputField().hide();
+            tokenfield.getTokenfieldInputField().hide().blur();
             $('#' + args.id).find('.tokenfield').attr("tabindex", "0");
         });
 


### PR DESCRIPTION
Because in Safari this still can have focus after being hidden, unlike other browsers