### PR TITLE
Fix bug in createSheet method when max number of rows is reached

### DIFF
--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -205,7 +205,7 @@ public class ExcelExport {
     public void createSheet(@Nullable String name) {
         if (currentSheet != null) {
             autosizeColumns();
-            currentSheet.setAutoFilter(new CellRangeAddress(0, rows, 0, maxCols - 1));
+            addAutoFilter();
             rows = 0;
             maxCols = 0;
         }
@@ -436,9 +436,8 @@ public class ExcelExport {
             maxRowsReachedHandler.accept(currentSheet.getSheetName());
         }
         if (Strings.isFilled(determineMaxRowsReachedMessage())) {
-            Row r = currentSheet.createRow(rows);
+            Row r = currentSheet.createRow(rows++);
             addCell(r, determineMaxRowsReachedMessage(), 0, normalStyle);
-            rows++;
             return true;
         }
         return false;
@@ -491,7 +490,8 @@ public class ExcelExport {
                 autosizeColumns();
 
                 // Add autofilter...
-                currentSheet.setAutoFilter(new CellRangeAddress(0, rows - 1, 0, maxCols - 1));
+                addAutoFilter();
+
                 workbook.write(out);
             }
         } catch (IOException e) {
@@ -501,6 +501,10 @@ public class ExcelExport {
                 ((SXSSFWorkbook) workbook).dispose();
             }
         }
+    }
+
+    private void addAutoFilter() {
+        currentSheet.setAutoFilter(new CellRangeAddress(0, rows - 1, 0, maxCols - 1));
     }
 
     private void autosizeColumns() {

--- a/src/test/java/sirius/web/data/ExcelExportSpec.groovy
+++ b/src/test/java/sirius/web/data/ExcelExportSpec.groovy
@@ -182,4 +182,23 @@ class ExcelExportSpec extends BaseSpecification {
         cleanup:
         Files.delete(testFile)
     }
+
+    @Scope(Scope.SCOPE_NIGHTLY)
+    def "creation of new work sheet works correctly when max number of rows is reached in the current sheet"() {
+        given:
+        File testFile = File.createTempFile("excel-output", ".xls")
+        when:
+        ExcelExport export = ExcelExport.asStreamingXLSX()
+        // overshoot the max num of rows a little for testing purposes
+        for (int i = 1; i <= XLSX_MAX_ROWS + 100; i++) {
+            export.addRow("A-" + i)
+        }
+        export.createSheet("Sheet1")
+        export.addRow("A row on Sheet1")
+        export.writeToStream(new FileOutputStream(testFile))
+        then:
+        noExceptionThrown()
+        cleanup:
+        Files.delete(testFile)
+    }
 }


### PR DESCRIPTION
"rows" was incremented, so it's not a valid row number for sheets which exeeded the row limit. This throws an exception when adding an auto-filter