### PR TITLE
Fixes zero-arg lambdas in Noodle and provides two minor improvements.

### DIFF
--- a/src/main/java/sirius/pasta/noodle/LambdaHandler.java
+++ b/src/main/java/sirius/pasta/noodle/LambdaHandler.java
@@ -43,13 +43,20 @@ class LambdaHandler implements InvocationHandler {
             return method.invoke(proxy);
         }
 
-        // Transfer arguments...
-        for (int i = 0; i < Math.min(args.length, numLocals); i++) {
-            environment.writeVariable(contextOffset + i, args[i]);
-        }
-        // Null all remaning locals...
-        for (int i = args.length; i < numLocals; i++) {
-            environment.writeVariable(contextOffset + i, null);
+        if (args != null) {
+            // Transfer arguments...
+            for (int i = 0; i < Math.min(args.length, numLocals); i++) {
+                environment.writeVariable(contextOffset + i, args[i]);
+            }
+            // Null all remaining locals...
+            for (int i = args.length; i < numLocals; i++) {
+                environment.writeVariable(contextOffset + i, null);
+            }
+        } else {
+            // Null all locals...
+            for (int i = 0; i < numLocals; i++) {
+                environment.writeVariable(contextOffset + i, null);
+            }
         }
 
         // Creates another invocation, with appropriate instruction pointer offset, custom stack and shared

--- a/src/main/java/sirius/pasta/noodle/compiler/Parser.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Parser.java
@@ -832,10 +832,10 @@ public class Parser extends InputProcessor {
             return parseInvalidLambda();
         }
 
-        LambdaNode lambdaNode = new LambdaNode(start);
+        int numVariablesBeforeLambda = context.getVariableScoper().getMaxVariables();
+        LambdaNode lambdaNode = new LambdaNode(start, numVariablesBeforeLambda);
         lambdaNode.setSamInterface(TypeTools.simplifyToClass(calleeType, Object.class));
         VariableScoper.Scope scope = context.getVariableScoper().pushScope();
-        int numVariablesBeforeLambda = context.getVariableScoper().getMaxVariables();
         parseLambdaParameters(lambdaNode, calleeType, targetMethod);
         parseLambdaBody(lambdaNode, targetMethod);
         lambdaNode.setNumberOfLocals(context.getVariableScoper().getMaxVariables() - numVariablesBeforeLambda);

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/LambdaNode.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/LambdaNode.java
@@ -42,6 +42,7 @@ import java.util.List;
 public class LambdaNode extends Node {
 
     private final List<VariableScoper.Variable> arguments = new ArrayList<>();
+    private final int localsOffset;
     private Type samInterface;
     private Node body;
     private int numberOfLocals;
@@ -50,9 +51,11 @@ public class LambdaNode extends Node {
      * Creates a new node for the given position.
      *
      * @param position the position where the lambda starts
+     * @param localsOffset the first argument or local within the variable to shadow...
      */
-    public LambdaNode(Position position) {
+    public LambdaNode(Position position, int localsOffset) {
         super(position);
+        this.localsOffset = localsOffset;
     }
 
     /**
@@ -97,7 +100,7 @@ public class LambdaNode extends Node {
     @Override
     public void emit(Assembler assembler) {
         assembler.emitPushConstant(samInterface, position);
-        assembler.emitPushConstant(arguments.get(0).getLocalIndex(), position);
+        assembler.emitPushConstant(localsOffset, position);
         assembler.emitByteCode(OpCode.LAMBDA, numberOfLocals, position);
         Assembler.Label endLabel = assembler.createLabel();
         assembler.emitJump(OpCode.JMP, endLabel, position);

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -418,7 +418,7 @@ class TunnelHandler implements AsyncHandler<String> {
         CallContext.setCurrent(cc);
 
         WebServer.LOG.WARN("Tunnel - ERROR %s for %s",
-                           t.getMessage() + " (" + t.getMessage() + ")",
+                           t.getMessage() + " (" + t.getClass().getName() + ")",
                            webContext.getRequestedURI());
         if (!(t instanceof ClosedChannelException)) {
             if (failureHandler != null) {

--- a/src/main/resources/default/templates/system/state.html.pasta
+++ b/src/main/resources/default/templates/system/state.html.pasta
@@ -90,7 +90,7 @@
                             <t:dot color="green">Norminal</t:dot>
                         </i:block>
                         <i:block name="YELLOW">
-                            <t:dot color="green">Warnings Present</t:dot>
+                            <t:dot color="yellow">Warnings Present</t:dot>
                         </i:block>
                         <i:block name="RED">
                             <t:dot color="red">Critical</t:dot>

--- a/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
@@ -91,6 +91,8 @@ class CompilerSpec extends BaseSpecification {
         and: "Var-args generic type propagation works"
         compile("let sum = 0; java.util.Arrays.asList(3,4).forEach(|x| sum = sum + x); return sum;").
                 call(new SimpleEnvironment()) == 7
+        and: "zero-arg lambdas work"
+        compile("let x = 0; NoodleExample.invokeUnitOfWork(|| x = 42); return x;").call(new SimpleEnvironment()) == 42
     }
 
     def "conditions work as expected"() {

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
@@ -8,6 +8,8 @@
 
 package sirius.pasta.noodle.compiler;
 
+import sirius.kernel.commons.UnitOfWork;
+
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
@@ -48,6 +50,10 @@ public class NoodleExample {
 
     public static void invokeConsumer(IntConsumer consumer) {
         consumer.accept(3);
+    }
+
+    public static void invokeUnitOfWork(UnitOfWork unit) throws Exception {
+        unit.execute();
     }
 
     public static Stream<Integer> intStream() {


### PR DESCRIPTION
We now support zero-arg lambdas like `NoodleExample.invokeUnitOfWork(|| x = 42);`.

Also an error message and a color-code has been fixed as drive-by bug fixes.