### PR TITLE
Downgrades netty to version without resource leaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.51.Final</version>
+            <version>4.1.49.Final</version>
         </dependency>
 
         <!-- Used to compile SCSS (SASS) files into CSS files -->


### PR DESCRIPTION
We do this to prevent regressions until we find a fix for the ByteBuf resource leaks occurring with the latest netty version.

Fixes: SIRI-252