### PR TITLE
Updates to the latest netty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.49.Final</version>
+                <version>4.1.59.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Netty has reported a security issue and thus needs to be updated:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21290

Fixes: SIRI-269