### PR TITLE
Installs a circuit breaker.

### DIFF
--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -234,7 +234,7 @@ public class UserContext implements SubContext {
             return Optional.of(currentUser);
         }
 
-        // As this mehtod might be called concurrently (e.g. by the deferred language installer of the WebServerHandler),
+        // As this method might be called concurrently (e.g. by the deferred language installer of the WebServerHandler),
         // we also have to abort if we're already within a user lookup....
         if (fetchingCurrentUser) {
             return Optional.empty();

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -234,6 +234,12 @@ public class UserContext implements SubContext {
             return Optional.of(currentUser);
         }
 
+        // As this mehtod might be called concurrently (e.g. by the deferred language installer of the WebServerHandler),
+        // we also have to abort if we're already within a user lookup....
+        if (fetchingCurrentUser) {
+            return Optional.empty();
+        }
+
         UserManager manager = getUserManager();
         UserInfo user = manager.findUserForRequest(ctx);
         if (user.isLoggedIn()) {


### PR DESCRIPTION
When trying to invoke bindUserIfPresent(WebContext) while we're
already resolving the current user, we must abort to prevent an
endless recursion.

This happened in SellSite where we tried to obtain a database,
which in its constructor created a formatter, which in turn detected
the current language which then eventually invoked this method
when then again tried to resolve the current user, ending up trying
to obtain the same database again.

As databases are kept as ConcurrentHashMap, re-entering computeIfAbsent()
runs into an endless recursion.