### PR TITLE
Added 'mail.smtp.ssl.trust' to mail session properties

### DIFF
--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -28,6 +28,7 @@ public class SMTPConfiguration {
     private String mailSender;
     private String mailSenderName;
     private boolean useSenderAndEnvelopeFrom;
+    private String trustedServers;
 
     @ConfigValue("mail.smtp.host")
     private static String smtpHost;
@@ -49,6 +50,9 @@ public class SMTPConfiguration {
 
     @ConfigValue("mail.smtp.useEnvelopeFrom")
     private static boolean smtpUseEnvelopeFrom;
+
+    @ConfigValue("mail.smtp.trustedServers")
+    private static String smtpTrustedServers;
 
     private SMTPConfiguration() {
     }
@@ -104,6 +108,11 @@ public class SMTPConfiguration {
         return this;
     }
 
+    public SMTPConfiguration setTrustedServers(String trustedServers) {
+        this.trustedServers = trustedServers;
+        return this;
+    }
+
     /**
      * Creates a new configuration based on the config files.
      *
@@ -118,7 +127,8 @@ public class SMTPConfiguration {
                                 .setPassword(smtpPassword)
                                 .setMailSender(smtpSender)
                                 .setMailSenderName(smtpSenderName)
-                                .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom);
+                                .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom)
+                                .setTrustedServers(smtpTrustedServers);
     }
 
     /**
@@ -145,7 +155,8 @@ public class SMTPConfiguration {
                                 .setPassword(settings.get("mail.password").getString())
                                 .setMailSender(settings.get("mail.sender").getString())
                                 .setMailSenderName(settings.get("mail.senderName").getString())
-                                .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean());
+                                .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean())
+                                .setTrustedServers(settings.get("mail.trustedServers").getString());
     }
 
     /**
@@ -173,6 +184,15 @@ public class SMTPConfiguration {
      */
     public static boolean getDefaultUseSenderAndEnvelopeFrom() {
         return smtpUseEnvelopeFrom;
+    }
+
+    /**
+     * Returns a whitespace separated list of servers (domain names), whose SSL certificates can be trusted.
+     *
+     * @return a whitespace separated list of servers (domain names), whose SSL certificates can be trusted.
+     */
+    public String getTrustedServers() {
+        return trustedServers;
     }
 
     /**

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -71,6 +71,7 @@ class SendMailTask implements Runnable {
     private static final String MAIL_FROM = "mail.from";
     private static final String MAIL_SMTP_HOST = "mail.smtp.host";
     private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+    private static final String MAIL_SMTP_SSL_TRUST = "mail.smtp.ssl.trust";
     private static final String MAIL_SMTP_PORT = "mail.smtp.port";
     private static final String MAIL_SMTP_CONNECTIONTIMEOUT = "mail.smtp.connectiontimeout";
     private static final String MAIL_SMTP_TIMEOUT = "mail.smtp.timeout";
@@ -358,6 +359,7 @@ class SendMailTask implements Runnable {
 
         props.setProperty(MAIL_TRANSPORT_PROTOCOL, config.getProtocol().getProtocol());
         props.setProperty(MAIL_SMTP_STARTTLS_ENABLE, Boolean.toString(config.getProtocol().isStarttls()));
+        props.setProperty(MAIL_SMTP_SSL_TRUST, config.getTrustedServers());
         Authenticator auth = new MailAuthenticator(config);
         if (Strings.isEmpty(config.getMailPassword())) {
             props.setProperty(MAIL_SMTP_AUTH, Boolean.FALSE.toString());

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -395,6 +395,10 @@ mail {
         # Determines if sender: / from: and envelope-from: headers are used.
         useEnvelopeFrom = true
 
+        # Contains a whitespace separated list of servers (domain names), whose SSL certificates can be trusted.
+        # Set trustedServers to "*" to trust any server. Per default, no server SSL certificates are trusted!
+        trustedServers = ""
+
         # Contains the settings required to enable DKIM
         dkim {
 

--- a/src/main/resources/scope-conf/mail.conf
+++ b/src/main/resources/scope-conf/mail.conf
@@ -20,4 +20,8 @@ mail {
 
     # Determines if sender: / from: and envelope-from: headers are used.
     useEnvelopeFrom = true
+
+    # Contains a whitespace separated list of servers (domain names), whose SSL certificates can be trusted.
+    # Set trustedServers to "*" to trust any server. Per default, no server SSL certificates are trusted!
+    trustedServers = ""
 }


### PR DESCRIPTION
We need to accept ssl certificates based on host or domain names to initialize a TLS smtp connection. Added configuration key and corresponding logic that per default doesn't accept any certificates!