### PR TITLE
Set SameSite policy and Secure-Flag for login cookie

### DIFF
--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -117,6 +117,9 @@ http {
     # created which will be deleted once the browser is closed.
     sessionCookieTTL = 90 days
 
+    # Determines the SameSite attribute of the session cookie. Usually, Strict should be fine.
+    sessionCookieSameSite = Lax
+
     # Specifies the secret used to validate the consistency of client sessions. If no value is present (default)
     # a random secret is created on startup. However this implies that sessions do not work across clusters
     # or across server restart. Therefore its a good idea to provide a fixed secret here. The value should be

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -10,6 +10,7 @@ package sirius.web.controller;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.cookie.CookieHeaderNames;
 import sirius.kernel.async.Future;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.Streams;
@@ -65,7 +66,7 @@ public class TestController extends BasicController {
 
     @Routed("/test/cookieCacheTest")
     public void testCookieCacheTest(WebContext ctx) {
-        ctx.setCookie("Test", "1", 3600);
+        ctx.setCookie("Test", "1", 3600, CookieHeaderNames.SameSite.Strict);
         ctx.respondWith().cached().direct(HttpResponseStatus.OK, "OK");
     }
 


### PR DESCRIPTION
Set the policy to "lax" for now, which is the default (for modern browsers).
The config can be overridden to use another policy.

If the user accesses the site via SSL, the cookie is marked "secure".
In general this should not be a problem, but subsequent http-calls will be unauthenticated.