### PR TITLE
Allows to add rows into sheets already created

### DIFF
--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -238,7 +238,6 @@ public class ExcelExport {
         if (sheetIndex < 0) {
             throw Exceptions.handle().withSystemErrorMessage("Workbook has no Sheet named '%s'.", name).handle();
         }
-        workbook.setSelectedTab(sheetIndex);
         currentSheet = workbook.getSheetAt(sheetIndex);
     }
 

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -229,11 +229,13 @@ public class ExcelExport {
     }
 
     /**
-     * Sets the sheet provided as the currently selected sheet.
+     * Sets the sheet provided as the current sheet to receive data.
+     * <p>
+     * Note that this won't change the Sheet visible when the file is open.
      *
      * @param name the name of the worksheet
      */
-    public void selectSheet(String name) {
+    public void setCurrentSheet(String name) {
         int sheetIndex = workbook.getSheetIndex(name);
         if (sheetIndex < 0) {
             throw Exceptions.handle().withSystemErrorMessage("Workbook has no Sheet named '%s'.", name).handle();

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -226,6 +226,20 @@ public class ExcelExport {
     }
 
     /**
+     * Sets the sheet provided as the currently selected sheet.
+     *
+     * @param name the name of the worksheet
+     */
+    public void selectSheet(String name) {
+        int sheetIndex = workbook.getSheetIndex(name);
+        if (sheetIndex < 0) {
+            throw Exceptions.handle().withSystemErrorMessage("Workbook has no Sheet named '%s'.", name).handle();
+        }
+        workbook.setSelectedTab(sheetIndex);
+        currentSheet = workbook.getSheetAt(sheetIndex);
+    }
+
+    /**
      * Creates a new export which uses the legacy Excel'97 format (.xls).
      *
      * @return a new exporter using the Excel'97 format

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -228,7 +228,7 @@ public class ExcelExport {
     /**
      * Sets the sheet provided as the current sheet to receive data.
      * <p>
-     * Note that this won't change the Sheet visible when the file is open.
+     * Note that this won't set the Sheet active when the file is opened.
      *
      * @param name the name of the worksheet
      */

--- a/src/test/java/sirius/web/data/ExcelExportSpec.groovy
+++ b/src/test/java/sirius/web/data/ExcelExportSpec.groovy
@@ -85,6 +85,34 @@ class ExcelExportSpec extends BaseSpecification {
         Files.delete(testFile)
     }
 
+    def "create excel sheet with multiple sheets"() {
+        given:
+        File testFile = File.createTempFile("excel-output", ".xlsx")
+        def data = [["S1-A-1", "S1-B-1", "S1-C-1"], ["S1-A-2", "S1-B-2", "S1-C-2"], ["S2-A-1", "S2-B-1", "S2-C-1"], ["S2-A-2", "S2-B-2", "S2-C-2"]]
+        when:
+        ExcelExport export = ExcelExport.asStreamingXLSX(false)
+        export.createSheet("First Sheet")
+        export.addRowAsList(data[0] as ArrayList)
+        export.createSheet("Second Sheet")
+        export.addRowAsList(data[2] as ArrayList)
+        export.setCurrentSheet("First Sheet")
+        export.addRowAsList(data[1] as ArrayList)
+        export.setCurrentSheet("Second Sheet")
+        export.addRowAsList(data[3] as ArrayList)
+        export.writeToStream(new FileOutputStream(testFile))
+        then:
+        def currentData = 0
+        XLSXProcessor.create(testFile.getName(), new FileInputStream(testFile), true)
+                     .run({
+                              lineNum, row ->
+                                  assert row.asList() == data[currentData]
+                                  currentData++
+                          },
+                          { e -> false })
+        cleanup:
+        Files.delete(testFile)
+    }
+
     @Scope(Scope.SCOPE_NIGHTLY)
     def "only allow 1 million rows in an xlsx excel sheet"() {
         given:

--- a/src/test/java/sirius/web/data/ExcelExportSpec.groovy
+++ b/src/test/java/sirius/web/data/ExcelExportSpec.groovy
@@ -91,13 +91,13 @@ class ExcelExportSpec extends BaseSpecification {
         def data = [["S1-A-1", "S1-B-1", "S1-C-1"], ["S1-A-2", "S1-B-2", "S1-C-2"], ["S2-A-1", "S2-B-1", "S2-C-1"], ["S2-A-2", "S2-B-2", "S2-C-2"]]
         when:
         ExcelExport export = ExcelExport.asStreamingXLSX(false)
-        export.createSheet("First Sheet")
+        export.createSheet()
         export.addRowAsList(data[0] as ArrayList)
-        export.createSheet("Second Sheet")
+        export.createSheet()
         export.addRowAsList(data[2] as ArrayList)
-        export.setCurrentSheet("First Sheet")
+        export.setCurrentSheet(0)
         export.addRowAsList(data[1] as ArrayList)
-        export.setCurrentSheet("Second Sheet")
+        export.setCurrentSheet(1)
         export.addRowAsList(data[3] as ArrayList)
         export.writeToStream(new FileOutputStream(testFile))
         then:


### PR DESCRIPTION
A new method allow us to select the Sheet to add rows, needed when we need to jump back and forth across sheets.

Note that this won't change the actual visible sheet once Excel opens. The first sheet remains as the visible one. A method could be added to change the current visible sheet if the need arrises.

Fixes: OX-6630