### PR TITLE
Extracts the PDF image replace logic into separate handlers

### DIFF
--- a/src/main/java/sirius/web/templates/Generator.java
+++ b/src/main/java/sirius/web/templates/Generator.java
@@ -145,8 +145,8 @@ public class Generator {
      * Specifies which {@link ContentHandler} is used to generate the content.
      * <p>
      * Most of the time, the content handler is auto-detected using the file name of the template. An example
-     * would be <b>.pdf.vm</b> which will force the {@link TagliatellePDFContentHandler}
-     * to generate a PDF file using the template. However, by using {@code generator.handler("pdf-vm")}
+     * would be <b>.pdf.pasta</b> which will force the {@link sirius.web.templates.pdf.TagliatellePDFContentHandler}
+     * to generate a PDF file using the template. However, by using {@code generator.handler("pdf-pasta")}
      * it can be ensured, that this handler is picked, without relying on the file name.
      *
      * @param handlerType the name of the handler type to use. Constants can be found by looking at the
@@ -294,8 +294,8 @@ public class Generator {
      * @return <tt>true</tt> if the given template ends with the given extension, <tt>false</tt> otherwise.
      * In contrast to {@link #isTemplateFileExtension(String)} this will not consider the first "." to be the
      * file extension but rather really check if the template name ends with the given extension. Therefore
-     * for a template named <tt>test.js.vm</tt> this will return <tt>true</tt> for
-     * {@code isTemplateEndsWith(".vm")} but <tt>false</tt> for {@code isTemplateFileExtension("vm")}
+     * for a template named <tt>test.js.pasta</tt> this will return <tt>true</tt> for
+     * {@code isTemplateEndsWith(".pasta")} but <tt>false</tt> for {@code isTemplateFileExtension("pasta")}
      */
     public boolean isTemplateEndsWith(@Nonnull String extension) {
         return Strings.isFilled(templateName) && templateName.toLowerCase().endsWith(extension);

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -6,7 +6,7 @@
  * http://www.scireum.de - info@scireum.de
  */
 
-package sirius.web.templates;
+package sirius.web.templates.pdf;
 
 import com.google.zxing.Writer;
 import com.google.zxing.client.j2se.MatrixToImageWriter;

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -100,12 +100,11 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
     }
 
     private PdfReplaceHandler findHandler(String protocol) {
-        for (PdfReplaceHandler handler : handlers) {
-            if (handler.accepts(protocol)) {
-                return handler;
-            }
-        }
-
-        throw new UnsupportedOperationException(Strings.apply("No handler for protocol '%s' could be found", protocol));
+        return handlers.stream()
+                       .filter(handler -> handler.accepts(protocol))
+                       .findFirst()
+                       .orElseThrow(() -> new UnsupportedOperationException(Strings.apply(
+                               "No handler for protocol '%s' could be found",
+                               protocol)));
     }
 }

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -8,62 +8,36 @@
 
 package sirius.web.templates.pdf;
 
-import com.google.zxing.Writer;
-import com.google.zxing.client.j2se.MatrixToImageWriter;
-import com.google.zxing.common.BitMatrix;
-import com.google.zxing.qrcode.QRCodeWriter;
-import com.lowagie.text.BadElementException;
-import com.lowagie.text.Image;
-import com.lowagie.text.pdf.Barcode;
-import com.lowagie.text.pdf.Barcode128;
-import com.lowagie.text.pdf.BarcodeEAN;
-import com.lowagie.text.pdf.BarcodeInter25;
 import org.w3c.dom.Element;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.ReplacedElement;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.layout.LayoutContext;
-import org.xhtmlrenderer.pdf.ITextFSImage;
 import org.xhtmlrenderer.pdf.ITextImageElement;
 import org.xhtmlrenderer.pdf.ITextOutputDevice;
 import org.xhtmlrenderer.pdf.ITextReplacedElementFactory;
 import org.xhtmlrenderer.render.BlockBox;
 import sirius.kernel.commons.Strings;
-import sirius.kernel.commons.Tuple;
-import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.PriorityParts;
 import sirius.kernel.health.Exceptions;
-import sirius.web.resources.Resource;
-import sirius.web.resources.Resources;
-import sirius.web.security.UserContext;
+import sirius.web.templates.pdf.handlers.PdfReplaceHandler;
 
-import javax.annotation.Nonnull;
-import java.awt.Color;
-import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 
 /**
- * Used by the XHTMLRenderer (creating PDFs) to generate barcodes and to support ratio aware scaling of images.
+ * Used by the XHTMLRenderer (creating PDFs) to replace img elements by their references image.
  * <p>
- * A barcode can be added by placing an img tag with an type attribute: &lt;img type="code128" src="0815" /&gt;.
- * As type <b>code128</b>, <b>ean</b>, <b>interleaved2of5</b>, <b>interleaved2of5checksummed</b> and <b>qr</b> are
- * supported.
+ * Alongside http different URI protocols are supported. These are handled by classes extending
+ * {@link PdfReplaceHandler}.
  */
-class ImageReplacedElementFactory extends ITextReplacedElementFactory {
+public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
 
     private static final String TAG_TYPE_IMG = "img";
-
     private static final String ATTR_SRC = "src";
-    private static final String ATTR_TYPE = "type";
 
-    private static final String PROTOCOL_HTTP = "http";
-
-    private static final String BARCODE_TYPE_QR = "qr";
-    private static final String BARCODE_TYPE_CODE128 = "code128";
-    private static final String BARCODE_TYPE_EAN = "ean";
-    private static final String BARCODE_TYPE_INTERLEAVED_2_OF_5 = "interleaved2of5";
-    private static final String BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED = "interleaved2of5checksummed";
-
-    @Part
-    private static Resources resources;
+    @PriorityParts(PdfReplaceHandler.class)
+    private static List<PdfReplaceHandler> handlers;
 
     /**
      * Generates a new element factory for the given output
@@ -80,7 +54,6 @@ class ImageReplacedElementFactory extends ITextReplacedElementFactory {
                                                  UserAgentCallback uac,
                                                  int cssWidth,
                                                  int cssHeight) {
-
         Element e = box.getElement();
         if (e == null) {
             return null;
@@ -97,16 +70,10 @@ class ImageReplacedElementFactory extends ITextReplacedElementFactory {
         }
 
         try {
-            String type = e.getAttribute(ATTR_TYPE);
+            Optional<FSImage> image = resolveUri(src, uac, cssWidth, cssHeight);
 
-            if (Strings.isFilled(type)) {
-                return createImageForBarcode(type, src, cssWidth, cssHeight);
-            }
-
-            ReplacedElement image = createResizedImage(uac, cssWidth, cssHeight, src);
-
-            if (image != null) {
-                return image;
+            if (image.isPresent()) {
+                return new ITextImageElement(image.get());
             }
         } catch (Exception ex) {
             Exceptions.handle(ex);
@@ -115,177 +82,30 @@ class ImageReplacedElementFactory extends ITextReplacedElementFactory {
         return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
     }
 
-    private ReplacedElement createResizedImage(UserAgentCallback uac, int cssWidth, int cssHeight, String src)
-            throws BadElementException, IOException {
-        FSImage image = null;
-        if (!src.toLowerCase().startsWith(PROTOCOL_HTTP)) {
-            Resource resource = resources.resolve(UserContext.getCurrentScope().getScopeId(), src).orElse(null);
-            if (resource != null) {
-                try {
-                    // First try to load the URL via the user agent - this will somehow result
-                    // in better images (correct DPI settings)
-                    image = uac.getImageResource(resource.getUrl().toString()).getImage();
-                } catch (Exception t) {
-                    // Fallback which works but seems to have strange DPI settings sometimes
-                    image = new ITextFSImage(Image.getInstance(resource.getUrl()));
-                }
+    private Optional<FSImage> resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight) {
+        String protocol = Strings.split(uri, "://").getFirst();
+        PdfReplaceHandler handler = findHandler(protocol);
+
+        try {
+            FSImage image = handler.resolveUri(uri, userAgentCallback, cssWidth, cssHeight);
+
+            if (image != null) {
+                return Optional.of(image);
+            }
+        } catch (Exception e) {
+            Exceptions.handle(e);
+        }
+
+        return Optional.empty();
+    }
+
+    private PdfReplaceHandler findHandler(String protocol) {
+        for (PdfReplaceHandler handler : handlers) {
+            if (handler.accepts(protocol)) {
+                return handler;
             }
         }
 
-        if (image == null) {
-            image = uac.getImageResource(src).getImage();
-        }
-
-        if (image != null) {
-            if (cssWidth != -1 || cssHeight != -1) {
-                Tuple<Integer, Integer> newSize = computeResizeBox(cssWidth, cssHeight, image);
-                if (newSize != null) {
-                    image.scale(newSize.getFirst(), newSize.getSecond());
-                }
-            }
-            return new ITextImageElement(image);
-        }
-        return null;
-    }
-
-    private ReplacedElement createImageForBarcode(String type, String src, int cssWidth, int cssHeight)
-            throws Exception {
-        if (BARCODE_TYPE_QR.equalsIgnoreCase(type)) {
-            Writer writer = new QRCodeWriter();
-            BitMatrix matrix = writer.encode(src,
-                                             com.google.zxing.BarcodeFormat.QR_CODE,
-                                             cssWidth != -1 ? cssWidth : 600,
-                                             cssHeight != -1 ? cssHeight : 600);
-
-            FSImage fsImage =
-                    new ITextFSImage(Image.getInstance(MatrixToImageWriter.toBufferedImage(matrix), Color.WHITE));
-
-            if (cssWidth != -1 || cssHeight != -1) {
-                fsImage.scale(cssWidth, cssHeight);
-            }
-
-            return new ITextImageElement(fsImage);
-        }
-
-        Barcode code = createBarcode(type);
-        code.setCode(padCodeIfNecessary(code, src));
-
-        java.awt.Image awtImage = code.createAwtImage(Color.BLACK, Color.WHITE);
-
-        int scaleFactor = calculateBarcodeScaleFactor(cssWidth, cssHeight, awtImage);
-
-        awtImage = awtImage.getScaledInstance(awtImage.getWidth(null) * scaleFactor,
-                                              awtImage.getHeight(null) * scaleFactor,
-                                              java.awt.Image.SCALE_REPLICATE);
-
-        FSImage fsImage = new ITextFSImage(Image.getInstance(awtImage, Color.WHITE, true));
-
-        if (cssWidth != -1 || cssHeight != -1) {
-            fsImage.scale(cssWidth, cssHeight);
-        }
-
-        return new ITextImageElement(fsImage);
-    }
-
-    private int calculateBarcodeScaleFactor(int cssWidth, int cssHeight, java.awt.Image awtImage) {
-        return (int) Math.max(Math.ceil(cssWidth / (float) awtImage.getWidth(null)),
-                              Math.ceil(cssHeight / (float) awtImage.getHeight(null)));
-    }
-
-    /**
-     * Creates an instance of {@link Barcode} that matches the given type descriptor.
-     *
-     * @param type the requested type
-     * @return the barcode
-     */
-    @Nonnull
-    private Barcode createBarcode(String type) {
-        if (BARCODE_TYPE_CODE128.equalsIgnoreCase(type)) {
-            return new Barcode128();
-        }
-
-        if (BARCODE_TYPE_EAN.equalsIgnoreCase(type)) {
-            return new BarcodeEAN();
-        }
-
-        if (BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(type)) {
-            return new BarcodeInter25();
-        }
-
-        if (BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(type)) {
-            Barcode code = new BarcodeInter25();
-            code.setGenerateChecksum(true);
-            return code;
-        }
-
-        throw new UnsupportedOperationException("Type is not supported");
-    }
-
-    /**
-     * Pad the code if necessary.
-     * <p>
-     * Unfortunately padding will not be added automatically when using <b>interleaved2of5</b> or
-     * <b>interleaved2of5checksummed</b>. Thus we manually prepend a zero if the code length is uneven.
-     *
-     * @param code the instance of the barcode
-     * @param src  the code from the src attribute
-     * @return the padded code, or the original code if padding was not needed
-     */
-    private String padCodeIfNecessary(Barcode code, String src) {
-        if (code instanceof BarcodeInter25) {
-            int length = BarcodeInter25.keepNumbers(src).length();
-
-            // Length is uneven and no checksum will be added
-            if (length % 2 != 0 && !code.isGenerateChecksum()) {
-                return "0" + src;
-            }
-
-            // Length is even but a checksum will be added
-            if (length % 2 == 0 && code.isGenerateChecksum()) {
-                return "0" + src;
-            }
-        }
-
-        return src;
-    }
-
-    /**
-     * Computes a width and height according to cssWidth and cssHeight while maintaining the original aspect ratio.
-     *
-     * @param cssWidth  the effective width set by attributes or css
-     * @param cssHeight the effective height set by attributes or css
-     * @param fsImage   the image to scale down
-     * @return a new width and height fitting into a rectangle defined by cssWidth/cssHeight
-     */
-    private Tuple<Integer, Integer> computeResizeBox(int cssWidth, int cssHeight, FSImage fsImage) {
-        if (cssWidth == -1 && cssHeight == -1) {
-            return null;
-        }
-
-        int newWidth = -1;
-        int newHeight = fsImage.getHeight();
-
-        // Downsize and maintain aspect ratio...
-        if (fsImage.getWidth() > cssWidth && cssWidth > -1) {
-            newWidth = cssWidth;
-            newHeight = (newWidth * fsImage.getHeight()) / fsImage.getWidth();
-        }
-
-        if (cssHeight > -1 && newHeight > cssHeight) {
-            newHeight = cssHeight;
-            newWidth = (newHeight * fsImage.getWidth()) / fsImage.getHeight();
-        }
-
-        // No resize required
-        if (newWidth == -1) {
-            return null;
-        }
-
-        // No upscaling!
-        if (newWidth > fsImage.getWidth() || newHeight > fsImage.getHeight()) {
-            return null;
-        }
-
-        return Tuple.create(newWidth, newHeight);
+        throw new UnsupportedOperationException(Strings.apply("No handler for protocol '%s' could be found", protocol));
     }
 }

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
@@ -6,13 +6,16 @@
  * http://www.scireum.de - info@scireum.de
  */
 
-package sirius.web.templates;
+package sirius.web.templates.pdf;
 
 import org.xhtmlrenderer.pdf.ITextRenderer;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
+import sirius.web.templates.ContentHandler;
+import sirius.web.templates.Generator;
+import sirius.web.templates.TagliatelleContentHandler;
 
 import java.io.OutputStream;
 

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -23,7 +23,7 @@ import java.awt.Color;
 import java.awt.Image;
 
 /**
- * Responsible for resolving barcode:// URIs.
+ * Resolves barcode:// URIs to barcode images.
  * <p>
  * The format of the URI needs to match barcode://type/content. As type <b>code128</b>, <b>ean</b>,
  * <b>interleaved2of5</b> and <b>interleaved2of5checksummed</b> are supported. The content is the number that should be
@@ -106,7 +106,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
     }
 
     /**
-     * Pad the code if necessary.
+     * Pads the code if necessary.
      * <p>
      * Unfortunately padding will not be added automatically when using <b>interleaved2of5</b> or
      * <b>interleaved2of5checksummed</b>. Thus we manually prepend a zero if the code length is uneven.

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -1,0 +1,135 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf.handlers;
+
+import com.lowagie.text.pdf.Barcode;
+import com.lowagie.text.pdf.Barcode128;
+import com.lowagie.text.pdf.BarcodeEAN;
+import com.lowagie.text.pdf.BarcodeInter25;
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.pdf.ITextFSImage;
+import sirius.kernel.commons.Strings;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.awt.Color;
+import java.awt.Image;
+
+/**
+ * Responsible for resolving barcode:// URIs.
+ * <p>
+ * The format of the URI needs to match barcode://type/content. As type <b>code128</b>, <b>ean</b>,
+ * <b>interleaved2of5</b> and <b>interleaved2of5checksummed</b> are supported. The content is the number that should be
+ * represented by the barcode.
+ */
+public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
+
+    private static final String BARCODE_TYPE_CODE128 = "code128";
+    private static final String BARCODE_TYPE_EAN = "ean";
+    private static final String BARCODE_TYPE_INTERLEAVED_2_OF_5 = "interleaved2of5";
+    private static final String BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED = "interleaved2of5checksummed";
+
+    @Override
+    public boolean accepts(String protocol) {
+        return "barcode".equals(protocol);
+    }
+
+    @Nullable
+    @Override
+    public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
+            throws Exception {
+        String[] barcodeInfo = Strings.split(uri, "://").getSecond().split("/");
+
+        if (barcodeInfo.length != 2) {
+            throw new IllegalArgumentException("The URI is required to match the format 'barcode://type/content'");
+        }
+
+        Barcode code = createBarcode(barcodeInfo[0]);
+        code.setCode(padCodeIfNecessary(code, barcodeInfo[1]));
+
+        Image awtImage = code.createAwtImage(Color.BLACK, Color.WHITE);
+
+        int scaleFactor = calculateBarcodeScaleFactor(cssWidth, cssHeight, awtImage);
+
+        awtImage = awtImage.getScaledInstance(awtImage.getWidth(null) * scaleFactor,
+                                              awtImage.getHeight(null) * scaleFactor,
+                                              Image.SCALE_REPLICATE);
+
+        FSImage fsImage = new ITextFSImage(com.lowagie.text.Image.getInstance(awtImage, Color.WHITE, true));
+
+        if (cssWidth != -1 || cssHeight != -1) {
+            fsImage.scale(cssWidth, cssHeight);
+        }
+
+        return fsImage;
+    }
+
+    private int calculateBarcodeScaleFactor(int cssWidth, int cssHeight, Image awtImage) {
+        return (int) Math.max(Math.ceil(cssWidth / (float) awtImage.getWidth(null)),
+                              Math.ceil(cssHeight / (float) awtImage.getHeight(null)));
+    }
+
+    /**
+     * Creates an instance of {@link Barcode} that matches the given type descriptor.
+     *
+     * @param type the requested type
+     * @return the barcode
+     */
+    @Nonnull
+    private Barcode createBarcode(String type) {
+        if (BARCODE_TYPE_CODE128.equalsIgnoreCase(type)) {
+            return new Barcode128();
+        }
+
+        if (BARCODE_TYPE_EAN.equalsIgnoreCase(type)) {
+            return new BarcodeEAN();
+        }
+
+        if (BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(type)) {
+            return new BarcodeInter25();
+        }
+
+        if (BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(type)) {
+            Barcode code = new BarcodeInter25();
+            code.setGenerateChecksum(true);
+            return code;
+        }
+
+        throw new UnsupportedOperationException(Strings.apply("Type '%s' is not supported", type));
+    }
+
+    /**
+     * Pad the code if necessary.
+     * <p>
+     * Unfortunately padding will not be added automatically when using <b>interleaved2of5</b> or
+     * <b>interleaved2of5checksummed</b>. Thus we manually prepend a zero if the code length is uneven.
+     *
+     * @param code the instance of the barcode
+     * @param src  the code from the src attribute
+     * @return the padded code, or the original code if padding was not needed
+     */
+    private String padCodeIfNecessary(Barcode code, String src) {
+        if (code instanceof BarcodeInter25) {
+            int length = BarcodeInter25.keepNumbers(src).length();
+
+            // Length is uneven and no checksum will be added
+            if (length % 2 != 0 && !code.isGenerateChecksum()) {
+                return "0" + src;
+            }
+
+            // Length is even but a checksum will be added
+            if (length % 2 == 0 && code.isGenerateChecksum()) {
+                return "0" + src;
+            }
+        }
+
+        return src;
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -16,6 +16,7 @@ import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.pdf.ITextFSImage;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,6 +30,7 @@ import java.awt.Image;
  * <b>interleaved2of5</b> and <b>interleaved2of5checksummed</b> are supported. The content is the number that should be
  * represented by the barcode.
  */
+@Register
 public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
 
     private static final String BARCODE_TYPE_CODE128 = "code128";

--- a/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
@@ -15,7 +15,7 @@ import sirius.kernel.di.std.Register;
 import javax.annotation.Nullable;
 
 /**
- * Responsible for resolving http:// and https:// URIs and resizing the image while maintaining the image ratio.
+ * Resolves http:// and https:// URIs to resized images while maintaining the image ratios.
  */
 @Register
 public class HttpPdfReplaceHandler extends PdfReplaceHandler {

--- a/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf.handlers;
+
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nullable;
+
+/**
+ * Responsible for resolving http:// and https:// URIs and resizing the image while maintaining the image ratio.
+ */
+@Register
+public class HttpPdfReplaceHandler extends PdfReplaceHandler {
+
+    @Override
+    public boolean accepts(String protocol) {
+        return protocol.startsWith("http");
+    }
+
+    @Override
+    @Nullable
+    public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
+            throws Exception {
+        return resizeImage(userAgentCallback.getImageResource(uri).getImage(), cssWidth, cssHeight);
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -1,0 +1,141 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf.handlers;
+
+import com.lowagie.text.BadElementException;
+import com.lowagie.text.Image;
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.pdf.ITextFSImage;
+import sirius.kernel.commons.Tuple;
+import sirius.kernel.di.std.AutoRegister;
+import sirius.kernel.di.std.Priorized;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Represents a image replace handler that is used by {@link sirius.web.templates.pdf.ImageReplacedElementFactory} to
+ * resolve an image URI with a specific protocol.
+ */
+@AutoRegister
+public abstract class PdfReplaceHandler implements Priorized {
+
+    @Override
+    public int getPriority() {
+        return Priorized.DEFAULT_PRIORITY;
+    }
+
+    /**
+     * Determines if this handler can resolve a URI with the given protocol.
+     *
+     * @param protocol the protocol to check
+     * @return <tt>true</tt> if {@link #resolveUri(String, UserAgentCallback, int, int)} should be called for the given
+     * protocol, <tt>false</tt> otherwise
+     */
+    public abstract boolean accepts(String protocol);
+
+    /**
+     * Resolves the image with the given URI.
+     *
+     * @param uri               the URI to resolve
+     * @param userAgentCallback the user agent to use to resolve image resources
+     * @param cssWidth          the requested image width in pixels
+     * @param cssHeight         the requested image height in pixels
+     * @return the image if the URI could be resolved, <tt>null</tt> otherwise
+     * @throws Exception in case of an error while resolving the URI.
+     */
+    @Nullable
+    public abstract FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
+            throws Exception;
+
+    /**
+     * Resolves the image with the given URL.
+     *
+     * @param userAgentCallback the user agent to use to resolve image resources
+     * @param url               the URL to resolve
+     * @return the resolved image
+     * @throws BadElementException in case the  resource doesn't have a valid format
+     * @throws IOException         in case of an IO error
+     */
+    protected FSImage resolveResource(UserAgentCallback userAgentCallback, URL url)
+            throws BadElementException, IOException {
+        try {
+            // First try to load the URL via the user agent - this will somehow result
+            // in better images (correct DPI settings)
+            return userAgentCallback.getImageResource(url.toString()).getImage();
+        } catch (Exception t) {
+            // Fallback which works but seems to have strange DPI settings sometimes
+            return new ITextFSImage(Image.getInstance(url));
+        }
+    }
+
+    /**
+     * Resizes the given image while maintaining the correct ratio.
+     *
+     * @param image     the image to resize
+     * @param cssWidth  the requested image width in pixels
+     * @param cssHeight the requested image height in pixels
+     * @return the resized image
+     */
+    @Nonnull
+    protected FSImage resizeImage(@Nonnull FSImage image, int cssWidth, int cssHeight) {
+        if (cssWidth != -1 || cssHeight != -1) {
+            Tuple<Integer, Integer> newSize = computeResizeBox(cssWidth, cssHeight, image);
+
+            if (newSize != null) {
+                image.scale(newSize.getFirst(), newSize.getSecond());
+            }
+        }
+
+        return image;
+    }
+
+    /**
+     * Computes a width and height according to cssWidth and cssHeight while maintaining the original aspect ratio.
+     *
+     * @param cssWidth  the effective width set by attributes or css
+     * @param cssHeight the effective height set by attributes or css
+     * @param fsImage   the image to scale down
+     * @return a new width and height fitting into a rectangle defined by cssWidth/cssHeight
+     */
+    private Tuple<Integer, Integer> computeResizeBox(int cssWidth, int cssHeight, FSImage fsImage) {
+        if (cssWidth == -1 && cssHeight == -1) {
+            return null;
+        }
+
+        int newWidth = -1;
+        int newHeight = fsImage.getHeight();
+
+        // Downsize and maintain aspect ratio...
+        if (fsImage.getWidth() > cssWidth && cssWidth > -1) {
+            newWidth = cssWidth;
+            newHeight = (newWidth * fsImage.getHeight()) / fsImage.getWidth();
+        }
+
+        if (cssHeight > -1 && newHeight > cssHeight) {
+            newHeight = cssHeight;
+            newWidth = (newHeight * fsImage.getWidth()) / fsImage.getHeight();
+        }
+
+        // No resize required
+        if (newWidth == -1) {
+            return null;
+        }
+
+        // No upscaling!
+        if (newWidth > fsImage.getWidth() || newHeight > fsImage.getHeight()) {
+            return null;
+        }
+
+        return Tuple.create(newWidth, newHeight);
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 import java.awt.Color;
 
 /**
- * Responsible for resolving qr:// URIs.
+ * Resolves qr:// URIs to QR code images.
  * <p>
  * The format of the URI needs to match qr://content where content is the data that should be represented by the QR
  * code.

--- a/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
@@ -17,6 +17,7 @@ import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.pdf.ITextFSImage;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nullable;
 import java.awt.Color;
@@ -27,6 +28,7 @@ import java.awt.Color;
  * The format of the URI needs to match qr://content where content is the data that should be represented by the QR
  * code.
  */
+@Register
 public class QrCodePdfReplaceHandler extends PdfReplaceHandler {
 
     @Override

--- a/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf.handlers;
+
+import com.google.zxing.Writer;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.lowagie.text.Image;
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.pdf.ITextFSImage;
+import sirius.kernel.commons.Strings;
+
+import javax.annotation.Nullable;
+import java.awt.Color;
+
+/**
+ * Responsible for resolving qr:// URIs.
+ * <p>
+ * The format of the URI needs to match qr://content where content is the data that should be represented by the QR
+ * code.
+ */
+public class QrCodePdfReplaceHandler extends PdfReplaceHandler {
+
+    @Override
+    public boolean accepts(String protocol) {
+        return "qr".equals(protocol);
+    }
+
+    @Nullable
+    @Override
+    public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
+            throws Exception {
+        String data = Strings.split(uri, "://").getSecond();
+
+        Writer writer = new QRCodeWriter();
+        BitMatrix matrix = writer.encode(data,
+                                         com.google.zxing.BarcodeFormat.QR_CODE,
+                                         cssWidth != -1 ? cssWidth : 600,
+                                         cssHeight != -1 ? cssHeight : 600);
+
+        FSImage fsImage = new ITextFSImage(Image.getInstance(MatrixToImageWriter.toBufferedImage(matrix), Color.WHITE));
+
+        if (cssWidth != -1 || cssHeight != -1) {
+            fsImage.scale(cssWidth, cssHeight);
+        }
+
+        return fsImage;
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf.handlers;
+
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+import sirius.web.resources.Resource;
+import sirius.web.resources.Resources;
+
+import javax.annotation.Nullable;
+
+/**
+ * Responsible for resolving resource:// URIs using {@link Resources} and resizing the image while maintaining the image
+ * ratio.
+ */
+@Register
+public class ResourcePdfReplaceHandler extends PdfReplaceHandler {
+
+    @Part
+    private Resources resources;
+
+    @Override
+    public boolean accepts(String protocol) {
+        return "resource".equals(protocol);
+    }
+
+    @Override
+    @Nullable
+    public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
+            throws Exception {
+        String path = Strings.split(uri, "://").getSecond();
+        Resource resource = resources.resolve(path).orElse(null);
+
+        if (resource != null) {
+            return resizeImage(resolveResource(userAgentCallback, resource.getUrl()), cssWidth, cssHeight);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
@@ -19,8 +19,8 @@ import sirius.web.resources.Resources;
 import javax.annotation.Nullable;
 
 /**
- * Responsible for resolving resource:// URIs using {@link Resources} and resizing the image while maintaining the image
- * ratio.
+ * Resolves resource:// URIs that are referencing {@link Resources} to resized images while maintaining the image
+ * ratios.
  */
 @Register
 public class ResourcePdfReplaceHandler extends PdfReplaceHandler {


### PR DESCRIPTION
This allows for easy integration of custom logic (for example embedding blobs without the use of http).

Migration:
If internal resources (assets) are used via relative URLs these need to be prepended with resource://.

Barcodes and QR codes using the type attribute in the img tag are now instead generated by using the barcode:// and qr:// URI protocols.