### PR TITLE
Fix: Verbatim Code in Default Template

### DIFF
--- a/src/main/resources/default/templates/tycho/page-footer.html.pasta
+++ b/src/main/resources/default/templates/tycho/page-footer.html.pasta
@@ -4,7 +4,7 @@
             <i:invoke template="/templates/wondergem/page-footer-menu.html.pasta"  />
         </div>
         <div class="text-right form-control-sm text-muted">
-            <span title="@CallContext.getCurrent().getWatch().elapsedMillis() ms (@const(sirius.kernel.info.Product.getProduct().getDetails()))">CallContext.getNodeName()</span>
+            <span title="@CallContext.getCurrent().getWatch().elapsedMillis() ms (@const(sirius.kernel.info.Product.getProduct().getDetails()))">@CallContext.getNodeName()</span>
         </div>
     </div>
 </div>

--- a/src/main/resources/default/templates/wondergem/page-footer.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-footer.html.pasta
@@ -4,7 +4,7 @@
             <i:invoke template="/templates/wondergem/page-footer-menu.html.pasta"/>
         </div>
         <div class="pull-right" style="text-align: right">
-            <small title="@CallContext.getCurrent().getWatch().elapsedMillis() ms (@const(sirius.kernel.info.Product.getProduct().getDetails()))">CallContext.getNodeName()</small>
+            <small title="@CallContext.getCurrent().getWatch().elapsedMillis() ms (@const(sirius.kernel.info.Product.getProduct().getDetails()))">@CallContext.getNodeName()</small>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Fixes verbatim `CallContext.getNodeName()` in footer