### PR TITLE
Makes Noodle null-safe again.

### DIFF
--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -367,7 +367,12 @@ public class Invocation {
             }
         } else {
             Object self = pop();
-            if (numberOfArguments == 0) {
+            if (self == null) {
+                while(numberOfArguments-- > 0) {
+                    pop();
+                }
+                push(null);
+            } else if (numberOfArguments == 0) {
                 push(methodHandle.invoke(self));
             } else if (numberOfArguments == 1) {
                 Object arg1 = pop();


### PR DESCRIPTION
Just like Tagliatelle did earlier, we handle null.someMethod()
to simply return null instead of crashing with an NPE.