### PR TITLE
SIRI-317 Fix the JMP_FALSE handling

### DIFF
--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -124,9 +124,7 @@ public class Invocation {
                     environment.writeVariable(index, pop());
                     break;
                 case JMP_FALSE:
-                    if (Boolean.FALSE.equals(pop())) {
-                        instructionPointer += index;
-                    }
+                    handleJumpFalse(index);
                     break;
                 case JMP:
                     instructionPointer += index;
@@ -263,6 +261,13 @@ public class Invocation {
             throw createVmError(Strings.apply("Cannot store into the field %s of %s",
                                               field.getName(),
                                               field.getDeclaringClass().getName()));
+        }
+    }
+
+    private void handleJumpFalse(int index) {
+        Object value = pop();
+        if (value == null || Boolean.FALSE.equals(value)) {
+            instructionPointer += index;
         }
     }
 

--- a/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
@@ -48,4 +48,20 @@ class CompilerSpec extends BaseSpecification {
         compile("NoodleExample.INSTANCE.privateField = 'Hello'; return NoodleExample.INSTANCE.privateField;").call(new SimpleEnvironment()) == "Hello"
     }
 
+    def "conditions work as expected"() {
+        expect:
+        compile(input).call(new SimpleEnvironment()) == output
+        where:
+        input            | output
+        "false"          | false
+        "true"           | true
+        "false && true"  | false
+        "true && true"   | true
+        "false || false" | false
+        "false || true"  | true
+        "null && true"   | false
+        "null && false"  | false
+        "null || true"   | true
+        "null || false"  | false
+    }
 }

--- a/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
@@ -194,6 +194,15 @@ class CompilerSpec extends BaseSpecification {
         test.basicallyEqual(result, expectedResult)
     }
 
+    def "if works as expected"() {
+        when:
+        String a = tagliatelle.resolve("/templates/if.html.pasta").get().renderToString("a")
+        String b = tagliatelle.resolve("/templates/if.html.pasta").get().renderToString("b")
+        then:
+        test.basicallyEqual(a, "a")
+        test.basicallyEqual(b, "b")
+    }
+
     def "switch works as expected"() {
         when:
         String a = tagliatelle.resolve("/templates/switch.html.pasta").get().renderToString("a")

--- a/src/test/resources/templates/if.html.pasta
+++ b/src/test/resources/templates/if.html.pasta
@@ -1,0 +1,8 @@
+<i:arg type="String" name="condition"/>
+
+<i:if test="@condition == 'a'">
+    a
+    <i:else>
+        b
+    </i:else>
+</i:if>


### PR DESCRIPTION
The JMP_FALSE opcode pops a value from the stack and will jump to a given label if the value is false. In the AND operation this will prevent the evaluation of the right operand and the whole operation will evaluate as false (See Conjunction.java). Likewise in a OR operation the JMP_FALSE will prevent the evaluation of the second operand and the whole operation will evaluate as true in case the first operand is true (See Disjunction.java).

In the case of 'null AND true' the null is not handled as being false, leading to a true evaluation of the operation. To fix this an additional check was added to handle null as false when the JMP_FALSE opcode is encountered.