### PR TITLE
Fixes an npe if the request is null

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -2001,7 +2001,13 @@ public class WebContext implements SubContext {
 
     @Override
     public String toString() {
-        return "WebContext (Committed: " + responseCommitted + "): " + request.toString();
+        String result = "WebContext (Committed: " + responseCommitted + "): ";
+
+        if (request == null) {
+            return result;
+        }
+        
+        return result + request.toString();
     }
 
     @Override


### PR DESCRIPTION
This is e.g. possible if the toString method is called in an async job