### PR TITLE
Adds support for propagating generic types down a call chain.

### DIFF
--- a/src/main/java/sirius/tagliatelle/compiler/Parser.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Parser.java
@@ -449,6 +449,11 @@ class Parser extends InputProcessor {
             Class<?> type = (Class<?>) parameters.get(0).eval(null);
             if (Transformable.class.isAssignableFrom(self.getType())) {
                 return new TransformerCast(self, type);
+            }
+
+            if (type.isAssignableFrom(self.getType())) {
+                context.warning(reader.current(), "Ignoring unnecessary cast from %s to %s", self.getType(), type);
+                return self;
             } else {
                 return new NativeCast(self, type);
             }

--- a/src/main/java/sirius/tagliatelle/expression/Expression.java
+++ b/src/main/java/sirius/tagliatelle/expression/Expression.java
@@ -10,6 +10,10 @@ package sirius.tagliatelle.expression;
 
 import sirius.tagliatelle.rendering.LocalRenderContext;
 
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
 /**
  * Represents a node of the expression AST.
  */
@@ -58,4 +62,17 @@ public interface Expression {
      * @return the type of objects created by this expression
      */
     Class<?> getType();
+
+    /**
+     * Returns the generic type if available.
+     * <p>
+     * This can be used when trying to deduce the actual type from a type variable. This is
+     * the counterpart to {@link Method#getGenericReturnType()}.
+     *
+     * @return the generic return type or <tt>null</tt> if none is available
+     */
+    @Nullable
+    default Type getGenericType() {
+        return null;
+    }
 }

--- a/src/main/java/sirius/tagliatelle/expression/MethodCall.java
+++ b/src/main/java/sirius/tagliatelle/expression/MethodCall.java
@@ -233,6 +233,7 @@ public class MethodCall extends Call {
         if (parameterExpressions == NO_ARGS) {
             try {
                 this.method = selfExpression.getType().getMethod(name);
+                checkDeprecation(position, context);
                 return;
             } catch (NoSuchMethodException e) {
                 Exceptions.ignore(e);

--- a/src/main/java/sirius/tagliatelle/expression/TenaryOperation.java
+++ b/src/main/java/sirius/tagliatelle/expression/TenaryOperation.java
@@ -10,6 +10,9 @@ package sirius.tagliatelle.expression;
 
 import sirius.tagliatelle.rendering.LocalRenderContext;
 
+import javax.annotation.Nullable;
+import java.lang.reflect.Type;
+
 /**
  * Represents a tenary operation liek {@code condition ? expr : expr}.
  * <p>
@@ -85,5 +88,11 @@ public class TenaryOperation implements Expression {
     @Override
     public Class<?> getType() {
         return leftExpression.getType();
+    }
+
+    @Nullable
+    @Override
+    public Type getGenericType() {
+        return leftExpression.getGenericType();
     }
 }

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -281,10 +281,9 @@ class CompilerSpec extends BaseSpecification {
         then:
         errors.size() == 1
         errors.get(0).getSeverity() == ParseError.Severity.WARNING
-        errors.
-                get(0).
-                getMessage().
-                contains("The method sirius.tagliatelle.TestObject.deprecatedMethod is marked as deprecated")
+        errors.get(0)
+              .getMessage()
+              .contains("The method sirius.tagliatelle.TestObject.deprecatedMethod is marked as deprecated")
     }
 
     def "calling a deprecated macro is detected"() {

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -293,10 +293,9 @@ class CompilerSpec extends BaseSpecification {
         then:
         errors.size() == 1
         errors.get(0).getSeverity() == ParseError.Severity.WARNING
-        errors.
-                get(0).
-                getMessage().
-                contains("The macro deprecatedMacro (sirius.tagliatelle.DeprecatedMacro) is deprecated.")
+        errors.get(0)
+              .getMessage()
+              .contains("The macro deprecatedMacro (sirius.tagliatelle.DeprecatedMacro) is deprecated.")
     }
 
     def "invalid varargs are detected"() {
@@ -310,10 +309,10 @@ class CompilerSpec extends BaseSpecification {
         then:
         errors.size() == 2
         errors.get(0).getError().getSeverity() == ParseError.Severity.ERROR
-        errors.get(0).
-                toString().
-                contains(
-                        "Incompatible attribute types. e:invalidArgumentTaglib expects int for 'invalidArgument', but class java.lang.String was given.")
+        errors.get(0)
+              .toString()
+              .contains(
+                      "Incompatible attribute types. e:invalidArgumentTaglib expects int for 'invalidArgument', but class java.lang.String was given.")
         !errors.get(1).toString().contains("NullPointerException")
     }
 

--- a/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/tagliatelle/CompilerSpec.groovy
@@ -94,6 +94,19 @@ class CompilerSpec extends BaseSpecification {
         ctx.getTemplate().renderToString(TestObject.INSTANCE, Amount.TEN) == "-10"
     }
 
+    def "generic type propagation works"() {
+        when:
+        def ctx = new CompilationContext(new Template("test", null), null)
+        List<CompileError> errors = new Compiler(ctx, "<i:arg type=\"sirius.tagliatelle.TestObject\" name=\"test\" />" +
+                "@test.getGenericReturnType().getFirst().apply('Test').get().as(String.class).substring(1)").compile()
+        then:
+        errors.size() == 1
+        and: "We expect a warning as our cast to String is now unnecessary due to proper generic propagation"
+        errors.get(0).getError().getSeverity() == ParseError.Severity.WARNING
+        and:
+        ctx.getTemplate().renderToString(TestObject.INSTANCE) == "est"
+    }
+
     def "vararg detection works with several parameters"() {
         when:
         def ctx = new CompilationContext(new Template("test", null), null)
@@ -268,7 +281,10 @@ class CompilerSpec extends BaseSpecification {
         then:
         errors.size() == 1
         errors.get(0).getSeverity() == ParseError.Severity.WARNING
-        errors.get(0).getMessage().contains("The method sirius.tagliatelle.TestObject.deprecatedMethod is marked as deprecated")
+        errors.
+                get(0).
+                getMessage().
+                contains("The method sirius.tagliatelle.TestObject.deprecatedMethod is marked as deprecated")
     }
 
     def "calling a deprecated macro is detected"() {
@@ -278,7 +294,10 @@ class CompilerSpec extends BaseSpecification {
         then:
         errors.size() == 1
         errors.get(0).getSeverity() == ParseError.Severity.WARNING
-        errors.get(0).getMessage().contains("The macro deprecatedMacro (sirius.tagliatelle.DeprecatedMacro) is deprecated.")
+        errors.
+                get(0).
+                getMessage().
+                contains("The macro deprecatedMacro (sirius.tagliatelle.DeprecatedMacro) is deprecated.")
     }
 
     def "invalid varargs are detected"() {

--- a/src/test/java/sirius/tagliatelle/TestObject.java
+++ b/src/test/java/sirius/tagliatelle/TestObject.java
@@ -9,13 +9,21 @@
 package sirius.tagliatelle;
 
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
+import sirius.kernel.commons.ValueHolder;
+
+import java.util.function.Function;
 
 /**
- * Used to test vararg methods and method overloading with generics
+ * Used to test various scenarios regarding generics etc.
  */
 public class TestObject extends GenericTestObject<String> {
 
     public static final TestObject INSTANCE = new TestObject();
+
+    public Tuple<Function<String, ValueHolder<String>>, Integer> getGenericReturnType() {
+        return Tuple.create(s -> new ValueHolder<>(s), 1);
+    }
 
     public String varArgTest(String input, Object... params) {
         return Strings.apply(input, params);


### PR DESCRIPTION
Especially for entities which have a reference like
`SQLEntityRef<OtherEntity> ref`;

Tagliatelle now knows that `entity.getRef().fetchValue()` is of type
`OtherEntity`.