### PR TITLE
SIRI 227: Make the error reporting for ACE more generic, so it can be re-used

### DIFF
--- a/src/main/java/sirius/tagliatelle/compiler/CompileException.java
+++ b/src/main/java/sirius/tagliatelle/compiler/CompileException.java
@@ -11,7 +11,9 @@ package sirius.tagliatelle.compiler;
 import sirius.tagliatelle.Template;
 import sirius.web.services.JSONStructuredOutput;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Thrown to indicate one or more {@link CompileError compilation errors}.
@@ -62,7 +64,7 @@ public class CompileException extends Exception {
      * @return all errors and warnings which occurred while processing the user input
      */
     public List<CompileError> getErrors() {
-        return errors;
+        return Collections.unmodifiableList(errors);
     }
 
     /**
@@ -80,16 +82,7 @@ public class CompileException extends Exception {
      * @param out the JSON output to write to
      */
     public void reportAsJSON(JSONStructuredOutput out) {
-        out.beginArray("problems");
-        for (CompileError error : getErrors()) {
-            out.beginObject("problem");
-            out.property("row", error.getError().getPosition().getLine() - 1);
-            out.property("column", error.getError().getPosition().getPos());
-            out.property("text", error.getError().getMessage());
-            out.property("type", "error");
-            out.endObject();
-        }
-        out.endArray();
+        Compiler.reportAsJson(getErrors().stream().map(CompileError::getError).collect(Collectors.toList()), out);
     }
 }
 

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -106,6 +106,13 @@ public class Compiler extends InputProcessor {
         reportAsJson(context.getErrors(), out);
     }
 
+    /**
+     * Output specific errors to the json, so that the ACE editor can understand them.
+     *
+     * @param errors the errors to report
+     * @param out    the json output
+     * @see #reportProblemsAsJson(JSONStructuredOutput)
+     */
     public static void reportAsJson(Collection<ParseError> errors, JSONStructuredOutput out) {
         out.beginArray("problems");
         for (ParseError error : errors) {

--- a/src/main/java/sirius/tagliatelle/compiler/Compiler.java
+++ b/src/main/java/sirius/tagliatelle/compiler/Compiler.java
@@ -26,11 +26,13 @@ import sirius.tagliatelle.expression.ConstantString;
 import sirius.tagliatelle.expression.Expression;
 import sirius.tagliatelle.expression.MacroCall;
 import sirius.tagliatelle.tags.TagHandler;
+import sirius.web.services.JSONStructuredOutput;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -93,6 +95,28 @@ public class Compiler extends InputProcessor {
         reader = null;
 
         return processCollectedErrors();
+    }
+
+    /**
+     * Outputs compilation warnings and errors to the json, so that the ACE editor can understand them.
+     *
+     * @param out the json output
+     */
+    public void reportProblemsAsJson(JSONStructuredOutput out) {
+        reportAsJson(context.getErrors(), out);
+    }
+
+    public static void reportAsJson(Collection<ParseError> errors, JSONStructuredOutput out) {
+        out.beginArray("problems");
+        for (ParseError error : errors) {
+            out.beginObject("problem");
+            out.property("row", error.getPosition().getLine() - 1);
+            out.property("column", error.getPosition().getPos());
+            out.property("text", error.getMessage());
+            out.property("type", error.getSeverity().name().toLowerCase());
+            out.endObject();
+        }
+        out.endArray();
     }
 
     /**


### PR DESCRIPTION
To be reused in S2