### PR TITLE
Adds a optional js parameter to restrict image upload box to a single file

### DIFF
--- a/src/main/resources/default/taglib/w/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/imageUpload.html.pasta
@@ -3,6 +3,7 @@
 <i:arg type="String" name="imageUrl" default="" />
 <i:arg type="String" name="previewUrl" default="@imageUrl" />
 <i:arg type="String" name="allowedExtensions" default="'[]'" />
+<i:arg type="boolean" name="singleFile" default="false" />
 
 <i:pragma name="description" value="Renders an image upload within a Wondergem template" />
 
@@ -14,7 +15,8 @@
                 this,
                 '@previewUrl',
                 '@imageUrl',
-                 <i:raw>@allowedExtensions</i:raw>
+                 <i:raw>@allowedExtensions</i:raw>,
+                @singleFile
         );
         });
     });

--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -148,11 +148,12 @@
         return params;
     }
 
-    function imageUpload(url, target, defaultPreview, defaultImage, allowedExtensions) {
+    function imageUpload(url, target, defaultPreview, defaultImage, allowedExtensions, singleFile) {
         var container = target;
         new qq.FileUploader({
             element: target,
             action: url,
+            multiple: !singleFile,
             debug: false,
             onComplete: function (cmp_id, fileName, responseJSON) {
                 clearMessages();


### PR DESCRIPTION
Using this, the file picker window will only allow to select a single file and when dropping multiple files into the upload area only the first file is uploaded.

The default behaviour when this parameter is not given is NOT changed.

Fixes: OX-5358