### PR TITLE
SE-9538 Allows rendering interleaved 2 of 5 barcodes in PDFs

### DIFF
--- a/src/main/java/sirius/web/templates/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/ImageReplacedElementFactory.java
@@ -223,7 +223,7 @@ class ImageReplacedElementFactory extends ITextReplacedElementFactory {
         if (code instanceof BarcodeInter25) {
             int length = BarcodeInter25.keepNumbers(src).length();
 
-            // Length is unenven and no checksum will be added
+            // Length is uneven and no checksum will be added
             if (length % 2 != 0 && !code.isGenerateChecksum()) {
                 return "0" + src;
             }


### PR DESCRIPTION
The code will be prepended with a 0 to ensure an even number of digits.