### PR TITLE
Fixes a seemingly random type interference bug when bridge methods are generated out of order.

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -211,15 +211,18 @@ public class MethodCall extends Call {
         // This is reasonable, as this takes generic type parameters
         // into account and selects the proper method...
         try {
-            return type.getMethod(name, parameterTypes);
+            Method fastMatch = type.getMethod(name, parameterTypes);
+            if (!fastMatch.isBridge()) {
+                return fastMatch;
+            }
         } catch (NoSuchMethodException e) {
             Exceptions.ignore(e);
         }
 
         // Try to find an appropriate method using coercions known to the system...
-        for (Method m : type.getMethods()) {
-            if (signatureMatch(m, name, parameterTypes)) {
-                return m;
+        for (Method candidateMethod : type.getMethods()) {
+            if (!candidateMethod.isBridge() && signatureMatch(candidateMethod, name, parameterTypes)) {
+                return candidateMethod;
             }
         }
 

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -157,8 +157,6 @@ public class MethodCall extends Call {
      * @param compilationContext the compilation context for error reporting
      * @return <tt>true</tt> if the method was bound successfully, <tt>false</tt> otherwise
      */
-    @SuppressWarnings("ArrayEquality")
-    @Explain("This is a re-used constant so an identity check works fine here")
     public boolean tryBindToMethod(CompilationContext compilationContext) {
         try {
             Class<?>[] parameterTypes = new Class<?>[parameterNodes.length];

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -160,18 +160,6 @@ public class MethodCall extends Call {
     @SuppressWarnings("ArrayEquality")
     @Explain("This is a re-used constant so an identity check works fine here")
     public boolean tryBindToMethod(CompilationContext compilationContext) {
-        if (parameterNodes == NO_ARGS) {
-            try {
-                this.method = selfNode.getType().getMethod(methodName);
-                checkDeprecation(compilationContext);
-                checkStaticCallSite(compilationContext);
-                checkSandbox(compilationContext);
-                return true;
-            } catch (NoSuchMethodException e) {
-                Exceptions.ignore(e);
-            }
-        }
-
         try {
             Class<?>[] parameterTypes = new Class<?>[parameterNodes.length];
             for (int i = 0; i < parameterNodes.length; i++) {


### PR DESCRIPTION
These methods are synthesized by the javac compiler to handle covariant
return types. Sadly this creates a method list which cannot be created
in a sane environment (e.g. two methods can have the same name and
arguments but different return types). These methods are only generated
to coerce calls to covariant superclass methods.

We're generally not interested in these methods, as these also wipe out
any generic infos.

Note that we cannot provide a test for this fix, as the method list of
a class is unordered (ordering is sheer luck). Therefore most of the
time the bridge methods are placed after the "real" methods and thus
this fix would not be needed. However in *some* circumstances, most
commonly in production, the order seems to be flipped.