### PR TITLE
Fix autosizing for cells in streaming ExcelExports

### DIFF
--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -25,6 +25,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.WorkbookUtil;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
@@ -209,6 +210,9 @@ public class ExcelExport {
             currentSheet = workbook.createSheet(WorkbookUtil.createSafeSheetName(name));
         } else {
             currentSheet = workbook.createSheet();
+        }
+        if (currentSheet instanceof SXSSFSheet) {
+            ((SXSSFSheet) currentSheet).trackAllColumnsForAutoSizing();
         }
         currentSheet.createFreezePane(0, 1, 0, 1);
         PrintSetup ps = currentSheet.getPrintSetup();

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -211,9 +211,6 @@ public class ExcelExport {
         } else {
             currentSheet = workbook.createSheet();
         }
-        if (currentSheet instanceof SXSSFSheet) {
-            ((SXSSFSheet) currentSheet).trackAllColumnsForAutoSizing();
-        }
         currentSheet.createFreezePane(0, 1, 0, 1);
         PrintSetup ps = currentSheet.getPrintSetup();
         ps.setPaperSize(PrintSetup.A4_PAPERSIZE);
@@ -465,6 +462,10 @@ public class ExcelExport {
     }
 
     private void autosizeColumns() {
+        if (currentSheet instanceof SXSSFSheet) {
+            // we do not want to autosize columns of streamed excel sheets, because of performance reasons
+            return;
+        }
         for (short col = 0; col < maxCols; col++) {
             // Don't distort images
             if (!pictureCols.contains(col)) {

--- a/src/test/java/sirius/web/data/ExcelExportTest.groovy
+++ b/src/test/java/sirius/web/data/ExcelExportTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.data
+
+import sirius.kernel.BaseSpecification
+import sirius.kernel.commons.Files
+
+class ExcelExportSpec extends BaseSpecification {
+
+    def "create simple excel sheet"() {
+        given:
+        File testFile = File.createTempFile("excel-output", ".xlsx")
+        when:
+        ExcelExport export = ExcelExport.asStandardXLSX()
+        export.addRow("A-1", "B-1", "C-1")
+        export.addRowAsList(["A-2", "B-2", "C-2"] as ArrayList)
+        export.writeToStream(new FileOutputStream(testFile))
+        then:
+        def expectLineNum = 1
+        def expectedRow = [["A-1", "B-1", "C-1"], ["A-2", "B-2", "C-2"]]
+        LineBasedProcessor.create(testFile.getName(), new FileInputStream(testFile))
+                          .run({
+                                   lineNum, row ->
+                                       assert lineNum == expectLineNum++
+                                       assert row.asList() == expectedRow[lineNum - 1]
+                               },
+                               { e -> false })
+        cleanup:
+        Files.delete(testFile)
+    }
+
+    def "create simple streaming excel sheet"() {
+        given:
+        File testFile = File.createTempFile("excel-output", ".xlsx")
+        when:
+        ExcelExport export = ExcelExport.asStreamingXLSX()
+        export.addRow("A-1", "B-1", "C-1")
+        export.addRowAsList(["A-2", "B-2", "C-2"] as ArrayList)
+        export.writeToStream(new FileOutputStream(testFile))
+        then:
+        def expectLineNum = 1
+        def expectedRow = [["A-1", "B-1", "C-1"], ["A-2", "B-2", "C-2"]]
+        LineBasedProcessor.create(testFile.getName(), new FileInputStream(testFile))
+                          .run({
+                                   lineNum, row ->
+                                       assert lineNum == expectLineNum++
+                                       assert row.asList() == expectedRow[lineNum - 1]
+                               },
+                               { e -> false })
+        cleanup:
+        Files.delete(testFile)
+    }
+}


### PR DESCRIPTION
With the new Version of Apache-POI column-widths must be explicitly tracked if you want to be able to call "Sheet#autoSizeColumn(int column)" (like in ExcelExport#autosizeColumns)