### PR TITLE
Permits to identify a message so it won't be added twice to the messa…

### DIFF
--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -45,6 +45,13 @@ public class Message {
     private boolean actionJavascript;
 
     /**
+     * Id for the message to identify the message.
+     * <p>
+     * This is helpful to check if a message already exists.
+     */
+    private String uniqueMessageId = "";
+
+    /**
      * Creates a new message with the given content, details info and message type.
      *
      * @param message the message to show to the user
@@ -224,5 +231,13 @@ public class Message {
 
     public void setActionJavascript(boolean actionJavascript) {
         this.actionJavascript = actionJavascript;
+    }
+
+    public void setUniqueMessageId(String uniqueMessageId) {
+        this.uniqueMessageId = uniqueMessageId;
+    }
+
+    public String getUniqueMessageId() {
+        return uniqueMessageId;
     }
 }

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -304,6 +304,15 @@ public class UserContext implements SubContext {
      * @param msg the message to be shown to the user
      */
     public void addMessage(Message msg) {
+        if (Strings.isFilled(msg.getUniqueMessageId()) && msgList.stream()
+                                                                 .map(Message::getUniqueMessageId)
+                                                                 .filter(Strings::isFilled)
+                                                                 .anyMatch(uniqueMessageId -> Strings.areEqual(
+                                                                          uniqueMessageId,
+                                                                          msg.getUniqueMessageId()))) {
+            return;
+        }
+
         msgList.add(msg);
     }
 


### PR DESCRIPTION
…ge list

This may happen if during the template rendering process an error occurs and the exception is handled.
If we add the same error message multiple times we don't want to display the message more than once
- Fixes: SE-8703