### PR TITLE
The enabled/disabled check is now applied after expression parsing

### DIFF
--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -177,14 +177,6 @@ public class Permissions {
             return true;
         }
 
-        if (DISABLED.equals(permissionExpression)) {
-            return false;
-        }
-
-        if (ENABLED.equals(permissionExpression)) {
-            return true;
-        }
-
         for (String orClause : permissionExpression.split(",")) {
             if (permissionsFullfilled(orClause, containsPermission)) {
                 return true;
@@ -205,10 +197,15 @@ public class Permissions {
 
     protected static boolean permissionFullfilled(String permission, Predicate<String> containsPermission) {
         if (permission.startsWith("!")) {
-            return containsPermission == null || !containsPermission.test(permission.substring(1));
-        } else {
-            return containsPermission != null && containsPermission.test(permission);
+            return !permissionFullfilled(permission.substring(1), containsPermission);
         }
+        if (DISABLED.equals(permission)) {
+            return false;
+        }
+        if (ENABLED.equals(permission)) {
+            return true;
+        }
+        return containsPermission != null && containsPermission.test(permission);
     }
 
     /**

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -55,6 +55,6 @@ class PermissionsSpec extends BaseSpecification {
         "!a"                 | null                                                                   | true
         "enabled"            | null                                                                   | true
         "!enabled"           | null                                                                   | false
-        "enabled+a"          | { permission -> ("a" == permission) }
+        "enabled+a"          | { permission -> ("a" == permission) }                                  | true
     }
 }

--- a/src/test/java/sirius/web/security/PermissionsSpec.groovy
+++ b/src/test/java/sirius/web/security/PermissionsSpec.groovy
@@ -42,7 +42,7 @@ class PermissionsSpec extends BaseSpecification {
         expect:
         Permissions.hasPermission(permissionExpression, hasSinglePermissionPredicate) == expectedResult
         where:
-        permissionExpression | hasSinglePermissionPredicate                                        | expectedResult
+        permissionExpression | hasSinglePermissionPredicate                                           | expectedResult
         "a"                  | { permission -> ["a", "b", "c"].contains(permission) } as Predicate | true
         "!a"                 | { permission -> ["a", "b", "c"].contains(permission) } as Predicate | false
         "d"                  | { permission -> ["a", "b", "c"].contains(permission) } as Predicate | false
@@ -51,7 +51,10 @@ class PermissionsSpec extends BaseSpecification {
         "a+d"                | { permission -> ["a", "b", "c"].contains(permission) } as Predicate | false
         "a,d"                | { permission -> ["a", "b", "c"].contains(permission) } as Predicate | true
         "d,e"                | { permission -> ["a", "b", "c"].contains(permission) } as Predicate | false
-        "a"                  | null                                                                | false
-        "!a"                 | null                                                                | true
+        "a"                  | null                                                                   | false
+        "!a"                 | null                                                                   | true
+        "enabled"            | null                                                                   | true
+        "!enabled"           | null                                                                   | false
+        "enabled+a"          | { permission -> ("a" == permission) }
     }
 }


### PR DESCRIPTION
This means, that 'enabled' and 'disabled' can be used as part of a permission expression.
For example: 'a+enabled,!disabled+b' works now as expected and is equivalent to 'a,b'