### PR TITLE
Prevents date fields from filling automatically

### DIFF
--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -64,6 +64,7 @@
             ignoreReadonly: true,
             keepInvalid: true,
             useCurrent: false,
+            showTodayButton: true,
             icons: {
                 time: 'fa fa-clock-o',
                 date: 'fa fa-calendar',

--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -63,6 +63,7 @@
             locale: "@lang",
             ignoreReadonly: true,
             keepInvalid: true,
+            useCurrent: false,
             icons: {
                 time: 'fa fa-clock-o',
                 date: 'fa fa-calendar',


### PR DESCRIPTION
This also wasn't the case with the old library. And because it fires the change event, this leads to problems when the current day is actually forbidden.