### PR TITLE
Checks whether change event has to be triggered on token create

### DIFF
--- a/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
+++ b/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
@@ -163,11 +163,11 @@ var multiSelect = function (args) {
                     return false;
                 }
             }
-
-            triggerChangeEventIfNecessary();
         } else {
             token.label = suggestions.getTokenForValue(token.value).label;
         }
+
+        triggerChangeEventIfNecessary();
 
         if (tokenfield.hasToken(token)) {
             tokenfield.removeToken(token);


### PR DESCRIPTION
Previously it only did that when the token was not already present which missed a case for the singleselect input when the selected suggestion is changed in the underlying select input via code.

More descriptive the following way of events did not trigger a change on the select:
$select::change -> tokenfield.appendTokens -> tokenfield::onBeforeCreateToken (token already present)

This was a problem as the internal `currentInput` field wasnt reset this way which resulted in no event being triggered when the user selects the old value the next time.

Sample: singleselect value item1 -> code changes value to item2 -> user selects item1 again -> no event was triggered for change from item2 to item1

Fixes: OX-6499