### PR TITLE
Permits to attach completion callbacks in WebContexts.

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -135,7 +135,7 @@ public class Response {
     private HttpHeaders headers;
 
     /*
-     * Stores the the effective response code.
+     * Stores the effective response code.
      */
     private volatile int responseCode;
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -135,6 +135,11 @@ public class Response {
     private HttpHeaders headers;
 
     /*
+     * Stores the the effective response code.
+     */
+    private volatile int responseCode;
+
+    /*
      * Stores the max expiration of this response. A null value indicates to use the defaults suggested
      * by the content creator.
      */
@@ -381,6 +386,7 @@ public class Response {
             wc.contentHandler.exhaust();
         }
 
+        responseCode = response.status().code();
         wc.responseCommitted = true;
         wc.committed = System.currentTimeMillis();
         wc.releaseContentHandler();
@@ -422,6 +428,9 @@ public class Response {
             return;
         }
         wc.responseCompleted = true;
+        if (wc.completionPromise != null) {
+            wc.completionPromise.success(responseCode);
+        }
         if (WebServer.LOG.isFINE()) {
             WebServer.LOG.FINE("COMPLETING: " + wc.getRequestedURI());
         }

--- a/src/test/java/sirius/web/http/CompletionPromiseTestController.java
+++ b/src/test/java/sirius/web/http/CompletionPromiseTestController.java
@@ -1,0 +1,32 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.HandledException;
+import sirius.web.controller.Controller;
+import sirius.web.controller.Routed;
+
+@Register
+public class CompletionPromiseTestController implements Controller {
+
+    public static int lastPromisedReturnCode = 0;
+
+    @Override
+    public void onError(WebContext ctx, HandledException error) {
+        ctx.respondWith().error(HttpResponseStatus.INTERNAL_SERVER_ERROR, error);
+    }
+
+    @Routed("/test/completion-promise")
+    public void completePromise(WebContext context) {
+        context.getCompletionPromise().onSuccess(code -> lastPromisedReturnCode = code);
+        context.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
+}

--- a/src/test/java/sirius/web/http/TestResponse.java
+++ b/src/test/java/sirius/web/http/TestResponse.java
@@ -257,6 +257,11 @@ public class TestResponse extends Response {
     private void completeResponse() {
         innerCallContext = CallContext.getCurrent();
         responsePromise.success(this);
+        wc.responseCompleted = true;
+
+        if (wc.completionPromise != null) {
+            wc.completionPromise.success(status.code());
+        }
     }
 
     @Override

--- a/src/test/java/sirius/web/http/WebContextSpec.groovy
+++ b/src/test/java/sirius/web/http/WebContextSpec.groovy
@@ -79,6 +79,28 @@ class WebContextSpec extends BaseSpecification {
         "xx, de;q=0.5, en-gb;q=0.7" | "en"
     }
 
+    def "getCompletionPromise() works if a promise has been installed"() {
+        given:
+        CompletionPromiseTestController.lastPromisedReturnCode = 0
+        when:
+        HttpURLConnection c = new URL("http://localhost:9999/test/completion-promise").openConnection()
+        c.setRequestMethod("GET")
+        c.connect()
+        then:
+        c.getResponseCode() == 200
+        and:
+        CompletionPromiseTestController.lastPromisedReturnCode == 200
+    }
+
+    def "getCompletionPromise() works if invoked after completion"() {
+        when:
+        def request = TestRequest.GET("/test?a=a")
+        and:
+        def result = request.execute()
+        then:
+        request.getCompletionPromise().isSuccessful()
+    }
+
     def "setSessionValue works as expected"() {
         when:
         HttpURLConnection c = new URL("http://localhost:9999/test/session-test").openConnection()


### PR DESCRIPTION
Sometimes we want to perform some tasks (i.e. statistics)
if a request was completely handled - this can be used by
attaching handlers on the newly created promise.