### PR TITLE
Outputs the proper row counter after processing a file.

### DIFF
--- a/src/main/java/sirius/web/data/CSVProcessor.java
+++ b/src/main/java/sirius/web/data/CSVProcessor.java
@@ -51,5 +51,9 @@ public class CSVProcessor implements LineBasedProcessor {
                 }
             }
         });
+
+        if (tc.isActive() && rowCounter.get() > 0) {
+            tc.setState(NLS.get("LineBasedProcessor.linesProcessed"), rowCounter.get());
+        }
     }
 }

--- a/src/main/java/sirius/web/data/XLSProcessor.java
+++ b/src/main/java/sirius/web/data/XLSProcessor.java
@@ -77,6 +77,10 @@ public class XLSProcessor implements LineBasedProcessor {
                 }
             }
         }
+
+        if (tc.isActive() && current > 0) {
+            tc.setState(NLS.get("LineBasedProcessor.linesProcessed"), current);
+        }
     }
 
     private short getLastFilledCell(Row row) {


### PR DESCRIPTION
Ensures that after a file has been fully read, a final state
with the proper row count is emitted. As while processing,
the state update is frequency limited, this might end with
an invalid count which might confuse a user.

Fixes: SIRI-126