### PR TITLE
Creates only an error message if the login was not successful

### DIFF
--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -126,16 +126,18 @@ public abstract class GenericUserManager implements UserManager {
                 onLogin(ctx, result);
                 return result;
             }
+
+            result = loginViaSSOToken(ctx);
+            if (result != null) {
+                onLogin(ctx, result);
+                return result;
+            }
+
+            UserContext.message(Message.error(NLS.get("GenericUserManager.invalidLogin")));
         } catch (HandledException e) {
             UserContext.message(Message.error(e.getMessage()));
         } catch (Exception e) {
             UserContext.message(Message.error(Exceptions.handle(UserContext.LOG, e)));
-        }
-
-        result = loginViaSSOToken(ctx);
-        if (result != null) {
-            onLogin(ctx, result);
-            return result;
         }
 
         return defaultUser;
@@ -358,7 +360,6 @@ public abstract class GenericUserManager implements UserManager {
                 return result;
             }
             log("Login of %s failed using password", user);
-            UserContext.message(Message.error(NLS.get("GenericUserManager.invalidLogin")));
         }
         return null;
     }


### PR DESCRIPTION
Because we always to try to login with our user credentials and which will fail for an sso token
we always created an error message.

This change will only show the error message if neither the credentials login and the sso login were
successful
- Fixes: SE-8976