### PR TITLE
Only tries to create auto-filters if at least one row is present.

### DIFF
--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -504,7 +504,9 @@ public class ExcelExport {
     }
 
     private void addAutoFilter() {
-        currentSheet.setAutoFilter(new CellRangeAddress(0, rows - 1, 0, maxCols - 1));
+        if (rows > 0 && maxCols > 0) {
+            currentSheet.setAutoFilter(new CellRangeAddress(0, rows - 1, 0, maxCols - 1));
+        }
     }
 
     private void autosizeColumns() {


### PR DESCRIPTION
If a completely empty file is created, we must not attempt to
specify a range for the autofilters as these would result in a
"negative" range.