### PR TITLE
Read in POI Workbook as stream within XLSProcessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,13 @@
             <version>4.1.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.monitorjbl</groupId>
+            <artifactId>xlsx-streamer</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
+
     </dependencies>
 
 </project>

--- a/src/main/java/sirius/web/data/XLSProcessor.java
+++ b/src/main/java/sirius/web/data/XLSProcessor.java
@@ -8,6 +8,7 @@
 
 package sirius.web.data;
 
+import com.monitorjbl.xlsx.StreamingReader;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
@@ -15,7 +16,6 @@ import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import sirius.kernel.async.TaskContext;
 import sirius.kernel.commons.Doubles;
 import sirius.kernel.commons.RateLimit;
@@ -48,7 +48,7 @@ public class XLSProcessor implements LineBasedProcessor {
 
     @Override
     public void run(RowProcessor rowProcessor, Predicate<Exception> errorHandler) throws Exception {
-        Workbook wb = xslx ? new XSSFWorkbook(input) : new HSSFWorkbook(input);
+        Workbook wb = xslx ? StreamingReader.builder().bufferSize(4096).open(input) : new HSSFWorkbook(input);
         Sheet sheet = wb.getSheetAt(0);
         Iterator<Row> iter = sheet.rowIterator();
         int current = 0;


### PR DESCRIPTION
- former call to XSSFWorkbook constructor with input stream loading the whole thing in memory to provide random cell access which required a large amount of heap space
- now we are streaming the input xlsx file at XLSProcessor where we iterate row-wise anyhow
- unfortunately xls cannot be streamed
