### PR TITLE
Excludes the netty dependency brought by async-http-client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
             <version>2.12.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Used to generate QR codes -->


### PR DESCRIPTION
First and foremost we want to control which netty version is in use. Second we include the
nettly-all and async http client enumerates all netty jars by itself. Therefore both versions
end up in the classpath which might/will lead to runtime linking issues.