### PR TITLE
Fix: User Info

### DIFF
--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -347,11 +347,11 @@ public class UserInfo extends Composable {
         if (nameAppendixSupplier != null) {
             String appendix = nameAppendixSupplier.get();
             if (Strings.isFilled(appendix)) {
-                return Strings.apply("%s (%s)", username, nameAppendixSupplier.get());
+                return Strings.apply("%s (%s)", getUserName(), nameAppendixSupplier.get());
             }
         }
 
-        return username;
+        return getUserName();
     }
 
     /**


### PR DESCRIPTION
This allows subclasses of `UserInfo` to only override `getUserName()` without modifying the field.