### PR TITLE
SIRI-306: Make session pinning work with cookie changes

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -822,6 +822,7 @@ public class WebContext implements SubContext {
     private boolean isLegacyCookieValid(String sessionPin) {
         return sessionPinLegacyCookieNames.stream()
                                           .map(this::getCookieValue)
+                                          .filter(Objects::nonNull)
                                           .map(this::calculateEffectiveSessionPin)
                                           .anyMatch(effectiveSessionPin -> Strings.areEqual(effectiveSessionPin,
                                                                                             sessionPin));

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -308,6 +308,18 @@ public class WebContext implements SubContext {
     private static boolean sessionPinning;
 
     /**
+     * Name of the session pin cookie used to validate a corresponding client session cookie
+     */
+    @ConfigValue("http.sessionCookie.pinName")
+    private static String sessionPinCookieName;
+
+    /**
+     * Name of previously used session pin cookie names that are still read for validation
+     */
+    @ConfigValue("http.sessionCookie.pinLegacyNames")
+    private static List<String> sessionPinLegacyCookieNames;
+
+    /**
      * The ttl of the client session cookie. If this is 0, it will be a "session cookie" and therefore
      * be deleted when the browser is closed
      */
@@ -782,10 +794,10 @@ public class WebContext implements SubContext {
     private void checkAndEnforceSessionPinning() {
         String givenSessionPin = getCookieValue(getSessionPinCookieName());
         String sessionPin = session.get(SESSION_PIN_KEY);
-        String effectiveSessionPin =
-                Strings.isEmpty(givenSessionPin) ? "" : Hasher.md5().hash(givenSessionPin).toHexString();
+        String effectiveSessionPin = calculateEffectiveSessionPin(givenSessionPin);
 
-        if (Strings.isFilled(sessionPin) && !Strings.areEqual(sessionPin, effectiveSessionPin)) {
+        if (Strings.isFilled(sessionPin) && !Strings.areEqual(sessionPin, effectiveSessionPin) && !isLegacyCookieValid(
+                sessionPin)) {
             SESSION_CHECK.SEVERE(Strings.apply("Session pin mismatch: %s (%s) vs. %s%n%s%n%s%nIP: %s",
                                                givenSessionPin,
                                                effectiveSessionPin,
@@ -807,8 +819,20 @@ public class WebContext implements SubContext {
         }
     }
 
+    private boolean isLegacyCookieValid(String sessionPin) {
+        return sessionPinLegacyCookieNames.stream()
+                                          .map(this::getCookieValue)
+                                          .map(this::calculateEffectiveSessionPin)
+                                          .anyMatch(effectiveSessionPin -> Strings.areEqual(effectiveSessionPin,
+                                                                                            sessionPin));
+    }
+
+    private String calculateEffectiveSessionPin(String givenSessionPin) {
+        return Strings.isEmpty(givenSessionPin) ? "" : Hasher.md5().hash(givenSessionPin).toHexString();
+    }
+
     private String getSessionPinCookieName() {
-        return sessionCookieName + "_PIN";
+        return sessionPinCookieName;
     }
 
     /**

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -114,6 +114,20 @@ http {
         # This is disabled by default as the "pin" could be misjudged as "tracking" id
         pinSession = false
 
+        # Specifies the name of the cookie used to validate a corresponding client session cookie. Only used
+        # when session pinning is activated using #pinSession
+        pinName = "SIRIUS_PIN"
+
+        # Specifies names of cookies that should be used as fallback for session pinning validation in case the
+        # regular one #pinName is not valid.
+        # Use case: The pinning cookie has by design a very long lifetime. In case of changed cookie settings, it won't
+        # be updated with those new settings and so would have different settings than the short-live session cookie.
+        # With settings (e.g. #sameSite) changed, client won't send both cookies together with would result in a
+        # session pinning error invalidating the session.
+        # How to use: Whenever changing cookie settings that will alter the client's sending behaviour, you should
+        # change the #pinName and add the old name to #pinLegacyNames
+        pinLegacyNames = ["SIRIUS_SESSION_PIN"]
+
         # Determines the livetime of the client session cookie. If this is zero a "session" cookie is
         # created which will be deleted once the browser is closed.
         ttl = 90 days


### PR DESCRIPTION
- a change of cookie settings (e.g. samesite, domain, ...) might break the attachment of session pin cookie to session cookie and so invalidate all pinned sessions
- this can be prevented using a new pinning cookie name and fallback names
- see config key description for details

