### PR TITLE
remove a comment, because classes are already autoregistered +typos

### DIFF
--- a/src/main/java/sirius/web/health/CachingLoadInfoProvider.java
+++ b/src/main/java/sirius/web/health/CachingLoadInfoProvider.java
@@ -18,9 +18,6 @@ import java.util.function.Consumer;
 
 /**
  * Provides a basic implementation which caches all computed infos for up to ten seconds.
- * <p>
- * Be aware, that subclasses have to specify <tt>LoadInfoProvider</tt> in their <tt>Register</tt> annotation:
- * {@code @Register(classes = LoadInfoProvider.class)}.
  */
 public abstract class CachingLoadInfoProvider implements LoadInfoProvider {
 

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -22,7 +22,7 @@ sirius {
         labelPrefix = "sirius_"
 
         # By default, the metrics page can only be accessed directly. All public requests,
-        # which travel through a frontedn proxy or load balancer are blocked.
+        # which travel through a frontend proxy or load balancer are blocked.
         blockPublicAccess = true
     }
 }
@@ -228,7 +228,7 @@ health {
     # Determines how many intervals of the circular buffer have to be RED to consider the system
     # as "unstable" and therefore toggle an alarm (Cluster.isAlarmPresent). Not that independently of the
     # number, the current state also has to be RED in order to report an alarm. Therefore, if a system
-    # recovers, it will be immediatelly considered healthy.
+    # recovers, it will be immediately considered healthy.
     #
     # Tweak these numbers if a metric tends to flap between RED/GREEN to provide some averaging. By default
     # these numbers are quite aggressive and might report false positives from time to time.
@@ -367,7 +367,7 @@ cache {
         ttl = 1 hour
     }
 
-    # Caches user messages accross redirects or JSON calls to display them later
+    # Caches user messages across redirects or JSON calls to display them later
     user-messages {
         maxSize = 2048
         ttl = 2 minute
@@ -523,7 +523,7 @@ crunchlog {
 # Determines the hour of the day, when old files are deleted from the crunchlog
 timer.daily.crunchlog-cleanup = 17
 
-# Contains rewirtes applied to the values within @Routed. This can be used to resolve
+# Contains rewrites applied to the values within @Routed. This can be used to resolve
 # routing conflicts with legacy controllers
 controller.rewrites {
     default {}


### PR DESCRIPTION
The annotation in subclasses will produce a startup warning "...is already autoregistered..."