### PR TITLE
Adds polyfill for forEach function of NodeList

### DIFF
--- a/src/main/resources/default/assets/common/common-polyfills.js
+++ b/src/main/resources/default/assets/common/common-polyfills.js
@@ -73,3 +73,11 @@ if (!String.prototype.endsWith) {
         return lastIndex !== -1 && lastIndex === position;
     };
 }
+
+/**
+ * Polyfill for the NodeList.forEach function
+ * see https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+ */
+if (window.NodeList && !NodeList.prototype.forEach) {
+    NodeList.prototype.forEach = Array.prototype.forEach;
+}

--- a/src/main/resources/default/templates/wondergem/scripts/polyfill.html.pasta
+++ b/src/main/resources/default/templates/wondergem/scripts/polyfill.html.pasta
@@ -73,4 +73,12 @@
             return lastIndex !== -1 && lastIndex === position;
         };
     }
+
+    /**
+     * Polyfill for the NodeList.forEach function
+     * see https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    if (window.NodeList && !NodeList.prototype.forEach) {
+        NodeList.prototype.forEach = Array.prototype.forEach;
+    }
 </script>


### PR DESCRIPTION
IE 11 actually doesnt support this. We chose the concise variant as according to MDN this is actually the way some browsers implement NodeList.forEach.

Fixes: SIRI-266