### PR TITLE
Simplifies creating helpers.

### DIFF
--- a/src/main/java/sirius/web/security/HelperFactory.java
+++ b/src/main/java/sirius/web/security/HelperFactory.java
@@ -40,16 +40,6 @@ public interface HelperFactory<H> extends Priorized {
     Class<H> getHelperType();
 
     /**
-     * Returns a short and descriptive name which can be used to fetch the helper in templates.
-     * <p>
-     * We prefer using names over class names in templates as this make refactorings way easier.
-     *
-     * @return the unique name used to fetch the helper in a template
-     */
-    @Nonnull
-    String getName();
-
-    /**
      * Creates a new helper for the given scope.
      *
      * @param scope the scope for which this helper is created

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -79,7 +79,7 @@ public class ScopeInfo extends Composable {
     private static List<HelperFactory<?>> factories;
 
     @Part
-    private static GlobalContext ctx;
+    private static GlobalContext globalContext;
 
     /**
      * Creates a new <tt>ScopeInfo</tt> with the given parameters.
@@ -279,7 +279,7 @@ public class ScopeInfo extends Composable {
     }
 
     private Object populateHelper(Class<?> type, Object helper, Map<Class<?>, Object> localContext) {
-        ctx.wire(helper);
+        globalContext.wire(helper);
         fillConfig(helper);
 
         // Note that we deliberately make the helper visible in the local context here so that "fillFriends" is
@@ -468,8 +468,8 @@ public class ScopeInfo extends Composable {
     public UserManager getUserManager() {
         if (userManager == null) {
             Extension ext = Sirius.getSettings().getExtension("security.scopes", getScopeType());
-            userManager = ctx.getPart(ext.get("manager").asString("public"), UserManagerFactory.class)
-                             .createManager(this, ext);
+            userManager = globalContext.getPart(ext.get("manager").asString("public"), UserManagerFactory.class)
+                                       .createManager(this, ext);
         }
 
         return userManager;

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -13,7 +13,6 @@ import com.typesafe.config.ConfigFactory;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Reflection;
 import sirius.kernel.commons.Streams;
-import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.ValueHolder;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
@@ -29,9 +28,12 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,8 +55,6 @@ public class ScopeInfo extends Composable {
 
     private static final String DEFAULT_SCOPE_ID = "default";
 
-    private static final int HELPER_FRIENDS_MAX_DEPTH = 25;
-
     /**
      * If no distinct scope is recognized by the current <tt>ScopeDetector</tt> or if no detector is installed,
      * this scope is used.
@@ -62,14 +62,13 @@ public class ScopeInfo extends Composable {
     public static final ScopeInfo DEFAULT_SCOPE =
             new ScopeInfo(DEFAULT_SCOPE_ID, DEFAULT_SCOPE_ID, DEFAULT_SCOPE_ID, null, null, null);
 
-    private String scopeId;
-    private String scopeType;
-    private String scopeName;
-    private String lang;
-    private Function<ScopeInfo, Config> configSupplier;
-    private Function<ScopeInfo, Object> scopeSupplier;
-    private Map<Class<?>, Object> helpersByType = new ConcurrentHashMap<>();
-    private Map<String, Object> helpersByName = new ConcurrentHashMap<>();
+    private final String scopeId;
+    private final String scopeType;
+    private final String scopeName;
+    private final String lang;
+    private final Function<ScopeInfo, Config> configSupplier;
+    private final Function<ScopeInfo, Object> scopeSupplier;
+    private final Map<Class<?>, Object> helpersByType = new ConcurrentHashMap<>();
     private UserSettings settings;
     private UserManager userManager;
 
@@ -208,82 +207,87 @@ public class ScopeInfo extends Composable {
     public <T> T getHelper(Class<T> clazz) {
         Object result = helpersByType.get(clazz);
         if (result == null) {
-            result = makeHelperByType(clazz);
+            result = findOrCreateHelper(clazz);
         }
 
         return (T) result;
     }
 
-    /**
-     * Retrieves the helper of the given name.
-     * <p>
-     * Helpers are utility classes which are kept per <tt>ScopeInfo</tt> and created by {@link HelperFactory}
-     * instances.
-     * <p>
-     * When using helpers in templates, it is better to refer to them via name than via class, as this stays constant
-     * when renaming or moving classes.
-     *
-     * @param name the name of the helper to fetch
-     * @param <T>  the generic type of the helper
-     * @return a cached or newly created instance of the helper for this scope.
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T getHelper(String name) {
-        Object result = helpersByName.get(name);
+    private synchronized Object findOrCreateHelper(Class<?> helperType) {
+        Object result = helpersByType.get(helperType);
         if (result == null) {
-            result = makeHelperByName(name);
+            Map<Class<?>, Object> localContext = new HashMap<>(helpersByType);
+            result = makeHelperByType(helperType, localContext);
+            localContext.forEach((type, helper) -> helpersByType.putIfAbsent(type, helper));
         }
 
-        return (T) result;
+        return result;
     }
 
-    private Object makeHelperByType(Class<?> aClass) {
-        return makeHelper(findFactoryForType(aClass));
+    private Object makeHelperByType(Class<?> aClass, Map<Class<?>, Object> localContext) {
+        return populateHelper(aClass, createHelperByType(aClass), localContext);
     }
 
-    private HelperFactory<?> findFactoryForType(Class<?> aClass) {
+    private Object createHelperByType(Class<?> aClass) {
         for (HelperFactory<?> factory : factories) {
             if (aClass.equals(factory.getHelperType())) {
-                return factory;
+                return factory.make(this);
             }
         }
 
+        return makeHelperByConstructor(aClass);
+    }
+
+    private Object makeHelperByConstructor(Class<?> aClass) {
+        // First try to instantiate with a constructor that takes ScopeInfo as argument....
+        try {
+            Constructor<?> constructor = aClass.getDeclaredConstructor(ScopeInfo.class);
+            return constructor.newInstance(this);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            // There is either no constructor or it isn't accessible -> ignore
+            Exceptions.ignore(e);
+        } catch (InstantiationException | InvocationTargetException e) {
+            throw Exceptions.handle()
+                            .to(UserContext.LOG)
+                            .error(e)
+                            .withSystemErrorMessage("Cannot auto instantiate a helper of type %s - %s (%s)",
+                                                    aClass.getName())
+                            .handle();
+        }
+
+        // Then try to instantiate with a no args constructor....
+        try {
+            Constructor<?> constructor = aClass.getDeclaredConstructor();
+            return constructor.newInstance();
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            // There is either no constructor or it isn't accessible -> ignore
+            Exceptions.ignore(e);
+        } catch (InstantiationException | InvocationTargetException e) {
+            throw Exceptions.handle()
+                            .to(UserContext.LOG)
+                            .error(e)
+                            .withSystemErrorMessage("Cannot auto instantiate a helper of type %s - %s (%s)",
+                                                    aClass.getName())
+                            .handle();
+        }
+
+        // There is no way to instantiate this helper - give up...
         throw Exceptions.handle()
                         .to(UserContext.LOG)
                         .withSystemErrorMessage("Cannot make a helper of type %s", aClass.getName())
                         .handle();
     }
 
-    private Object makeHelperByName(String name) {
-        for (HelperFactory<?> factory : factories) {
-            if (Strings.areEqual(name, factory.getName())) {
-                return makeHelper(factory);
-            }
-        }
+    private Object populateHelper(Class<?> type, Object helper, Map<Class<?>, Object> localContext) {
+        ctx.wire(helper);
+        fillConfig(helper);
 
-        throw Exceptions.handle()
-                        .to(UserContext.LOG)
-                        .withSystemErrorMessage("Cannot make a helper named %s", name)
-                        .handle();
-    }
+        // Note that we deliberately make the helper visible in the local context here so that "fillFriends" is
+        // catable of handling circular references...
+        localContext.put(type, helper);
+        fillFriends(helper, localContext);
 
-    private Object makeHelper(HelperFactory<?> factory) {
-        return makeHelper(factory, 0);
-    }
-
-    private Object makeHelper(HelperFactory<?> factory, int circuitBreaker) {
-        circuitBreaker++;
-
-        Object result = factory.make(this);
-
-        ctx.wire(result);
-        fillConfig(result);
-        fillFriends(result, circuitBreaker);
-
-        helpersByType.put(factory.getHelperType(), result);
-        helpersByName.put(factory.getName(), result);
-
-        return result;
+        return helper;
     }
 
     private void fillConfig(Object result) {
@@ -291,41 +295,43 @@ public class ScopeInfo extends Composable {
         Reflection.getAllFields(result.getClass())
                   .stream()
                   .filter(f -> f.isAnnotationPresent(HelperConfig.class))
-                  .forEach(f -> scopeSettings.injectValueFromConfig(result,
-                                                                    f,
-                                                                    f.getAnnotation(HelperConfig.class).value()));
-    }
-
-    private void fillFriends(Object result, int circuitBreaker) {
-        Reflection.getAllFields(result.getClass())
-                  .stream()
-                  .filter(field -> field.isAnnotationPresent(Helper.class))
-                  .forEach(field -> {
+                  .forEach(f -> {
                       try {
-                          fillFriend(result, field, circuitBreaker);
-                      } catch (Exception e) {
-                          Exceptions.handle()
-                                    .error(e)
-                                    .to(UserContext.LOG)
-                                    .withSystemErrorMessage("Cannot fill friend %s in %s of helper %s (%s): %s (%s)",
-                                                            field.getType().getName(),
-                                                            field.getName(),
-                                                            result,
-                                                            result.getClass().getName())
-                                    .handle();
+                          scopeSettings.injectValueFromConfig(result, f, f.getAnnotation(HelperConfig.class).value());
+                      } catch (IllegalArgumentException e) {
+                          UserContext.LOG.WARN("Failed to fill a helper-config value: %s for scope %s",
+                                               e.getMessage(),
+                                               getScopeId());
                       }
                   });
     }
 
-    private void fillFriend(Object result, Field field, int circuitBreaker) throws IllegalAccessException {
-        HelperFactory<?> factory = findFactoryForType(field.getType());
+    private void fillFriends(Object result, Map<Class<?>, Object> localContext) {
+        Reflection.getAllFields(result.getClass())
+                  .stream()
+                  .filter(field -> field.isAnnotationPresent(Helper.class))
+                  .forEach(field -> fillFriend(result, field, localContext));
+    }
 
-        if (circuitBreaker > HELPER_FRIENDS_MAX_DEPTH) {
-            throw new IllegalStateException("Detected circular friend dependency");
+    private void fillFriend(Object helper, Field field, Map<Class<?>, Object> localContext) {
+        try {
+            Object friend = localContext.get(field.getType());
+            if (friend == null) {
+                friend = makeHelperByType(field.getType(), localContext);
+            }
+            field.setAccessible(true);
+            field.set(helper, friend);
+        } catch (Exception e) {
+            Exceptions.handle()
+                      .error(e)
+                      .to(UserContext.LOG)
+                      .withSystemErrorMessage("Cannot fill friend %s in %s of helper %s (%s): %s (%s)",
+                                              field.getType().getName(),
+                                              field.getName(),
+                                              helper,
+                                              helper.getClass().getName())
+                      .handle();
         }
-
-        field.setAccessible(true);
-        field.set(result, makeHelper(factory, circuitBreaker));
     }
 
     /**

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -560,6 +560,8 @@ public class UserContext implements SubContext {
         child.currentScope = currentScope;
         child.msgList = msgList;
         child.fieldErrors = fieldErrors;
+        child.fieldErrorMessages = fieldErrorMessages;
+        child.addedAdditionalMessages = addedAdditionalMessages;
 
         return child;
     }

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -135,22 +135,6 @@ public class UserContext implements SubContext {
     }
 
     /**
-     * Returns the helper with the given name for the current scope.
-     * <p>
-     * NOTE: This helper is per {@link ScopeInfo} not per {@link UserInfo}! Therefore no user dependent data may be kept
-     * in its state.
-     *
-     * @param name the name of the helper to fetch
-     * @param <H>  the generic type of the helper
-     * @return an instance of the given helper. If the helper can neither be found nor created, an exception will be
-     * thrown.
-     */
-    @Nonnull
-    public static <H> H getHelper(@Nonnull String name) {
-        return getCurrentScope().getHelper(name);
-    }
-
-    /**
      * Boilerplate method to quickly access the current scope.
      *
      * @return the currently active scope

--- a/src/test/java/sirius/tagliatelle/ExampleHelper.java
+++ b/src/test/java/sirius/tagliatelle/ExampleHelper.java
@@ -16,28 +16,6 @@ import javax.annotation.Nonnull;
 
 public class ExampleHelper {
 
-    @Register
-    public static class ExampleHelperFactory implements HelperFactory<ExampleHelper> {
-
-        @Nonnull
-        @Override
-        public Class<ExampleHelper> getHelperType() {
-            return ExampleHelper.class;
-        }
-
-        @Nonnull
-        @Override
-        public String getName() {
-            return "example";
-        }
-
-        @Nonnull
-        @Override
-        public ExampleHelper make(@Nonnull ScopeInfo scope) {
-            return new ExampleHelper();
-        }
-    }
-
     public String getTestValue() {
         return "test";
     }

--- a/src/test/java/sirius/web/security/AnotherExampleHelper.java
+++ b/src/test/java/sirius/web/security/AnotherExampleHelper.java
@@ -8,45 +8,18 @@
 
 package sirius.web.security;
 
-import sirius.kernel.commons.Explain;
-import sirius.kernel.di.std.Register;
-import sirius.kernel.health.Exceptions;
-
-import javax.annotation.Nonnull;
-
 public class AnotherExampleHelper {
 
-    @Register
-    public static class AnotherExampleHelperFactory implements HelperFactory<AnotherExampleHelper> {
+    private final ScopeInfo scopeInfo;
 
-        @Nonnull
-        @Override
-        public Class<AnotherExampleHelper> getHelperType() {
-            return AnotherExampleHelper.class;
-        }
+    @Helper
+    private ExampleHelper exampleHelper;
 
-        @Nonnull
-        @Override
-        public String getName() {
-            return "example2";
-        }
-
-        @Nonnull
-        @Override
-        @SuppressWarnings("squid:S2925")
-        @Explain("We need this delay here to test loading friend helpers.")
-        public AnotherExampleHelper make(@Nonnull ScopeInfo scope) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                throw Exceptions.handle(e);
-            }
-
-            return new AnotherExampleHelper();
-        }
+    public AnotherExampleHelper(ScopeInfo info) {
+        this.scopeInfo = info;
     }
 
-    public String getTestValue() {
-        return "test";
+    public ExampleHelper getExampleHelper() {
+        return exampleHelper;
     }
 }

--- a/src/test/java/sirius/web/security/ExampleHelper.java
+++ b/src/test/java/sirius/web/security/ExampleHelper.java
@@ -8,38 +8,12 @@
 
 package sirius.web.security;
 
-import sirius.kernel.di.std.Register;
-
-import javax.annotation.Nonnull;
-
 public class ExampleHelper {
-
-    @Register
-    public static class ExampleHelperFactory implements HelperFactory<ExampleHelper> {
-
-        @Nonnull
-        @Override
-        public Class<ExampleHelper> getHelperType() {
-            return ExampleHelper.class;
-        }
-
-        @Nonnull
-        @Override
-        public String getName() {
-            return "example1";
-        }
-
-        @Nonnull
-        @Override
-        public ExampleHelper make(@Nonnull ScopeInfo scope) {
-            return new ExampleHelper();
-        }
-    }
 
     @Helper
     private AnotherExampleHelper anotherExampleHelper;
 
-    public String getTestValue() {
-        return anotherExampleHelper.getTestValue();
+    public AnotherExampleHelper getAnotherExampleHelper() {
+        return anotherExampleHelper;
     }
 }

--- a/src/test/java/sirius/web/security/FactoryExampleHelper.java
+++ b/src/test/java/sirius/web/security/FactoryExampleHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.security;
+
+import javax.annotation.Nonnull;
+
+public class FactoryExampleHelper {
+
+    public static class Factory implements HelperFactory<FactoryExampleHelper> {
+
+        @Nonnull
+        @Override
+        public Class<FactoryExampleHelper> getHelperType() {
+            return FactoryExampleHelper.class;
+        }
+
+        @Nonnull
+        @Override
+        public FactoryExampleHelper make(@Nonnull ScopeInfo scope) {
+            return new FactoryExampleHelper();
+        }
+    }
+
+}


### PR DESCRIPTION
Removes the ability to reference a helper by its name.

This is essentially a deprecated approach which was left over
from the JSF days. We actually never did reference helpers by
their name and we probably will never, as we'd instantly loose
all benefits of Tagliatelle and its static compilation capabilities.

Note that now that HelperFactories are quite trivial as these are
only glorified constructors, we also permit to instantiate a helper
via its constructor (which might take ScopeInfo as parameter).

Note that a factory can still be used and will always be preferred
as we might use this to overwrite / change helpers in customizations.

Also note, that while refactoring the new instance creation, we also
added support for circular references across helpers and also made
sure that each helper only exists once per scope. (Previously the
@Helper annotation created a copy instead of referencing the real
helper).