### PR TITLE
Permits to supply optional class aliases.

### DIFF
--- a/src/main/java/sirius/pasta/noodle/ClassAliasProvider.java
+++ b/src/main/java/sirius/pasta/noodle/ClassAliasProvider.java
@@ -8,6 +8,8 @@
 
 package sirius.pasta.noodle;
 
+import sirius.kernel.di.std.Priorized;
+
 import java.util.function.BiConsumer;
 
 /**
@@ -16,11 +18,20 @@ import java.util.function.BiConsumer;
  * Implementations can be {@link sirius.kernel.di.std.Register registered} and then provide aliases for commonly used
  * classes.
  */
-public interface ClassAliasProvider {
+public interface ClassAliasProvider extends Priorized {
     /**
      * Collects all available aliases and their target classes
      *
      * @param consumer the consumer to supply with aliases
      */
     void collectAliases(BiConsumer<String, Class<?>> consumer);
+
+    /**
+     * Permits to provide optional aliases which should only be introduced if no conflicting alias exists.
+     *
+     * @param consumer the consumer to supply with aliases
+     */
+    default void collectOptionalAliases(BiConsumer<String, Class<?>> consumer) {
+    }
+
 }

--- a/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
+++ b/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
@@ -8,6 +8,7 @@
 
 package sirius.pasta.noodle;
 
+import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Files;
@@ -19,6 +20,7 @@ import sirius.kernel.commons.Values;
 import sirius.kernel.di.Injector;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.info.Product;
+import sirius.kernel.nls.Formatter;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.Page;
 import sirius.web.http.WebContext;
@@ -39,6 +41,11 @@ import java.util.function.BiConsumer;
 public class SiriusClassAliasProvider implements ClassAliasProvider {
 
     @Override
+    public int getPriority() {
+        return 10;
+    }
+
+    @Override
     public void collectAliases(BiConsumer<String, Class<?>> consumer) {
         consumer.accept("String", String.class);
         consumer.accept("int", int.class);
@@ -53,10 +60,10 @@ public class SiriusClassAliasProvider implements ClassAliasProvider {
         consumer.accept("LocalTime", LocalTime.class);
 
         consumer.accept("Page", Page.class);
-        consumer.accept("Sirius", Page.class);
+        consumer.accept("Sirius", Sirius.class);
         consumer.accept("Tuple", Tuple.class);
         consumer.accept("NLS", NLS.class);
-        consumer.accept("Formatter", NLS.class);
+        consumer.accept("Formatter", Formatter.class);
         consumer.accept("Value", Value.class);
         consumer.accept("Values", Values.class);
         consumer.accept("CallContext", CallContext.class);

--- a/src/main/java/sirius/pasta/noodle/compiler/CompilationContext.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/CompilationContext.java
@@ -12,13 +12,12 @@ import parsii.tokenizer.ParseError;
 import parsii.tokenizer.Position;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Strings;
-import sirius.kernel.di.std.Parts;
+import sirius.kernel.di.std.PriorityParts;
 import sirius.kernel.health.Exceptions;
 import sirius.pasta.Pasta;
 import sirius.pasta.noodle.ClassAliasProvider;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -74,8 +73,8 @@ public class CompilationContext {
      */
     private final Map<String, Class<?>> importedClasses = new HashMap<>();
 
-    @Parts(ClassAliasProvider.class)
-    private static Collection<ClassAliasProvider> aliasProviders;
+    @PriorityParts(ClassAliasProvider.class)
+    private static List<ClassAliasProvider> aliasProviders;
 
     /**
      * Contains all aliases collected via {@link ClassAliasProvider alias providers}.
@@ -290,11 +289,29 @@ public class CompilationContext {
     private static Map<String, Class<?>> getClassAliases() {
         if (aliases == null) {
             Map<String, Class<?>> aliasMap = new HashMap<>();
-            aliasProviders.forEach(p -> p.collectAliases(aliasMap::put));
+            aliasProviders.forEach(p -> p.collectAliases((name, type) -> addAlias(aliasMap, name, type)));
+            aliasProviders.forEach(p -> p.collectAliases((name, type) -> addOptionalAlias(aliasMap, name, type)));
             aliases = aliasMap;
         }
 
         return Collections.unmodifiableMap(aliases);
+    }
+
+    private static void addAlias(Map<String, Class<?>> aliasMap, String name, Class<?> type) {
+        if (aliasMap.containsKey(name)) {
+            Pasta.LOG.WARN("Failed to register %s as class alias for %s - This is already used by: %s",
+                           name,
+                           type,
+                           aliasMap.get(name));
+        } else {
+            aliasMap.put(name, type);
+        }
+    }
+
+    private static void addOptionalAlias(Map<String, Class<?>> aliasMap, String name, Class<?> type) {
+        if (!aliasMap.containsKey(name)) {
+            aliasMap.put(name, type);
+        }
     }
 
     /**

--- a/src/main/java/sirius/pasta/noodle/compiler/CompilationContext.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/CompilationContext.java
@@ -290,7 +290,7 @@ public class CompilationContext {
         if (aliases == null) {
             Map<String, Class<?>> aliasMap = new HashMap<>();
             aliasProviders.forEach(p -> p.collectAliases((name, type) -> addAlias(aliasMap, name, type)));
-            aliasProviders.forEach(p -> p.collectAliases((name, type) -> addOptionalAlias(aliasMap, name, type)));
+            aliasProviders.forEach(p -> p.collectOptionalAliases((name, type) -> addOptionalAlias(aliasMap, name, type)));
             aliases = aliasMap;
         }
 


### PR DESCRIPTION
This is mainly used by sirius biz which automatically provides an alias for each helper
and entity. However, if an application already uses an alias, we ignore the entity
or helper.