### PR TITLE
Avoids a ConcurrentModificationException in Java9+.

### DIFF
--- a/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
+++ b/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
@@ -102,7 +102,7 @@ public class Tagliatelle {
                 extensions.put(target, new ArrayList<>());
 
                 // Load and fill the result list. Note that we cannot use HashMap.computeIfAbsent here, as
-                // loadExtensions it self compiles templates which might end up calling this method leading
+                // loadExtensions itself compiles templates which might end up calling this method leading
                 // to a ConcurrentModificationException...
                 result = loadExtensions(target);
                 extensions.put(target, result);


### PR DESCRIPTION
The code itself was and if safe in the way we call it. However, Java9+
throws an exception for concurrent modifications within computeIfAbsent
as it fears infinite recursions for the same key (which isn't the case
in our scenario).