### PR TITLE
do not select whole text if keepInputOnSelect is set

### DIFF
--- a/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
+++ b/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
@@ -225,7 +225,7 @@ var multiSelect = function (args) {
                     tokenfield.clearTokens();
                     // the first focus is necessary so that .val will not create a token
                     // the second focus call will trigger the autocomplete with the correct value set
-                    tokenfield.getTokenfieldInputField().show().focus().val(input.trim()).select().focus();
+                    tokenfield.getTokenfieldInputField().show().focus().val(input.trim()).focus();
                 } else {
                     tokenfield.clearTokens();
                     tokenfield.getTokenfieldInputField().show().focus();


### PR DESCRIPTION
if you want to edit the text in the field but there is more than one word, you had no chance to select only one of them with the mouse. Now you can edit the text without problems

- fixes: SE-9586