### PR TITLE
Adds a new tag handler and an error message for a common pitfall.

### DIFF
--- a/src/main/java/sirius/tagliatelle/tags/BlockTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/BlockTag.java
@@ -65,15 +65,15 @@ public class BlockTag extends TagHandler {
             getCompilationContext().error(getStartOfTag(), "The attribute name of i:block must be filled.", name);
             return;
         }
+
+        Emitter body = getBlock(BLOCK_BODY);
         if (getParentHandler() != null) {
-            Emitter body = getBlock(BLOCK_BODY);
             if (body != null) {
                 getParentHandler().addBlock(name, body);
             } else {
                 getParentHandler().addBlock(name, ConstantEmitter.EMPTY);
             }
         } else {
-            Emitter body = getBlock(BLOCK_BODY);
             if (body != null) {
                 targetBlock.addChild(new ExtraBlockEmitter(name, body));
             }

--- a/src/main/java/sirius/tagliatelle/tags/ExtraBlockTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/ExtraBlockTag.java
@@ -1,0 +1,89 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.tagliatelle.tags;
+
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Register;
+import sirius.tagliatelle.TemplateArgument;
+import sirius.tagliatelle.emitter.CompositeEmitter;
+import sirius.tagliatelle.emitter.Emitter;
+import sirius.tagliatelle.emitter.ExtraBlockEmitter;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Permits to add an extra block to the global render context.
+ * <p>
+ * This is a kind of a special tag which permits that its body is added as extra block to the current global
+ * render context. Normally all {@link BlockTag blocks} defined at the top-level of the root template
+ * are added as extra block. However, using this block, an inner template (e.g. a tag being invoked) can
+ * also supply data into an extra block.
+ *
+ * @see sirius.tagliatelle.rendering.GlobalRenderContext#storeExtraBlock(String, String)
+ */
+public class ExtraBlockTag extends TagHandler {
+
+    private static final String PARAM_NAME = "name";
+    private static final String BLOCK_BODY = "body";
+
+    /**
+     * Creates new tags of the given type (name).
+     */
+    @Register
+    public static class Factory implements TagHandlerFactory {
+
+        @Nonnull
+        @Override
+        public String getName() {
+            return "i:extraBlock";
+        }
+
+        @Override
+        public TagHandler createHandler() {
+            return new ExtraBlockTag();
+        }
+
+        @Override
+        public List<TemplateArgument> reportArguments() {
+            return Collections.singletonList(new TemplateArgument(String.class,
+                                                                  PARAM_NAME,
+                                                                  "Contains the name of the provided block"));
+        }
+
+        @Override
+        public String getDescription() {
+            return "Declares an extra block which is directly made available to the GlobalRenderContext";
+        }
+    }
+
+    @Override
+    public void apply(CompositeEmitter targetBlock) {
+        String name = getConstantAttribute(PARAM_NAME).asString();
+        if (Strings.isEmpty(name)) {
+            getCompilationContext().error(getStartOfTag(), "The attribute name of i:extraBlock must be filled.", name);
+            return;
+        }
+
+        Emitter body = getBlock(BLOCK_BODY);
+        if (body != null) {
+            targetBlock.addChild(new ExtraBlockEmitter(name, body));
+        }
+    }
+
+    @Override
+    public Class<?> getExpectedAttributeType(String name) {
+        if (PARAM_NAME.equals(name)) {
+            return String.class;
+        }
+
+        return super.getExpectedAttributeType(name);
+    }
+}

--- a/src/main/java/sirius/tagliatelle/tags/RenderTag.java
+++ b/src/main/java/sirius/tagliatelle/tags/RenderTag.java
@@ -8,6 +8,7 @@
 
 package sirius.tagliatelle.tags;
 
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.tagliatelle.TemplateArgument;
 import sirius.tagliatelle.emitter.BlockEmitter;
@@ -56,6 +57,15 @@ public class RenderTag extends TagHandler {
 
     @Override
     public void apply(CompositeEmitter targetBlock) {
+        String name = getConstantAttribute(PARAM_NAME).asString();
+        if (Strings.isEmpty(name)) {
+            getCompilationContext().error(getStartOfTag(),
+                                          "The attribute name of i:render must be filled."
+                                          + " Use 'body' to refer to the default block defined when invoking a tag.",
+                                          name);
+            return;
+        }
+
         targetBlock.addChild(new BlockEmitter(getStartOfTag(),
                                               getConstantAttribute(PARAM_NAME).asString(),
                                               getBlock("body")));


### PR DESCRIPTION
We have now support for `<i:extraBlock>` which directly puts an extra block into the GlobalRenderContext.

Also `<i:render />` is now detected as NOOP and an error is reported suggesting to use
`<i:render name=body" />` - which is most probably what the user wanted.