### PR TITLE
Adds warning when 'profile cascading' wont work, because of the order

### DIFF
--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -92,10 +92,8 @@ public class Permissions {
          * Validates this profile and throws exception if problems exist.
          * <p>
          * An exception will be thrown if the profile refers to another profile applied earlier than itself.
-         *
-         * @throws Exception if this profile is not valid
          */
-        protected void validate() throws Exception {
+        protected void validate() {
             Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);
             for (String permission : thisProfile.getContext().keySet()) {
                 Extension otherProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, permission);
@@ -103,7 +101,7 @@ public class Permissions {
                     continue;
                 }
                 if (otherProfile.compareTo(thisProfile) <= 0) {
-                    throw new Exception(Strings.apply(
+                    throw new IllegalStateException(Strings.apply(
                             "Profile '%s' refers to a profile which is applied earlier than itself ('%s'). "
                             + "Therefore the profiles will not be resolved completely. Fix this by adding priorities.",
                             thisProfile.getId(),

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -53,6 +53,9 @@ public class Permissions {
 
     private static final Log LOG = Log.get("permissions");
 
+    /**
+     * Represents a profile defined in <tt>security.profiles</tt>.
+     */
     private static class Profile {
         public static final String SECURITY_PROFILES = "security.profiles";
 
@@ -60,12 +63,24 @@ public class Permissions {
         private final Set<String> permissionsToAdd;
         private final Set<String> permissionsToRemove;
 
+        /**
+         * Create a Profile with the given name, permissions this profiles adds and permissions this profile removes.
+         *
+         * @param name                the name of the profile
+         * @param permissionsToAdd    permissions this profile adds
+         * @param permissionsToRemove permission this profiles removes
+         */
         Profile(String name, Set<String> permissionsToAdd, Set<String> permissionsToRemove) {
             this.name = name;
             this.permissionsToAdd = permissionsToAdd;
             this.permissionsToRemove = permissionsToRemove;
         }
 
+        /**
+         * Applies the profile to the given set of permissions.
+         *
+         * @param permissions the permissions the profile should be applied to
+         */
         protected void apply(Set<String> permissions) {
             if (hasPermission(name, permissions::contains)) {
                 permissions.addAll(permissionsToAdd);
@@ -73,6 +88,13 @@ public class Permissions {
             }
         }
 
+        /**
+         * Validates this profile and throws exception if problems exist.
+         * <p>
+         * An exception will be thrown if the profile refers to another profile applied earlier than itself.
+         *
+         * @throws Exception if this profile is not valid
+         */
         protected void validate() throws Exception {
             Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);
             for (String permission : thisProfile.getContext().keySet()) {
@@ -90,6 +112,12 @@ public class Permissions {
             }
         }
 
+        /**
+         * Compile the given extension into a {@link Profile}.
+         *
+         * @param extension the extension to compile
+         * @return the compiled {@link Profile}
+         */
         protected static Profile compile(Extension extension) {
             Set<String> permissionsToAdd = new HashSet<>();
             Set<String> permissionsToRemove = new HashSet<>();

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -62,13 +62,13 @@ public class Permissions {
 
     private static List<Profile> getProfiles() {
         if (profilesCache == null) {
-            loadProfiles();
+            profilesCache = loadProfiles();
         }
 
         return profilesCache;
     }
 
-    private static void loadProfiles() {
+    private static List<Profile> loadProfiles() {
         List<Profile> profiles = new ArrayList<>();
 
         for (Extension ext : Sirius.getSettings().getExtensions(Profile.SECURITY_PROFILES)) {
@@ -81,7 +81,7 @@ public class Permissions {
             }
         }
 
-        profilesCache = profiles;
+        return profiles;
     }
 
     /**

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -79,10 +79,10 @@ public class Permissions {
             Monoflop warningOccured = Monoflop.create();
             for (String permission : thisProfile.getContext().keySet()) {
                 Extension otherProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, permission);
-                if (otherProfile == null) {
+                if (otherProfile == null || otherProfile.isDefault()) {
                     continue;
                 }
-                if (otherProfile.compareTo(thisProfile) < 0) {
+                if (otherProfile.compareTo(thisProfile) <= 0) {
                     warningOccured.toggle();
                     LOG.WARN("Profile '%s' refers to a profile wich is applied ealier than itself ('%s'). "
                              + "Therefore the profiles will not be resolved completely. Fix this by adding priorities.",

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -55,6 +55,8 @@ public class Permissions {
     private static final Log LOG = Log.get("permissions");
 
     private static class Profile {
+        public static final String SECURITY_PROFILES = "security.profiles";
+
         private final String name;
         private final Set<String> permissionsToAdd;
         private final Set<String> permissionsToRemove;
@@ -73,10 +75,10 @@ public class Permissions {
         }
 
         protected boolean validate() {
-            Extension thisProfile = Sirius.getSettings().getExtension("security.profiles", name);
+            Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);
             Monoflop warningOccured = Monoflop.create();
             for (String permission : thisProfile.getContext().keySet()) {
-                Extension otherProfile = Sirius.getSettings().getExtension("security.profiles", permission);
+                Extension otherProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, permission);
                 if (otherProfile == null) {
                     continue;
                 }
@@ -127,7 +129,7 @@ public class Permissions {
     private static void loadProfiles() {
         List<Profile> profiles = new ArrayList<>();
 
-        for (Extension ext : Sirius.getSettings().getExtensions("security.profiles")) {
+        for (Extension ext : Sirius.getSettings().getExtensions(Profile.SECURITY_PROFILES)) {
             Profile profile = Profile.compile(ext);
             profiles.add(profile);
             profile.validate();

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -82,7 +82,7 @@ public class Permissions {
                 }
                 if (otherProfile.compareTo(thisProfile) <= 0) {
                     throw new Exception(Strings.apply(
-                            "Profile '%s' refers to a profile wich is applied ealier than itself ('%s'). "
+                            "Profile '%s' refers to a profile which is applied earlier than itself ('%s'). "
                             + "Therefore the profiles will not be resolved completely. Fix this by adding priorities.",
                             thisProfile.getId(),
                             otherProfile.getId()));

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -1,0 +1,97 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.security;
+
+import sirius.kernel.Sirius;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.settings.Extension;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents a profile defined in <tt>security.profiles</tt>.
+ */
+public class Profile {
+    public static final String SECURITY_PROFILES = "security.profiles";
+
+    private final String name;
+    private final Set<String> permissionsToAdd;
+    private final Set<String> permissionsToRemove;
+
+    /**
+     * Create a Profile with the given name, permissions this profiles adds and permissions this profile removes.
+     *
+     * @param name                the name of the profile
+     * @param permissionsToAdd    permissions this profile adds
+     * @param permissionsToRemove permission this profiles removes
+     */
+    Profile(String name, Set<String> permissionsToAdd, Set<String> permissionsToRemove) {
+        this.name = name;
+        this.permissionsToAdd = new HashSet<>(permissionsToAdd);
+        this.permissionsToRemove = new HashSet<>(permissionsToRemove);
+    }
+
+    /**
+     * Applies the profile to the given set of permissions.
+     *
+     * @param permissions the permissions the profile should be applied to
+     */
+    protected void apply(Set<String> permissions) {
+        if (Permissions.hasPermission(name, permissions::contains)) {
+            permissions.addAll(permissionsToAdd);
+            permissions.removeAll(permissionsToRemove);
+        }
+    }
+
+    /**
+     * Validates this profile and throws exception if problems exist.
+     * <p>
+     * An exception will be thrown if the profile refers to another profile applied earlier than itself.
+     */
+    protected void validate() {
+        Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);
+        for (String permission : thisProfile.getContext().keySet()) {
+            Extension otherProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, permission);
+            if (otherProfile == null || otherProfile.isDefault()) {
+                continue;
+            }
+            if (otherProfile.compareTo(thisProfile) <= 0) {
+                throw new IllegalStateException(Strings.apply(
+                        "Profile '%s' refers to a profile which is applied earlier than itself ('%s'). "
+                        + "Therefore the profiles will not be resolved completely. Fix this by adding priorities.",
+                        thisProfile.getId(),
+                        otherProfile.getId()));
+            }
+        }
+    }
+
+    /**
+     * Compile the given extension into a {@link Profile}.
+     *
+     * @param extension the extension to compile
+     * @return the compiled {@link Profile}
+     */
+    protected static Profile compile(Extension extension) {
+        Set<String> permissionsToAdd = new HashSet<>();
+        Set<String> permissionsToRemove = new HashSet<>();
+
+        for (Map.Entry<String, Object> permission : extension.getContext().entrySet()) {
+            if (Boolean.TRUE.equals(permission.getValue())) {
+                permissionsToAdd.add(permission.getKey());
+            }
+            if (Boolean.FALSE.equals(permission.getValue())) {
+                permissionsToRemove.add(permission.getKey());
+            }
+        }
+
+        return new Profile(extension.getId(), permissionsToAdd, permissionsToRemove);
+    }
+}

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -70,7 +70,8 @@ class Profile {
             if (otherProfile != null && !otherProfile.isDefault() && otherProfile.compareTo(thisProfile) <= 0) {
                 throw new IllegalStateException(Strings.apply(
                         "Profile '%s' refers to a profile which is applied earlier than itself ('%s'). "
-                        + "Therefore the profiles will not be resolved completely. Fix this by adding priorities.",
+                        + "Therefore the profiles will not be resolved completely. Fix this by adding or changing "
+                        + "priorities.",
                         thisProfile.getId(),
                         otherProfile.getId()));
             }

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -67,10 +67,7 @@ class Profile {
         Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);
         for (String permission : thisProfile.getContext().keySet()) {
             Extension otherProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, permission);
-            if (otherProfile == null || otherProfile.isDefault()) {
-                continue;
-            }
-            if (otherProfile.compareTo(thisProfile) <= 0) {
+            if (otherProfile != null && !otherProfile.isDefault() && otherProfile.compareTo(thisProfile) <= 0) {
                 throw new IllegalStateException(Strings.apply(
                         "Profile '%s' refers to a profile which is applied earlier than itself ('%s'). "
                         + "Therefore the profiles will not be resolved completely. Fix this by adding priorities.",

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -61,7 +61,7 @@ class Profile {
     /**
      * Validates this profile and throws exception if problems exist.
      * <p>
-     * An exception will be thrown if the profile refers to another profile applied earlier than itself.
+     * @throws HandledException if the profile refers to another profile applied earlier than itself.
      */
     public void validate() {
         Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -33,7 +33,7 @@ public class Profile {
      * @param permissionsToAdd    permissions this profile adds
      * @param permissionsToRemove permission this profiles removes
      */
-    Profile(String name, Set<String> permissionsToAdd, Set<String> permissionsToRemove) {
+    public Profile(String name, Set<String> permissionsToAdd, Set<String> permissionsToRemove) {
         this.name = name;
         this.permissionsToAdd = new HashSet<>(permissionsToAdd);
         this.permissionsToRemove = new HashSet<>(permissionsToRemove);
@@ -44,7 +44,7 @@ public class Profile {
      *
      * @param permissions the permissions the profile should be applied to
      */
-    protected void apply(Set<String> permissions) {
+    public void apply(Set<String> permissions) {
         if (Permissions.hasPermission(name, permissions::contains)) {
             permissions.addAll(permissionsToAdd);
             permissions.removeAll(permissionsToRemove);
@@ -56,7 +56,7 @@ public class Profile {
      * <p>
      * An exception will be thrown if the profile refers to another profile applied earlier than itself.
      */
-    protected void validate() {
+    public void validate() {
         Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);
         for (String permission : thisProfile.getContext().keySet()) {
             Extension otherProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, permission);
@@ -79,7 +79,7 @@ public class Profile {
      * @param extension the extension to compile
      * @return the compiled {@link Profile}
      */
-    protected static Profile compile(Extension extension) {
+    public static Profile compile(Extension extension) {
         Set<String> permissionsToAdd = new HashSet<>();
         Set<String> permissionsToRemove = new HashSet<>();
 

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -19,7 +19,11 @@ import java.util.Set;
 /**
  * Represents a profile defined in <tt>security.profiles</tt>.
  */
-public class Profile {
+class Profile {
+
+    /**
+     * The key of the profiles-configuration in the '.conf'-files.
+     */
     public static final String SECURITY_PROFILES = "security.profiles";
 
     private final String name;
@@ -27,16 +31,19 @@ public class Profile {
     private final Set<String> permissionsToRemove;
 
     /**
-     * Create a Profile with the given name, permissions this profiles adds and permissions this profile removes.
+     * Creates a Profile with the given name, a set of permissions this profile adds and a set of permissions this
+     * profile removes.
+     * <p>
+     * This method is private, because profiles should be created via the {@link #compile(Extension)}-method.
      *
      * @param name                the name of the profile
      * @param permissionsToAdd    permissions this profile adds
      * @param permissionsToRemove permission this profiles removes
      */
-    public Profile(String name, Set<String> permissionsToAdd, Set<String> permissionsToRemove) {
+    private Profile(String name, Set<String> permissionsToAdd, Set<String> permissionsToRemove) {
         this.name = name;
-        this.permissionsToAdd = new HashSet<>(permissionsToAdd);
-        this.permissionsToRemove = new HashSet<>(permissionsToRemove);
+        this.permissionsToAdd = permissionsToAdd;
+        this.permissionsToRemove = permissionsToRemove;
     }
 
     /**
@@ -74,7 +81,7 @@ public class Profile {
     }
 
     /**
-     * Compile the given extension into a {@link Profile}.
+     * Compiles the given extension into a {@link Profile}.
      *
      * @param extension the extension to compile
      * @return the compiled {@link Profile}

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -61,7 +61,7 @@ class Profile {
     /**
      * Validates this profile and throws exception if problems exist.
      * <p>
-     * @throws HandledException if the profile refers to another profile applied earlier than itself.
+     * @throws IllegalStateException if the profile refers to another profile applied earlier than itself.
      */
     public void validate() {
         Extension thisProfile = Sirius.getSettings().getExtension(SECURITY_PROFILES, name);

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -471,8 +471,13 @@ security {
     # authorized, its permissions which reference profiles will be expanded automatically. This can be used to declare
     # permissions like "admin" which represent a multitude of permissions (which also might change over time).
     #
-    # Profiles are applied in order (sorted by their priority). Note that the name can be a complex
-    # expression string like "permission1+!permission2,permission3"...
+    # Profiles are applied in order (sorted by their priority). You will need to order the profiles in a way, that
+    # profiles referring to other profiles are applied before the profiles they refer to. You will be warned on the
+    # first usage of profiles if the priorities are invalid. See ProfileSpec.groovy for examples.
+    #
+    # Note that the name can be a complex expression string like "permission1+!permission2,permission3".
+    # WARNING: When the name is a complex expression you will NOT be warned about wrong priorities in the profiles!
+    # You need to check the priorities in these cases yourself!
     profiles {
     #    template {
     #        priority : 100

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -9,6 +9,7 @@
 package sirius.web.security
 
 import sirius.kernel.BaseSpecification
+import sirius.kernel.Sirius
 
 import java.util.function.Predicate
 
@@ -16,7 +17,7 @@ class PermissionsSpec extends BaseSpecification {
 
     def "applyProfiles keeps original roles"() {
         when:
-        def roles = new HashSet<String>(["A", "B", "C" ])
+        def roles = new HashSet<String>(["A", "B", "C"])
         and:
         Permissions.applyProfiles(roles)
         then:
@@ -36,6 +37,30 @@ class PermissionsSpec extends BaseSpecification {
         roles.contains("test-A")
         and:
         !roles.contains("test-B")
+    }
+
+    def "profile cascading is invalid when cascading to lower priority"() {
+        when:
+        boolean warning = Permissions.validateProfile(Sirius.getSettings().getExtension("security.profiles",
+                                                                                        "test-cascade-to-target-with-lower-priority"))
+        then:
+        warning == true
+    }
+
+    def "profile cascading is invalid when cascading to equal priority"() {
+        when:
+        boolean warning = Permissions.validateProfile(Sirius.getSettings().getExtension("security.profiles",
+                                                                                        "test-cascade-to-target-with-equal-priority"))
+        then:
+        warning == true
+    }
+
+    def "profile cascading is valid when cascading to higher priority"() {
+        when:
+        boolean warning = Permissions.validateProfile(Sirius.getSettings().getExtension("security.profiles",
+                                                                                        "test-cascade-to-target-with-higher-priority"))
+        then:
+        warning == false
     }
 
     def "test hasPermission"() {

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -41,24 +41,33 @@ class PermissionsSpec extends BaseSpecification {
 
     def "profile cascading is invalid when cascading to lower priority"() {
         when:
-        boolean warning = Permissions.validateProfile(Sirius.getSettings().getExtension("security.profiles",
-                                                                                        "test-cascade-to-target-with-lower-priority"))
+        boolean warning = Permissions
+                .Profile
+                .compile(Sirius.getSettings().getExtension("security.profiles",
+                                                           "test-cascade-to-target-with-lower-priority"))
+                .validate()
         then:
         warning == true
     }
 
     def "profile cascading is invalid when cascading to equal priority"() {
         when:
-        boolean warning = Permissions.validateProfile(Sirius.getSettings().getExtension("security.profiles",
-                                                                                        "test-cascade-to-target-with-equal-priority"))
+        boolean warning = Permissions
+                .Profile
+                .compile(Sirius.getSettings().getExtension("security.profiles",
+                                                           "test-cascade-to-target-with-equal-priority"))
+                .validate()
         then:
         warning == true
     }
 
     def "profile cascading is valid when cascading to higher priority"() {
         when:
-        boolean warning = Permissions.validateProfile(Sirius.getSettings().getExtension("security.profiles",
-                                                                                        "test-cascade-to-target-with-higher-priority"))
+        boolean warning = Permissions
+                .Profile
+                .compile(Sirius.getSettings().getExtension("security.profiles",
+                                                           "test-cascade-to-target-with-higher-priority"))
+                .validate()
         then:
         warning == false
     }

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -48,8 +48,8 @@ class PermissionsSpec extends BaseSpecification {
                 .validate()
         then:
         def e = thrown(Exception)
-        e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile wich is applied " +
-                "ealier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
+        e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile which is applied " +
+                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
                 "this by adding priorities."
     }
 
@@ -62,8 +62,8 @@ class PermissionsSpec extends BaseSpecification {
                 .validate()
         then:
         def e = thrown(Exception)
-        e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile wich is applied " +
-                "ealier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
+        e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile which is applied " +
+                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
                 "this by adding priorities."
     }
 

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -9,7 +9,6 @@
 package sirius.web.security
 
 import sirius.kernel.BaseSpecification
-import sirius.kernel.Sirius
 
 import java.util.function.Predicate
 
@@ -37,45 +36,6 @@ class PermissionsSpec extends BaseSpecification {
         roles.contains("test-A")
         and:
         !roles.contains("test-B")
-    }
-
-    def "profile cascading is invalid when cascading to lower priority"() {
-        when:
-        Permissions
-                .Profile
-                .compile(Sirius.getSettings().getExtension("security.profiles",
-                                                           "test-cascade-to-target-with-lower-priority"))
-                .validate()
-        then:
-        def e = thrown(IllegalStateException)
-        e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile which is applied " +
-                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
-                "this by adding priorities."
-    }
-
-    def "profile cascading is invalid when cascading to equal priority"() {
-        when:
-        Permissions
-                .Profile
-                .compile(Sirius.getSettings().getExtension("security.profiles",
-                                                           "test-cascade-to-target-with-equal-priority"))
-                .validate()
-        then:
-        def e = thrown(IllegalStateException)
-        e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile which is applied " +
-                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
-                "this by adding priorities."
-    }
-
-    def "profile cascading is valid when cascading to higher priority"() {
-        when:
-        Permissions
-                .Profile
-                .compile(Sirius.getSettings().getExtension("security.profiles",
-                                                           "test-cascade-to-target-with-higher-priority"))
-                .validate()
-        then:
-        noExceptionThrown()
     }
 
     def "test hasPermission"() {

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -47,7 +47,7 @@ class PermissionsSpec extends BaseSpecification {
                                                            "test-cascade-to-target-with-lower-priority"))
                 .validate()
         then:
-        def e = thrown(Exception)
+        def e = thrown(IllegalStateException)
         e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile which is applied " +
                 "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
                 "this by adding priorities."
@@ -61,7 +61,7 @@ class PermissionsSpec extends BaseSpecification {
                                                            "test-cascade-to-target-with-equal-priority"))
                 .validate()
         then:
-        def e = thrown(Exception)
+        def e = thrown(IllegalStateException)
         e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile which is applied " +
                 "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
                 "this by adding priorities."

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -41,35 +41,41 @@ class PermissionsSpec extends BaseSpecification {
 
     def "profile cascading is invalid when cascading to lower priority"() {
         when:
-        boolean warning = Permissions
+        Permissions
                 .Profile
                 .compile(Sirius.getSettings().getExtension("security.profiles",
                                                            "test-cascade-to-target-with-lower-priority"))
                 .validate()
         then:
-        warning == true
+        def e = thrown(Exception)
+        e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile wich is applied " +
+                "ealier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
+                "this by adding priorities."
     }
 
     def "profile cascading is invalid when cascading to equal priority"() {
         when:
-        boolean warning = Permissions
+        Permissions
                 .Profile
                 .compile(Sirius.getSettings().getExtension("security.profiles",
                                                            "test-cascade-to-target-with-equal-priority"))
                 .validate()
         then:
-        warning == true
+        def e = thrown(Exception)
+        e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile wich is applied " +
+                "ealier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
+                "this by adding priorities."
     }
 
     def "profile cascading is valid when cascading to higher priority"() {
         when:
-        boolean warning = Permissions
+        Permissions
                 .Profile
                 .compile(Sirius.getSettings().getExtension("security.profiles",
                                                            "test-cascade-to-target-with-higher-priority"))
                 .validate()
         then:
-        warning == false
+        noExceptionThrown()
     }
 
     def "test hasPermission"() {

--- a/src/test/java/sirius/web/security/ProfileSpec.groovy
+++ b/src/test/java/sirius/web/security/ProfileSpec.groovy
@@ -12,7 +12,7 @@ import sirius.kernel.BaseSpecification
 import sirius.kernel.Sirius
 import sirius.kernel.commons.Strings
 
-class ProfileTest extends BaseSpecification {
+class ProfileSpec extends BaseSpecification {
 
     def "profile cascading is invalid when cascading to lower priority"() {
         when:

--- a/src/test/java/sirius/web/security/ProfileTest.groovy
+++ b/src/test/java/sirius/web/security/ProfileTest.groovy
@@ -10,6 +10,7 @@ package sirius.web.security
 
 import sirius.kernel.BaseSpecification
 import sirius.kernel.Sirius
+import sirius.kernel.commons.Strings
 
 class ProfileTest extends BaseSpecification {
 
@@ -20,9 +21,7 @@ class ProfileTest extends BaseSpecification {
                .validate()
         then:
         def e = thrown(IllegalStateException)
-        e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile which is applied " +
-                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
-                "this by adding priorities."
+        e.getMessage() == createErrorMessage("test-cascade-to-target-with-lower-priority", "cascade-target")
     }
 
     def "profile cascading is invalid when cascading to equal priority"() {
@@ -32,9 +31,7 @@ class ProfileTest extends BaseSpecification {
                .validate()
         then:
         def e = thrown(IllegalStateException)
-        e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile which is applied " +
-                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
-                "this by adding priorities."
+        e.getMessage() == createErrorMessage("test-cascade-to-target-with-equal-priority", "cascade-target")
     }
 
     def "profile cascading is valid when cascading to higher priority"() {
@@ -44,5 +41,12 @@ class ProfileTest extends BaseSpecification {
                .validate()
         then:
         noExceptionThrown()
+    }
+
+    def createErrorMessage(profile1, profile2) {
+        return Strings.apply(
+                "Profile '%s' refers to a profile which is applied " +
+                        "earlier than itself ('%s'). Therefore the profiles will not be resolved completely. Fix " +
+                        "this by adding or changing priorities.", profile1, profile2)
     }
 }

--- a/src/test/java/sirius/web/security/ProfileTest.groovy
+++ b/src/test/java/sirius/web/security/ProfileTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.security
+
+import sirius.kernel.BaseSpecification
+import sirius.kernel.Sirius
+
+class ProfileTest extends BaseSpecification {
+
+    def "profile cascading is invalid when cascading to lower priority"() {
+        when:
+        Profile.compile(Sirius.getSettings().getExtension("security.profiles",
+                                                          "test-cascade-to-target-with-lower-priority"))
+               .validate()
+        then:
+        def e = thrown(IllegalStateException)
+        e.getMessage() == "Profile 'test-cascade-to-target-with-lower-priority' refers to a profile which is applied " +
+                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
+                "this by adding priorities."
+    }
+
+    def "profile cascading is invalid when cascading to equal priority"() {
+        when:
+        Profile.compile(Sirius.getSettings().getExtension("security.profiles",
+                                                          "test-cascade-to-target-with-equal-priority"))
+               .validate()
+        then:
+        def e = thrown(IllegalStateException)
+        e.getMessage() == "Profile 'test-cascade-to-target-with-equal-priority' refers to a profile which is applied " +
+                "earlier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix " +
+                "this by adding priorities."
+    }
+
+    def "profile cascading is valid when cascading to higher priority"() {
+        when:
+        Profile.compile(Sirius.getSettings().getExtension("security.profiles",
+                                                          "test-cascade-to-target-with-higher-priority"))
+               .validate()
+        then:
+        noExceptionThrown()
+    }
+}

--- a/src/test/resources/component-test-web.conf
+++ b/src/test/resources/component-test-web.conf
@@ -25,6 +25,25 @@ security {
             "test-A" : true,
             "test-B" : false
         }
+
+        cascade-target {
+            priority = 50
+        }
+
+        test-cascade-to-target-with-lower-priority {
+            priority: 55
+            cascade-target: true
+        }
+
+        test-cascade-to-target-with-equal-priority {
+            priority: 50
+            cascade-target: true
+        }
+
+        test-cascade-to-target-with-higher-priority {
+            priority: 45
+            cascade-target: true
+        }
     }
 
 }


### PR DESCRIPTION
... in which profiles are applied.

```
14:01:18.926 WARN  [main|20ms] permissions - Profile 'test-cascade-to-target-with-equal-priority' refers to a profile wich is applied ealier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix this by adding priorities.
14:01:18.928 WARN  [main|22ms] permissions - Profile 'test-cascade-to-target-with-lower-priority' refers to a profile wich is applied ealier than itself ('cascade-target'). Therefore the profiles will not be resolved completely. Fix this by adding priorities.