### PR TITLE
Simplifies the coercing of numbers when evaluating binary operations

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
@@ -132,15 +132,18 @@ public class Assembler {
 
         if (Long.class.equals(boxedOtherType) && Integer.class.equals(boxedType)) {
             emitByteCode(OpCode.COERCE_INT_TO_LONG, 0, position);
+            return;
         }
 
         if (Double.class.equals(boxedOtherType)) {
             if (Long.class.equals(boxedType)) {
                 emitByteCode(OpCode.COERCE_LONG_TO_DOUBLE, 0, position);
+                return;
             }
 
             if (Integer.class.equals(boxedType)) {
                 emitByteCode(OpCode.COERCE_INT_TO_DOUBLE, 0, position);
+                return;
             }
         }
     }

--- a/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
@@ -123,16 +123,24 @@ public class Assembler {
      * @param otherType the target type expected by the subsequent bytecodes
      */
     public void coerce(Position position, Class<?> type, Class<?> otherType) {
-        if (Long.class.equals(CompilationContext.autoboxClass(type)) && CompilationContext.isAssignableTo(Double.class,
-                                                                                                          CompilationContext
-                                                                                                                  .autoboxClass(
-                                                                                                                          otherType))) {
-            emitByteCode(OpCode.COERCE_LONG_TO_DOUBLE, 0, position);
-        } else if (Integer.class.equals(CompilationContext.autoboxClass(type))) {
-            if (CompilationContext.isAssignableTo(Double.class, CompilationContext.autoboxClass(otherType))) {
+        Class<?> boxedType = CompilationContext.autoboxClass(type);
+        Class<?> boxedOtherType = CompilationContext.autoboxClass(otherType);
+
+        if (boxedType.equals(boxedOtherType)) {
+            return;
+        }
+
+        if (Long.class.equals(boxedOtherType) && Integer.class.equals(boxedType)) {
+            emitByteCode(OpCode.COERCE_INT_TO_LONG, 0, position);
+        }
+
+        if (Double.class.equals(boxedOtherType)) {
+            if (Long.class.equals(boxedType)) {
+                emitByteCode(OpCode.COERCE_LONG_TO_DOUBLE, 0, position);
+            }
+
+            if (Integer.class.equals(boxedType)) {
                 emitByteCode(OpCode.COERCE_INT_TO_DOUBLE, 0, position);
-            } else if (CompilationContext.isAssignableTo(Long.class, CompilationContext.autoboxClass(otherType))) {
-                emitByteCode(OpCode.COERCE_INT_TO_LONG, 0, position);
             }
         }
     }

--- a/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
@@ -45,6 +45,10 @@ class CompilerSpec extends BaseSpecification {
         compile("NoodleExample.longToString(NoodleExample.AN_INT)").call(new SimpleEnvironment()) == "3"
         and:
         compile("NoodleExample.AN_INT + NoodleExample.A_LONG_OBJECT").call(new SimpleEnvironment()) == 36L
+        and:
+        compile("NoodleExample.A_DOUBLE + NoodleExample.AN_INT").call(new SimpleEnvironment()) == 4.2
+        and:
+        compile("NoodleExample.A_DOUBLE + NoodleExample.A_LONG").call(new SimpleEnvironment()) == 5.2
     }
 
 

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
@@ -22,6 +22,7 @@ public class NoodleExample {
     public static final long A_LONG = 4L;
     public static final Integer AN_INTEGER_OBJECT = Integer.valueOf(12);
     public static final Long A_LONG_OBJECT = Long.valueOf(33);
+    public static final Double A_DOUBLE = 1.2;
     public static final NoodleExample INSTANCE = new NoodleExample();
 
     public static String intToString(int number) {


### PR DESCRIPTION
The current construct is hard to understand. Also the bug fixed with #827 showed that this method could be called with type = Long and otherType = Object, which would fulfill the first if and then the Long would be falsely cast to Double.