### PR TITLE
SIRI-321 Fix Optional<T>.orElse(null) resulting in return type void

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
@@ -44,7 +44,7 @@ public class TypeTools {
         TypeVariable<?>[] variables = ((Class<?>) parameterizedType.getRawType()).getTypeParameters();
         Type[] actualParameters = parameterizedType.getActualTypeArguments();
         for (int i = 0; i < variables.length; i++) {
-            typeTable.put(variables[i].getName(), actualParameters[i]);
+            addTypeVariableInfo(variables[i].getName(), actualParameters[i]);
         }
 
         reduceTable();
@@ -61,8 +61,8 @@ public class TypeTools {
      */
     public TypeTools withMethod(Method method, Node[] parameters) {
         for (TypeVariable<?> methodVariable : method.getTypeParameters()) {
-            typeTable.put(methodVariable.getName(),
-                          methodVariable.getBounds().length > 0 ? methodVariable.getBounds()[0] : Object.class);
+            addTypeVariableInfo(methodVariable.getName(),
+                                methodVariable.getBounds().length > 0 ? methodVariable.getBounds()[0] : Object.class);
         }
 
         for (int i = 0; i < method.getParameterCount() && i < parameters.length; i++) {
@@ -102,7 +102,7 @@ public class TypeTools {
 
         // For a constant class, we know the resulting type...
         if (parameter.isConstant() && Class.class.isAssignableFrom(parameter.getType())) {
-            typeTable.put(typeVariableName, (Class<?>) parameter.getConstantValue());
+            addTypeVariableInfo(typeVariableName, (Class<?>) parameter.getConstantValue());
         }
     }
 
@@ -116,11 +116,7 @@ public class TypeTools {
         Type genericType = parameter.getGenericType();
         Type type = genericType == null ? parameter.getType() : genericType;
 
-        if ("void".equals(type.getTypeName())) {
-            typeTable.putIfAbsent(typeVariableName, type);
-        } else {
-            typeTable.put(typeVariableName, type);
-        }
+        addTypeVariableInfo(typeVariableName, type);
     }
 
     private void propagateConstantValueArrayTypeInfos(Type parameterType, Node parameter) {
@@ -133,11 +129,18 @@ public class TypeTools {
         String typeVariableName =
                 ((TypeVariable<?>) ((GenericArrayType) parameterType).getGenericComponentType()).getName();
         if (parameter.getType().isArray()) {
-            typeTable.put(typeVariableName, parameter.getType().getComponentType());
+            addTypeVariableInfo(typeVariableName, parameter.getType().getComponentType());
         } else {
             // seems to be a var args parameter..
             Type genericType = parameter.getGenericType();
-            typeTable.put(typeVariableName, genericType == null ? parameter.getType() : genericType);
+            addTypeVariableInfo(typeVariableName, genericType == null ? parameter.getType() : genericType);
+        }
+    }
+
+    private void addTypeVariableInfo(String typeVariableName, Type type) {
+        // Ignore void as this info is useless for us and we might even override good info
+        if (type != void.class) {
+            typeTable.put(typeVariableName, type);
         }
     }
 

--- a/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
@@ -51,7 +51,7 @@ public class TypeTools {
     }
 
     /**
-     * Tries to derive even more type variables by inspecting the given method an its parameters.
+     * Tries to derive even more type variables by inspecting the given method and its parameters.
      * <p>
      * This essentially can derive type variables from class, object or array parameters.
      *
@@ -114,7 +114,13 @@ public class TypeTools {
 
         String typeVariableName = ((TypeVariable<?>) parameterType).getName();
         Type genericType = parameter.getGenericType();
-        typeTable.put(typeVariableName, genericType == null ? parameter.getType() : genericType);
+        Type type = genericType == null ? parameter.getType() : genericType;
+
+        if ("void".equals(type.getTypeName())) {
+            typeTable.putIfAbsent(typeVariableName, type);
+        } else {
+            typeTable.put(typeVariableName, type);
+        }
     }
 
     private void propagateConstantValueArrayTypeInfos(Type parameterType, Node parameter) {

--- a/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
@@ -59,6 +59,9 @@ class CompilerSpec extends BaseSpecification {
         and:
         compile("NoodleExample.INSTANCE.privateField = 'Hello'; return NoodleExample.INSTANCE.privateField;").
                 call(new SimpleEnvironment()) == "Hello"
+        and:
+        compile("NoodleExample.filledOptional().orElse(null).privateField").
+                call(new SimpleEnvironment()) == "Hello World"
     }
 
     def "parsing let/if/for works"() {

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
@@ -8,7 +8,7 @@
 
 package sirius.pasta.noodle.compiler;
 
-import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.Stream;
@@ -58,6 +58,10 @@ public class NoodleExample {
 
     public static <E> Stream<E> singletonStream(E value) {
         return Stream.of(value);
+    }
+
+    public static Optional<NoodleExample> filledOptional() {
+        return Optional.of(new NoodleExample());
     }
 
     public static Consumer<Integer> intConsumer() {

--- a/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
@@ -108,6 +108,18 @@ class CompilerSpec extends BaseSpecification {
         ctx.getTemplate().renderToString(TestObject.INSTANCE) == "est"
     }
 
+    def "generic type propagation works with null"() {
+        when:
+        def source = "<i:arg type=\"sirius.pasta.tagliatelle.TestObject\" name=\"test\"/>" +
+                "@test.emptyOptional().orElse(null).substring(1)"
+        def ctx = new TemplateCompilationContext(new Template("test", null), SourceCodeInfo.forInlineCode(source), null)
+        List<CompileError> errors = new TemplateCompiler(ctx).compile()
+        then:
+        errors.size() == 0
+        and:
+        ctx.getTemplate().renderToString(TestObject.INSTANCE) == ""
+    }
+
     def "generic type propagation works for class parameters"() {
         when:
         def source = "@helper(sirius.pasta.tagliatelle.ExampleHelper.class).getTestValue()"

--- a/src/test/java/sirius/pasta/tagliatelle/TestObject.java
+++ b/src/test/java/sirius/pasta/tagliatelle/TestObject.java
@@ -12,6 +12,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.ValueHolder;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -32,5 +33,9 @@ public class TestObject extends GenericTestObject<String> {
     @Deprecated
     public void deprecatedMethod() {
         // Nothing to do...
+    }
+
+    public Optional<String> emptyOptional() {
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
The problem surfaces when we try to resolve the type of a method call. In the case of `Optional<String>.empty().orElse(null)` we already know the return type (T) will be String. But our logic throws this info away and replaces it with void when propagating the type of the null parameter value.