### PR TITLE
Fixes an internal overflow of the SharedConstantPool.

### DIFF
--- a/src/main/java/sirius/pasta/noodle/InterpreterCall.java
+++ b/src/main/java/sirius/pasta/noodle/InterpreterCall.java
@@ -93,14 +93,14 @@ public class InterpreterCall implements Callable {
             int index = instruction & 0x0000FFFF;
             if (lastCol != position.getPos()) {
                 listing.append("          ");
-                for (int p = 1; p < position.getPos(); p++) {
+                for (int p = 1; p < position.getPos() - 1; p++) {
                     listing.append(" ");
                 }
                 listing.append("^\n");
                 lastCol = position.getPos();
             }
             listing.append("          ");
-            for (int p = 1; p < position.getPos(); p++) {
+            for (int p = 1; p < position.getPos() - 1; p++) {
                 listing.append(" ");
             }
             listing.append(i);
@@ -111,11 +111,24 @@ public class InterpreterCall implements Callable {
             listing.append("\n\n");
             listing.append("Constants\n");
             listing.append("====================\n");
+            int index = 0;
             for (Object object : constants) {
+                listing.append(Strings.apply("%3s: ", index++));
                 listing.append(object);
                 listing.append("\n");
             }
         }
+
+        listing.append("\n\n");
+        listing.append("Shared Constants\n");
+        listing.append("====================\n");
+        int index = 0;
+        for (Object object : Invocation.SHARED_CONSTANT_POOL.getSharedConstants()) {
+            listing.append(Strings.apply("%3s: ", index++));
+            listing.append(object);
+            listing.append("\n");
+        }
+
 
         return listing.toString();
     }

--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -13,8 +13,10 @@ import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.transformers.Transformable;
+import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.nls.NLS;
+import sirius.pasta.Pasta;
 import sirius.pasta.noodle.macros.Macro;
 import sirius.web.security.UserContext;
 
@@ -273,11 +275,35 @@ public class Invocation {
         StringBuilder result = new StringBuilder(" Line:\n");
         result.append(offendingLine);
         result.append("\n");
-        for (int i = 1; i < position.getPos(); i++) {
+        for (int i = 1; i < position.getPos() - 1; i++) {
             result.append(" ");
         }
         result.append("^\n");
         return result.toString();
+    }
+
+    /**
+     * Creates an exception which is used when Noodle detects an inconsistent or invalid internal state.
+     * <p>
+     * These states should normally not be reached as the compiler should only emit valid bytecodes. Therefore
+     * we provide quite some excessivle loggig here.
+     *
+     * @param message the message to log
+     * @return an exception with a short and concise message of what happened. Also a long and elaborate message will
+     * be logged which might provide further insight.
+     */
+    private IllegalArgumentException vmError(String message) {
+        // Create a full blown exception for the logs...
+        IllegalStateException internalError = new IllegalStateException(Strings.apply(
+                "A Noodle VM error occurred: %s%n%nIP: %s%nStack: %s%nCall:%n%n%s",
+                message,
+                instructionPointer,
+                stack,
+                this.compiledMethod.disassemble()));
+        Exceptions.handle(Pasta.LOG, internalError);
+
+        // Return a shortened exception which may even be delivered to the frontend...
+        return new IllegalArgumentException(message);
     }
 
     private Object add(Object a, Object b) {
@@ -291,11 +317,7 @@ public class Invocation {
             return ((double) a) + (double) b;
         }
 
-        throw new IllegalArgumentException(Strings.apply("Cannot add %s and %s (%s, %s)",
-                                                         a,
-                                                         b,
-                                                         a.getClass(),
-                                                         b.getClass()));
+        throw vmError(Strings.apply("Cannot add %s and %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object sub(Object a, Object b) {
@@ -309,11 +331,7 @@ public class Invocation {
             return ((double) a) - (double) b;
         }
 
-        throw new IllegalArgumentException(Strings.apply("Cannot subtract %s minus %s (%s, %s)",
-                                                         a,
-                                                         b,
-                                                         a.getClass(),
-                                                         b.getClass()));
+        throw vmError(Strings.apply("Cannot subtract %s minus %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object mul(Object a, Object b) {
@@ -327,11 +345,7 @@ public class Invocation {
             return ((double) a) * (double) b;
         }
 
-        throw new IllegalArgumentException(Strings.apply("Cannot multiply %s by %s (%s, %s)",
-                                                         a,
-                                                         b,
-                                                         a.getClass(),
-                                                         b.getClass()));
+        throw vmError(Strings.apply("Cannot multiply %s by %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object div(Object a, Object b) {
@@ -345,11 +359,7 @@ public class Invocation {
             return ((double) a) / (double) b;
         }
 
-        throw new IllegalArgumentException(Strings.apply("Cannot divide %s by %s (%s, %s)",
-                                                         a,
-                                                         b,
-                                                         a.getClass(),
-                                                         b.getClass()));
+        throw vmError(Strings.apply("Cannot divide %s by %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object mod(Object a, Object b) {
@@ -363,11 +373,11 @@ public class Invocation {
             return ((double) a) % (double) b;
         }
 
-        throw new IllegalArgumentException(Strings.apply("Cannot compute the modulo of %s and %s (%s, %s)",
-                                                         a,
-                                                         b,
-                                                         a.getClass(),
-                                                         b.getClass()));
+        throw vmError(Strings.apply("Cannot compute the modulo of %s and %s (%s, %s)",
+                                    a,
+                                    b,
+                                    a.getClass(),
+                                    b.getClass()));
     }
 
     private String asString(Object value) {
@@ -380,6 +390,8 @@ public class Invocation {
             invokeMethod(numberOfArguments, isStatic, ((MethodPointer) target).getMethodHandle());
         } else if (target instanceof Macro) {
             invokeMacro(numberOfArguments, (Macro) target);
+        } else {
+            throw vmError(Strings.apply("Cannot invoke: %s", target));
         }
     }
 
@@ -481,7 +493,7 @@ public class Invocation {
 
     private Object pop() {
         if (stack.isEmpty()) {
-            throw new IllegalStateException("Stack underflow");
+            throw vmError("Stack underflow");
         }
         return stack.remove(stack.size() - 1);
     }

--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -376,8 +376,8 @@ public class Invocation {
 
     private void handleInvoke(int numberOfArguments, boolean isStatic) throws Throwable {
         Object target = pop();
-        if (target instanceof MethodHandle) {
-            invokeMethod(numberOfArguments, isStatic, (MethodHandle) target);
+        if (target instanceof MethodPointer) {
+            invokeMethod(numberOfArguments, isStatic, ((MethodPointer) target).getMethodHandle());
         } else if (target instanceof Macro) {
             invokeMacro(numberOfArguments, (Macro) target);
         }

--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -292,7 +292,7 @@ public class Invocation {
      * @return an exception with a short and concise message of what happened. Also a long and elaborate message will
      * be logged which might provide further insight.
      */
-    private IllegalArgumentException vmError(String message) {
+    private IllegalArgumentException createVmError(String message) {
         // Create a full blown exception for the logs...
         IllegalStateException internalError = new IllegalStateException(Strings.apply(
                 "A Noodle VM error occurred: %s%n%nIP: %s%nStack: %s%nCall:%n%n%s",
@@ -317,7 +317,7 @@ public class Invocation {
             return ((double) a) + (double) b;
         }
 
-        throw vmError(Strings.apply("Cannot add %s and %s (%s, %s)", a, b, a.getClass(), b.getClass()));
+        throw createVmError(Strings.apply("Cannot add %s and %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object sub(Object a, Object b) {
@@ -331,7 +331,7 @@ public class Invocation {
             return ((double) a) - (double) b;
         }
 
-        throw vmError(Strings.apply("Cannot subtract %s minus %s (%s, %s)", a, b, a.getClass(), b.getClass()));
+        throw createVmError(Strings.apply("Cannot subtract %s minus %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object mul(Object a, Object b) {
@@ -345,7 +345,7 @@ public class Invocation {
             return ((double) a) * (double) b;
         }
 
-        throw vmError(Strings.apply("Cannot multiply %s by %s (%s, %s)", a, b, a.getClass(), b.getClass()));
+        throw createVmError(Strings.apply("Cannot multiply %s by %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object div(Object a, Object b) {
@@ -359,7 +359,7 @@ public class Invocation {
             return ((double) a) / (double) b;
         }
 
-        throw vmError(Strings.apply("Cannot divide %s by %s (%s, %s)", a, b, a.getClass(), b.getClass()));
+        throw createVmError(Strings.apply("Cannot divide %s by %s (%s, %s)", a, b, a.getClass(), b.getClass()));
     }
 
     private Object mod(Object a, Object b) {
@@ -373,11 +373,11 @@ public class Invocation {
             return ((double) a) % (double) b;
         }
 
-        throw vmError(Strings.apply("Cannot compute the modulo of %s and %s (%s, %s)",
-                                    a,
-                                    b,
-                                    a.getClass(),
-                                    b.getClass()));
+        throw createVmError(Strings.apply("Cannot compute the modulo of %s and %s (%s, %s)",
+                                          a,
+                                          b,
+                                          a.getClass(),
+                                          b.getClass()));
     }
 
     private String asString(Object value) {
@@ -391,7 +391,7 @@ public class Invocation {
         } else if (target instanceof Macro) {
             invokeMacro(numberOfArguments, (Macro) target);
         } else {
-            throw vmError(Strings.apply("Cannot invoke: %s", target));
+            throw createVmError(Strings.apply("Cannot invoke: %s", target));
         }
     }
 
@@ -493,7 +493,7 @@ public class Invocation {
 
     private Object pop() {
         if (stack.isEmpty()) {
-            throw vmError("Stack underflow");
+            throw createVmError("Stack underflow");
         }
         return stack.remove(stack.size() - 1);
     }

--- a/src/main/java/sirius/pasta/noodle/MethodPointer.java
+++ b/src/main/java/sirius/pasta/noodle/MethodPointer.java
@@ -1,0 +1,68 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.noodle;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Wraps a {@link Method} along with its {@link MethodHandle} together.
+ * <p>
+ * This helps to provide a sane "toString" method and also supports calling "equals" - in contrast to
+ * <tt>MethodHandle</tt>.
+ */
+public class MethodPointer {
+
+    private final Method method;
+    private final MethodHandle methodHandle;
+
+    /**
+     * Creates a new pointer for the given method.
+     *
+     * @param method the method to point to
+     * @throws IllegalAccessException in case the method isn't accessible
+     */
+    public MethodPointer(Method method) throws IllegalAccessException {
+        this.method = method;
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        this.methodHandle = lookup.unreflect(method);
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public MethodHandle getMethodHandle() {
+        return methodHandle;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MethodPointer that = (MethodPointer) o;
+        return method.equals(that.method);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method);
+    }
+
+    @Override
+    public String toString() {
+        return method.toString();
+    }
+}

--- a/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
+++ b/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
@@ -11,7 +11,6 @@ package sirius.pasta.noodle;
 import sirius.pasta.Pasta;
 import sirius.pasta.noodle.macros.Macro;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +29,7 @@ public class SharedConstantPool {
      */
     private static final int MAX_SHARED_CONSTANTS = 16384;
 
-    private List<Object> sharedConstants;
+    private final List<Object> sharedConstants;
 
     /**
      * Creates a new instance and initializes it with some common values.

--- a/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
+++ b/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Keeps commonly used constants around in a single list so that the constant pool of
@@ -29,7 +30,7 @@ public class SharedConstantPool {
      */
     private static final int MAX_SHARED_CONSTANTS = 16384;
 
-    private List<Object> sharedConstants = new ArrayList<>();
+    private List<Object> sharedConstants;
 
     /**
      * Creates a new instance and initializes it with some common values.
@@ -37,7 +38,7 @@ public class SharedConstantPool {
      * Note that most probably the {@link Invocation#SHARED_CONSTANT_POOL} instance should be used.
      */
     protected SharedConstantPool() {
-        this.sharedConstants = new ArrayList<>(Arrays.asList(null, "", 0, 1, true, false));
+        this.sharedConstants = new CopyOnWriteArrayList<>(Arrays.asList(null, "", 0, 1, true, false));
     }
 
     /**
@@ -83,7 +84,7 @@ public class SharedConstantPool {
      *
      * @return a copy of all shared constants. Note that this list cannot be mutated.
      */
-    public synchronized List<Object> getSharedConstants() {
-        return Collections.unmodifiableList(new ArrayList<>(sharedConstants));
+    public List<Object> getSharedConstants() {
+        return Collections.unmodifiableList(sharedConstants);
     }
 }

--- a/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
+++ b/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
@@ -24,6 +24,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class SharedConstantPool {
 
     private List<Object> sharedConstants = new CopyOnWriteArrayList<>();
+    /**
+     * Provides an upper limit for the shared constant pool. Under normal conditions, the pool should be
+     * way smaller as only classes, macros and some common constants are cached.
+     */
+    private static final int MAX_SHARED_CONSTANTS = 16384;
 
     /**
      * Creates a new instance and initializes it with some common values.
@@ -62,6 +67,11 @@ public class SharedConstantPool {
         }
 
         if (constant instanceof MethodHandle || constant instanceof Class || constant instanceof Macro) {
+            if (sharedConstants.size() >= MAX_SHARED_CONSTANTS) {
+                Pasta.LOG.WARN("SharedConstantPool is full (more than %s entries). No more constants will be added...",
+                               MAX_SHARED_CONSTANTS);
+                return -1;
+            }
             sharedConstants.add(constant);
             return sharedConstants.size() - 1;
         } else {

--- a/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class Assembler {
 
     /**
-     * Represents the maximum internal index or offset which can be encoded in an bytecode.
+     * Represents the maximum internal index or offset which can be encoded in a bytecode.
      * <p>
      * A bytecode is a 32 bit integer, where the 16 "MSBs" are used to encode the {@link OpCode} and
      * the lower 16 bits are used to store the index, we cannot store more than 2^16.

--- a/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
@@ -9,6 +9,7 @@
 package sirius.pasta.noodle.compiler;
 
 import parsii.tokenizer.Position;
+import sirius.kernel.commons.Strings;
 import sirius.pasta.noodle.InterpreterCall;
 import sirius.pasta.noodle.Invocation;
 import sirius.pasta.noodle.OpCode;
@@ -24,6 +25,14 @@ import java.util.Objects;
  * This mainly simplifies generating appropriate jump instructions by supporting labels.
  */
 public class Assembler {
+
+    /**
+     * Represents the maximal internal index or offset which can be encoded in an bytecode.
+     * <p>
+     * A bytecode is a 32 bit integer, where the 16 "MSBs" are used to encode the {@link OpCode} and
+     * the lower 16 bits are used to store the index, we cannot store more than 2^16.
+     */
+    private static final int MAX_INDEX = (1 << 16) - 1;
 
     /**
      * Represents a label which can be used to generate a jump instruction to jump to the label.
@@ -68,6 +77,14 @@ public class Assembler {
      * @param position the position within the source code for which this op code was created
      */
     public void emitByteCode(OpCode code, int index, Position position) {
+        if (index >= MAX_INDEX) {
+            throw new IllegalArgumentException(Strings.apply(
+                    "Cannot emit opcode %s for index %s as this would overflow! (Position in file: %s",
+                    code,
+                    index,
+                    position.getLine() + ":" + position.getPos()));
+        }
+
         bytecode.add(code.ordinal() << 16 | index);
         ipToPositionTable.add(position);
     }

--- a/src/main/java/sirius/pasta/noodle/compiler/Parser.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Parser.java
@@ -16,6 +16,9 @@ import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.di.transformers.Transformable;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.HandledException;
+import sirius.pasta.Pasta;
 import sirius.pasta.noodle.InterpreterCall;
 import sirius.pasta.noodle.OpCode;
 import sirius.pasta.noodle.compiler.ir.Assignment;
@@ -760,8 +763,15 @@ public class Parser extends InputProcessor {
                         assembler.build(constExpr.getType(), constExpr.getGenericType(), context.getSourceCodeInfo());
                 Object value = expr.call(null);
                 return new Constant(position, value);
-            } catch (Exception e) {
+            } catch (HandledException e) {
                 context.error(position, "Failed to compile and evaluate const expression: %s", e.getMessage());
+                return new Constant(reader.consume(), null);
+            } catch (Exception e) {
+                context.error(position,
+                              "Failed to compile and evaluate const expression: %s in: %s - %s",
+                              constExpr.toString(),
+                              context.getSourceCodeInfo().getName(),
+                              Exceptions.handle(Pasta.LOG, e).getMessage());
                 return new Constant(reader.consume(), null);
             }
         }

--- a/src/main/java/sirius/pasta/noodle/compiler/SourceCodeInfo.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/SourceCodeInfo.java
@@ -109,4 +109,9 @@ public class SourceCodeInfo {
     public String getLocation() {
         return location;
     }
+
+    @Override
+    public String toString() {
+        return name + " (" + location + ")";
+    }
 }

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -444,9 +444,6 @@ public class MethodCall extends Call {
                 return;
             }
 
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MethodHandle handle = lookup.unreflect(method);
-
             for (int i = parameterNodes.length - 1; i >= 0; i--) {
                 parameterNodes[i].emit(assembler);
             }
@@ -456,7 +453,7 @@ public class MethodCall extends Call {
                 selfNode.emit(assembler);
             }
 
-            assembler.emitPushConstant(handle, position);
+            assembler.emitPushConstant(new MethodPointer(method), position);
             assembler.emitByteCode(isStatic ? OpCode.INVOCE_STATIC : OpCode.INVOKE, parameterNodes.length, position);
         } catch (Exception e) {
             throw Exceptions.handle()

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -17,6 +17,7 @@ import sirius.kernel.di.transformers.Transformable;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
+import sirius.pasta.noodle.MethodPointer;
 import sirius.pasta.noodle.OpCode;
 import sirius.pasta.noodle.compiler.Assembler;
 import sirius.pasta.noodle.compiler.CompilationContext;
@@ -424,7 +425,7 @@ public class MethodCall extends Call {
 
     @Override
     public String toString() {
-        return "MethdoCall: " + selfNode + "." + methodName + "(" + Arrays.stream(parameterNodes)
+        return "MethodCall: " + selfNode + "." + methodName + "(" + Arrays.stream(parameterNodes)
                                                                           .map(Object::toString)
                                                                           .collect(Collectors.joining(", ")) + ")";
     }


### PR DESCRIPTION
We kept all referenced MethodHandles in the shared constant pool. Now as MethodHandle doesn't support "equals", each compilation increased the pool size more and more.

Now that we store bytecodes as 32 bit ints, where the upper 16 bits index the OpCode and the lower 16 bit can represent an index into the constant table or the shared constant pool.

As we didn't validate these indices and also didn't impose any limits on the shared constant pool, the index bits which are "OR"'ed into the opcode bits, effectively changed the op code which was eventually executed. This lead invalid sequences of op codes and thus to crashes of Noodle (with more or less funny causes).

The fixes in this PR all try to fix and prevent errors of this class in the future. As the impact of this error is pretty high,
several distinct fixes and improvements have been applied.