### PR TITLE
Does not log an invalid CSRF token into the system log.

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1552,7 +1552,7 @@ public class WebContext implements SubContext {
         }
 
         if (!checkCSRFToken()) {
-            throw Exceptions.handle().to(WebServer.LOG).withNLSKey("WebContext.invalidCSRFToken").handle();
+            throw Exceptions.createHandled().withNLSKey("WebContext.invalidCSRFToken").handle();
         }
 
         return true;


### PR DESCRIPTION
The intention was to log this as this might be a security
breach / attempt. However, it turned out that in most of the cases,
the user just used multiple tabs or did other wired stuff with their
browser - therefore there is no need to jam the system log with these
messages.

Fixes: SIRI-81