### PR TITLE
BREAKING CHANGE: Uses a loop instead of a recursive call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>dev-16.4</sirius.kernel>
+        <sirius.kernel>dev-16.5</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -37,6 +37,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -153,17 +154,17 @@ public class ControllerDispatcher implements WebDispatcher {
     @Override
     @SuppressWarnings("squid:S1698")
     @Explain("We actually can use object identity here as this is a marker object.")
-    public boolean dispatch(WebContext ctx) throws Exception {
+    public DispatchDecision dispatch(WebContext ctx) throws Exception {
         String uri = determineEffectiveURI(ctx);
         for (final Route route : getRoutes()) {
             final List<Object> params = shouldExecute(ctx, uri, route, false);
             if (params != Route.NO_MATCH) {
                 preparePerformRoute(ctx, route, params, null);
-                return true;
+                return DispatchDecision.DONE;
             }
         }
 
-        return false;
+        return DispatchDecision.CONTINUE;
     }
 
     private void performRoute(WebContext ctx, Route route, List<Object> params) {
@@ -357,7 +358,7 @@ public class ControllerDispatcher implements WebDispatcher {
             routes = buildRouter();
         }
 
-        return routes;
+        return Collections.unmodifiableList(routes);
     }
 
     /*

--- a/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
@@ -43,7 +43,7 @@ public class DefaultDispatcher implements WebDispatcher {
     }
 
     @Override
-    public boolean dispatch(WebContext ctx) throws Exception {
+    public DispatchDecision dispatch(WebContext ctx) throws Exception {
         if ("/crossdomain.xml".equals(ctx.getRequestedURI()) && serveCrossdomain) {
             ctx.respondWith()
                .infinitelyCached()
@@ -80,6 +80,6 @@ public class DefaultDispatcher implements WebDispatcher {
                       Strings.apply("No dispatcher found for: %s", ctx.getRequestedURI()));
         }
 
-        return true;
+        return DispatchDecision.DONE;
     }
 }

--- a/src/main/java/sirius/web/http/WebDispatcher.java
+++ b/src/main/java/sirius/web/http/WebDispatcher.java
@@ -90,7 +90,7 @@ public interface WebDispatcher extends Priorized {
      * in order to directly process the uploaded data. A request for which <tt>true</tt> was replied will <b>not</b>
      * be dispatched again once it is complete.
      * <p>
-     * Note thatthis method will be invoked within the event loop of the web-server, therefore absolutely no blocking
+     * Note that this method will be invoked within the event loop of the web-server, therefore absolutely no blocking
      * operations must be performed. However, the returned <tt>Callback</tt> is executed in its own thread and free of
      * any constraints.
      *

--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -73,7 +73,8 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
     private Watch latencyWatch;
     private boolean ssl;
 
-    private DispatcherPipeline pipeline;
+    @Part
+    private static DispatcherPipeline pipeline;
 
     @Part
     private static Firewall firewall;
@@ -605,14 +606,6 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
         }
     }
 
-    private DispatcherPipeline getPipeline() {
-        if (pipeline == null) {
-            pipeline = DispatcherPipeline.create();
-        }
-
-        return pipeline;
-    }
-
     /*
      * Tries to dispatch a POST or PUT request before it is completely received so that the handler can install
      * a ContentHandler to process all incoming data.
@@ -622,7 +615,7 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
             WebServer.LOG.FINE("DISPATCHING: " + currentContext.getRequestedURI());
         }
 
-        return getPipeline().preDispatch(currentContext);
+        return pipeline.preDispatch(currentContext);
     }
 
     /*
@@ -633,7 +626,7 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
             WebServer.LOG.FINE("DISPATCHING: " + currentContext.getRequestedURI());
         }
         dispatched = true;
-        getPipeline().dispatch(currentContext);
+        pipeline.dispatch(currentContext);
         currentRequest = null;
     }
 

--- a/src/main/java/sirius/web/services/ServiceDispatcher.java
+++ b/src/main/java/sirius/web/services/ServiceDispatcher.java
@@ -52,9 +52,9 @@ public class ServiceDispatcher implements WebDispatcher {
     }
 
     @Override
-    public boolean dispatch(final WebContext ctx) throws Exception {
+    public DispatchDecision dispatch(final WebContext ctx) throws Exception {
         if (!ctx.getRequestedURI().startsWith("/service/")) {
-            return false;
+            return DispatchDecision.CONTINUE;
         }
         // The real dispatching is put into its own method to support inlining of this check by the JIT
         return doDispatch(ctx);
@@ -63,15 +63,15 @@ public class ServiceDispatcher implements WebDispatcher {
     /*
      * Actually tries to dispatch the incoming request which starts with /service....
      */
-    private boolean doDispatch(WebContext ctx) {
+    private DispatchDecision doDispatch(WebContext ctx) {
         String uri = ctx.getRequestedURI();
         Tuple<ServiceCall, StructuredService> handler = parsePath(ctx, uri);
         if (handler.getSecond() == null) {
-            return false;
+            return DispatchDecision.CONTINUE;
         }
 
         invokeService(ctx, handler.getFirst(), handler.getSecond());
-        return true;
+        return DispatchDecision.DONE;
     }
 
     private Tuple<ServiceCall, StructuredService> parsePath(WebContext ctx, String uri) {

--- a/src/test/java/sirius/web/dispatch/TestDispatcher.java
+++ b/src/test/java/sirius/web/dispatch/TestDispatcher.java
@@ -26,8 +26,7 @@ public class TestDispatcher implements WebDispatcher {
     }
 
     @Override
-    public void dispatch(WebContext ctx, Consumer<WebContext> startOfPipeline, Consumer<WebContext> nextStage)
-            throws Exception {
+    public DispatchDecision dispatch(WebContext ctx) throws Exception {
         if ("/large-blocking-calls".equalsIgnoreCase(ctx.getRequestedURI())) {
             // See WebServerSepc->"Invoke /large-blocking-calls with GET" to the appropriate test and explanation...
             OutputStream out = ctx.respondWith().outputStream(HttpResponseStatus.OK, "text/plain");
@@ -35,19 +34,14 @@ public class TestDispatcher implements WebDispatcher {
                 out.write("THISISLARGECONTENT".getBytes(Charsets.UTF_8));
             }
             out.close();
-            return;
+            return DispatchDecision.DONE;
         }
         if ("/redispatch".equalsIgnoreCase(ctx.getRequestedURI())) {
             // See WebServerSepc->"Redispatching works" to the appropriate test and explanation...
             ctx.withCustomPath("/service/json/test");
-            startOfPipeline.accept(ctx);
+            return DispatchDecision.RESTART;
         } else {
-            nextStage.accept(ctx);
+            return DispatchDecision.CONTINUE;
         }
-    }
-
-    @Override
-    public boolean dispatch(WebContext ctx) throws Exception {
-        return false;
     }
 }

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -59,6 +59,9 @@ public class TestRequest extends WebContext implements HttpRequest {
     @Part
     private static Resources resources;
 
+    @Part
+    private static DispatcherPipeline pipeline;
+
     private HttpHeaders testHeaders = new DefaultHttpHeaders();
     private String testUri;
     private Map<String, Object> parameters = Context.create();
@@ -67,7 +70,6 @@ public class TestRequest extends WebContext implements HttpRequest {
     private boolean preDispatch;
     private List<Cookie> testCookies = Lists.newArrayList();
     protected Promise<TestResponse> testResponsePromise = new Promise<>();
-    private DispatcherPipeline pipeline;
     private Map<String, String> testSession;
     protected boolean followRedirect = false;
 
@@ -420,10 +422,10 @@ public class TestRequest extends WebContext implements HttpRequest {
 
         CallContext.getCurrent().set(WebContext.class, this);
         try {
-            if (preDispatch && getPipeline().preDispatch(this)) {
+            if (preDispatch && pipeline.preDispatch(this)) {
                 contentHandler.handle(this.content.getByteBuf(), true);
             } else {
-                getPipeline().dispatch(this);
+                pipeline.dispatch(this);
             }
             return testResponsePromise;
         } catch (Exception e) {
@@ -511,14 +513,6 @@ public class TestRequest extends WebContext implements HttpRequest {
         return resources.resolve(resource)
                         .orElseThrow(() -> new IllegalArgumentException("Unknown Resource: " + resource))
                         .openStream();
-    }
-
-    private DispatcherPipeline getPipeline() {
-        if (pipeline == null) {
-            pipeline = DispatcherPipeline.create();
-        }
-
-        return pipeline;
     }
 
     private void setTestSessionValue(String key, Object value) {


### PR DESCRIPTION
This will simplify the internal handling of requests and also significantly reduce the length of the stack traces.