### PR TITLE
Refactors error handling and UserContext/Messages in general.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>dev-23.2.0</sirius.kernel>
+        <sirius.kernel>dev-23.3.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/pasta/noodle/macros/ExpandMessagesMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ExpandMessagesMacro.java
@@ -1,0 +1,59 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.noodle.macros;
+
+import parsii.tokenizer.Position;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+import sirius.pasta.noodle.Environment;
+import sirius.pasta.noodle.compiler.CompilationContext;
+import sirius.web.controller.MessageExpanders;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Runs all {@link sirius.web.controller.MessageExpander message expanders} on the given string.
+ *
+ * @see MessageExpanders
+ */
+@Register
+public class ExpandMessagesMacro extends BasicMacro {
+
+    @Part
+    private MessageExpanders messageExpanders;
+
+    @Override
+    protected Class<?> getType() {
+        return String.class;
+    }
+
+    @Override
+    protected void verifyArguments(CompilationContext compilationContext, Position position, List<Class<?>> args) {
+        if (args.size() != 1 || !CompilationContext.isAssignableTo(args.get(0), String.class)) {
+            throw new IllegalArgumentException("Expected a single String as argument.");
+        }
+    }
+
+    @Override
+    public Object invoke(Environment environment, Object[] args) {
+        return messageExpanders.expand((String) args[0]);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Executes all MessageExpanders on the given String and returns the result.";
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "expandMessage";
+    }
+}

--- a/src/main/java/sirius/web/ErrorCodeException.java
+++ b/src/main/java/sirius/web/ErrorCodeException.java
@@ -9,20 +9,31 @@
 package sirius.web;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.commons.Tuple;
+import sirius.kernel.health.ExceptionHint;
 import sirius.kernel.health.HandledException;
+import sirius.web.controller.Controller;
 import sirius.web.controller.Routed;
+
+import java.io.Serial;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Can be thrown in {@link sirius.web.services.StructuredService}s or in JSON calls ({@link Routed#jsonCall()}).
  * <p>
  * Adds an additional "code" property to the JSON result which contains the given code. Also the given message
  * is directly reported without any translation or logging.
+ *
+ * @deprecated Use {@link sirius.kernel.health.Exceptions.ErrorHandler#hint(ExceptionHint, Object)} and
+ * {@link sirius.web.controller.Controller#HTTP_STATUS} or {@link sirius.web.controller.Controller#ERROR_CODE}.
  */
+@Deprecated
 public class ErrorCodeException extends HandledException {
 
+    @Serial
     private static final long serialVersionUID = -5345498530492414479L;
-    private final String code;
-    private final transient HttpResponseStatus httpResponseStatus;
 
     /**
      * Creates a new exception with the given code and message.
@@ -34,9 +45,7 @@ public class ErrorCodeException extends HandledException {
      * @param message the message to add to the output
      */
     public ErrorCodeException(String code, String message) {
-        super(message);
-        this.code = code;
-        this.httpResponseStatus = HttpResponseStatus.OK;
+        super(message, Collections.singletonMap(Controller.ERROR_CODE, code), null);
     }
 
     /**
@@ -45,14 +54,16 @@ public class ErrorCodeException extends HandledException {
      * Note tha this is a <tt>HandledException</tt> so no further logging or error reporting will be performed by the
      * system.
      *
-     * @param code the error code to report
-     * @param message the message to add to the output
+     * @param code               the error code to report
+     * @param message            the message to add to the output
      * @param httpResponseStatus the {@link HttpResponseStatus} to report
      */
     public ErrorCodeException(String code, String message, HttpResponseStatus httpResponseStatus) {
-        super(message);
-        this.code = code;
-        this.httpResponseStatus = httpResponseStatus;
+        super(message,
+              Stream.of(Tuple.create(Controller.ERROR_CODE, code),
+                        Tuple.create(Controller.HTTP_STATUS, httpResponseStatus.code()))
+                    .collect(Collectors.toMap(Tuple::getFirst, Tuple::getSecond)),
+              null);
     }
 
     /**
@@ -61,10 +72,10 @@ public class ErrorCodeException extends HandledException {
      * @return the error code being reported
      */
     public String getCode() {
-        return code;
+        return getHint(Controller.ERROR_CODE).asString();
     }
 
     public HttpResponseStatus getHttpResponseStatus() {
-        return httpResponseStatus;
+        return HttpResponseStatus.valueOf(getHint(Controller.HTTP_STATUS).asInt(200));
     }
 }

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -178,9 +178,7 @@ public class BasicController implements Controller {
             return;
         }
 
-        if (error != null) {
-            UserContext.message(Message.error(error.getMessage()));
-        }
+        UserContext.handle(error);
         defaultRoute.accept(webContext);
     }
 

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -134,14 +134,14 @@ public class BasicController implements Controller {
      * Displays a generic "Changes have been saved" message.
      */
     public void showSavedMessage() {
-        UserContext.message(Message.info(NLS.get("BasicController.changesSaved")));
+        UserContext.message(Message.info().withTextMessage(NLS.get("BasicController.changesSaved")));
     }
 
     /**
      * Displays a genric "Object was deleted" message.
      */
     public void showDeletedMessage() {
-        UserContext.message(Message.info(NLS.get("BasicController.objectDeleted")));
+        UserContext.message(Message.info().withTextMessage(NLS.get("BasicController.objectDeleted")));
     }
 
     /**

--- a/src/main/java/sirius/web/controller/Controller.java
+++ b/src/main/java/sirius/web/controller/Controller.java
@@ -9,6 +9,7 @@
 package sirius.web.controller;
 
 import sirius.kernel.di.std.AutoRegister;
+import sirius.kernel.health.ExceptionHint;
 import sirius.kernel.health.HandledException;
 import sirius.web.http.WebContext;
 
@@ -42,6 +43,16 @@ import sirius.web.http.WebContext;
 public interface Controller {
 
     /**
+     * Used to specify the desired HTTP status code when handling the exception.
+     */
+    ExceptionHint HTTP_STATUS = new ExceptionHint("httpStatus");
+
+    /**
+     * Specifies an explicit error code to output when handling the exception.
+     */
+    ExceptionHint ERROR_CODE = new ExceptionHint("errorCode");
+
+    /**
      * In case processing a request via a method fails (throws an exception), this method will be called.
      * <p>
      * This provides a convenient way to render a "fallback" page like a list view, if a specialized details view
@@ -57,7 +68,7 @@ public interface Controller {
      * <p>
      * This provides a convenient way to generate a "fallback" JSON response.
      *
-     * @param webContext the context conatining the request
+     * @param webContext the context containing the request
      * @param error the error which occurred
      */
     void onJsonError(WebContext webContext, HandledException error);

--- a/src/main/java/sirius/web/controller/ErrorMessageTransformer.java
+++ b/src/main/java/sirius/web/controller/ErrorMessageTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+import sirius.kernel.di.std.AutoRegister;
+import sirius.kernel.di.std.Priorized;
+import sirius.kernel.health.HandledException;
+import sirius.web.security.UserContext;
+
+/**
+ * Can be used to further process or enhance error messages.
+ *
+ * @see Message#handle(Throwable)
+ */
+@AutoRegister
+public interface ErrorMessageTransformer extends Priorized {
+
+    /**
+     * Transforms the given message based on the hints in the given exception.
+     *
+     * @param exception the actual error which is being processed.
+     * @param message   the HTML error message which has been generated so far
+     * @return the enhanced message. If no enhancements are available, the original message will be returned
+     */
+    String transform(HandledException exception, String message);
+}

--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -135,7 +135,7 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and SUCCESS as type
-     * @deprecated User {@code success().withText(textMessage)}
+     * @deprecated Use {@code success().withText(textMessage)}
      */
     @Deprecated
     public static Message success(String textMessage) {
@@ -156,7 +156,7 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and INFO as type
-     * @deprecated User {@code info().withText(textMessage)}
+     * @deprecated Use {@code info().withText(textMessage)}
      */
     @Deprecated
     public static Message info(String textMessage) {
@@ -177,7 +177,7 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and WARN as type
-     *      @deprecated User {@code warn().withText(textMessage)}
+     *      @deprecated Use {@code warn().withText(textMessage)}
      */
     @Deprecated
     public static Message warn(String textMessage) {
@@ -198,7 +198,7 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and ERROR as type
-     * @deprecated User {@code success().withText(textMessage)}
+     * @deprecated Use {@code success().withText(textMessage)}
      */
     @Deprecated
     public static Message error(String textMessage) {

--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -135,7 +135,9 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and SUCCESS as type
+     * @deprecated User {@code success().withText(textMessage)}
      */
+    @Deprecated
     public static Message success(String textMessage) {
         return success().withTextMessage(textMessage);
     }
@@ -154,7 +156,9 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and INFO as type
+     * @deprecated User {@code info().withText(textMessage)}
      */
+    @Deprecated
     public static Message info(String textMessage) {
         return info().withTextMessage(textMessage);
     }
@@ -173,7 +177,9 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and WARN as type
+     *      @deprecated User {@code warn().withText(textMessage)}
      */
+    @Deprecated
     public static Message warn(String textMessage) {
         return warn().withTextMessage(textMessage);
     }
@@ -192,7 +198,9 @@ public class Message {
      *
      * @param textMessage the message content
      * @return a new message with the given content and ERROR as type
+     * @deprecated User {@code success().withText(textMessage)}
      */
+    @Deprecated
     public static Message error(String textMessage) {
         return error().withTextMessage(textMessage);
     }
@@ -223,7 +231,7 @@ public class Message {
      * @param type the severity of the message
      * @param html the HTML contents to show
      */
-    public Message(MessageLevel type, String html) {
+    protected Message(MessageLevel type, String html) {
         this.type = type;
         this.html = messageExpanders.expand(html);
     }

--- a/src/main/java/sirius/web/controller/MessageExpander.java
+++ b/src/main/java/sirius/web/controller/MessageExpander.java
@@ -1,0 +1,25 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+/**
+ * Permits intercepting and expanding messages which invoke the {@link MessageExpanders}.
+ *
+ * @see MessageExpanders
+ */
+public interface MessageExpander {
+
+    /**
+     * Expands the given message.
+     *
+     * @param message the message to expand
+     * @return the expanded message
+     */
+    String expand(String message);
+}

--- a/src/main/java/sirius/web/controller/MessageExpanders.java
+++ b/src/main/java/sirius/web/controller/MessageExpanders.java
@@ -1,0 +1,46 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.PartCollection;
+import sirius.kernel.di.std.Parts;
+import sirius.kernel.di.std.Register;
+
+/**
+ * Expands help- or error messages.
+ * <p>
+ * This can be used to expand macros or strings in help or error messages. This is e.g. used by sirius-biz and
+ * its knowledge base to easily inject links to articles without having to put HTML into every NLS keys (which is
+ * commonly scrambled by translation agencies).
+ */
+@Register(classes = MessageExpanders.class)
+public class MessageExpanders {
+
+    @Parts(MessageExpander.class)
+    private PartCollection<MessageExpander> expanders;
+
+    /**
+     * Expandes the given message by calling all known {@link MessageExpander} parts.
+     *
+     * @param message the message to expand
+     * @return the expanded message
+     */
+    public String expand(String message) {
+        if (Strings.isEmpty(message)) {
+            return message;
+        }
+
+        for (MessageExpander expander : expanders) {
+            message = expander.expand(message);
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/sirius/web/controller/PreserveErrorMessageTransformer.java
+++ b/src/main/java/sirius/web/controller/PreserveErrorMessageTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.ExceptionHint;
+import sirius.kernel.health.HandledException;
+
+/**
+ * Outputs the whole error message while preserving whitespaces.
+ * <p>
+ * This is mainly used to properly report <b>Tagliatelle</b> errors.
+ */
+@Register
+public class PreserveErrorMessageTransformer implements ErrorMessageTransformer {
+
+    public static final ExceptionHint PRESERVE = new ExceptionHint("preserve");
+
+    @Override
+    public String transform(HandledException exception, String message) {
+        if (exception.getHint(PRESERVE).asBoolean()) {
+            return "<div class=\"pre-message\">" + message + "</div>";
+        } else {
+            return message;
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+}

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -118,7 +118,7 @@ public class HelpDispatcher implements WebDispatcher {
             return DispatchDecision.DONE;
         }
 
-        UserContext.get().addMessage(Message.error(NLS.get("HelpDispatcher.unknownTopic")));
+        UserContext.get().addMessage(Message.error().withTextMessage(NLS.get("HelpDispatcher.unknownTopic")));
         return DispatchDecision.CONTINUE;
     }
 

--- a/src/main/java/sirius/web/health/ClusterMessageProvider.java
+++ b/src/main/java/sirius/web/health/ClusterMessageProvider.java
@@ -35,10 +35,13 @@ public class ClusterMessageProvider implements MessageProvider {
     @Override
     public void addMessages(Consumer<Message> messageConsumer) {
         if (cluster.isAlarmPresent() && UserContext.getCurrentUser().hasPermission(PERMISSION_SYSTEM_NOTIFY_STATE)) {
-            messageConsumer.accept(Message.error(Strings.apply("System state is %s (Cluster state is %s)",
-                                                               cluster.getNodeState(),
-                                                               cluster.getClusterState()))
-                                          .withAction("/system/state", "View System State"));
+            messageConsumer.accept(Message.error()
+                                          .withTextAndLink(Strings.apply("System state is %s (Cluster state is %s)",
+                                                                         cluster.getNodeState(),
+                                                                         cluster.getClusterState()),
+                                                           "View System State",
+                                                           "/system/state",
+                                                           null));
         }
     }
 }

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -53,6 +53,7 @@ import sirius.pasta.tagliatelle.Template;
 import sirius.pasta.tagliatelle.rendering.GlobalRenderContext;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
+import sirius.web.controller.PreserveErrorMessageTransformer;
 import sirius.web.services.JSONStructuredOutput;
 
 import javax.annotation.Nonnull;
@@ -886,8 +887,7 @@ public class Response {
             addHeaderIfNotExists(HttpHeaderNames.CACHE_CONTROL, NO_CACHE);
         }
         if (lastModifiedMillis > 0 && !headers().contains(HttpHeaderNames.LAST_MODIFIED)) {
-            addHeaderIfNotExists(HttpHeaderNames.
-                                         LAST_MODIFIED, formatter.format(new Date(lastModifiedMillis)));
+            addHeaderIfNotExists(HttpHeaderNames.LAST_MODIFIED, formatter.format(new Date(lastModifiedMillis)));
         }
     }
 
@@ -1186,7 +1186,12 @@ public class Response {
                                                                    .handle());
             template(status, template, params);
         } catch (CompileException e) {
-            throw Exceptions.handle().to(Resources.LOG).error(e).withSystemErrorMessage("%s", e.getMessage()).handle();
+            throw Exceptions.handle()
+                            .to(Resources.LOG)
+                            .hint(PreserveErrorMessageTransformer.PRESERVE, true)
+                            .error(e)
+                            .withDirectMessage(e.getMessage())
+                            .handle();
         }
     }
 

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -126,10 +126,10 @@ public abstract class GenericUserManager implements UserManager {
                 onLogin(webContext, result);
                 return result;
             }
-        } catch (HandledException e) {
-            UserContext.message(Message.error(e.getMessage()));
-        } catch (Exception e) {
-            UserContext.handle(e);
+        } catch (HandledException exception) {
+            UserContext.message(Message.error(exception));
+        } catch (Exception exception) {
+            UserContext.handle(exception);
         }
 
         result = loginViaSSOToken(webContext);
@@ -222,7 +222,7 @@ public abstract class GenericUserManager implements UserManager {
         webContext.hidePost();
         UserInfo result = findUserByName(webContext, user);
         if (result == null) {
-            UserContext.message(Message.error(NLS.get("GenericUserManager.invalidSSO")));
+            UserContext.message(Message.error().withTextMessage(NLS.get("GenericUserManager.invalidSSO")));
             return null;
         }
         if (checkTokenTTL(Value.of(challengeResponse.getFirst()).asLong(0), ssoGraceInterval)) {
@@ -375,7 +375,7 @@ public abstract class GenericUserManager implements UserManager {
 
         if (passwordPresent) {
             log("Login of %s failed using password", user);
-            UserContext.message(Message.error(NLS.get("GenericUserManager.invalidLogin")));
+            UserContext.message(Message.error().withTextMessage(NLS.get("GenericUserManager.invalidLogin")));
         }
 
         return null;

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -129,7 +129,7 @@ public abstract class GenericUserManager implements UserManager {
         } catch (HandledException e) {
             UserContext.message(Message.error(e.getMessage()));
         } catch (Exception e) {
-            UserContext.message(Message.error(Exceptions.handle(UserContext.LOG, e)));
+            UserContext.handle(e);
         }
 
         result = loginViaSSOToken(webContext);

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
+import sirius.web.controller.ErrorMessageTransformer;
 import sirius.web.controller.Message;
 import sirius.web.http.UserMessagesCache;
 import sirius.web.http.WebContext;
@@ -147,15 +148,16 @@ public class UserContext implements SubContext {
     /**
      * Handles the given exception by passing it to {@link sirius.kernel.health.Exceptions} and by creating an
      * appropriate message for the user.
+     * <p>
+     * Note that this might utilize {@link ErrorMessageTransformer error message transformers} to yield an optimal
+     * error message.
      *
-     * @param e the exception to handle. If the given exception is <tt>null</tt> nothing will happen.
+     * @param exception the exception to handle. If the given exception is <tt>null</tt>, nothing will happen.
      */
-    public static void handle(@Nullable Throwable e) {
-        if (e == null) {
-            return;
+    public static void handle(@Nullable Throwable exception) {
+        if (exception != null) {
+            message(Message.error(exception));
         }
-
-        message(Message.error(e));
     }
 
     /**

--- a/src/main/java/sirius/web/services/StructuredService.java
+++ b/src/main/java/sirius/web/services/StructuredService.java
@@ -11,7 +11,7 @@ package sirius.web.services;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.xml.StructuredOutput;
-import sirius.web.ErrorCodeException;
+import sirius.web.controller.Controller;
 import sirius.web.controller.Routed;
 
 /**
@@ -59,13 +59,7 @@ public interface StructuredService {
             }
 
             out.property("type", cause.getClass().getName());
-
-            if (e instanceof ErrorCodeException) {
-                out.property("code", ((ErrorCodeException) e).getCode());
-            } else {
-                out.property("code", "ERROR");
-            }
-
+            out.property("code", e.getHint(Controller.ERROR_CODE).asString("ERROR"));
             out.property("flow", CallContext.getCurrent().getMDCValue(CallContext.MDC_FLOW));
         } finally {
             out.endResult();

--- a/src/main/resources/default/assets/tycho/styles/misc.scss
+++ b/src/main/resources/default/assets/tycho/styles/misc.scss
@@ -33,3 +33,10 @@ a {
   vertical-align: top;
   margin-left: 0.5em;
 }
+
+// Renders "pre" errors, e.g. for Tagliatelle.
+.pre-message {
+  white-space: pre-wrap;
+  font-family: monospace;
+}
+

--- a/src/main/resources/default/taglib/t/helpbox.html.pasta
+++ b/src/main/resources/default/taglib/t/helpbox.html.pasta
@@ -6,7 +6,8 @@
     <div class="card-body">
         <div class="d-flex flex-row">
             <div class="mr-auto">
-                <i:render name="body"/>
+                <i:local name="contents" value="@renderToString('body')" />
+                <i:raw>@expandMessage(contents)</i:raw>
             </div>
             <div class="ml-4">
                 <i:render name="actions"/>

--- a/src/main/resources/default/taglib/t/textarea.html.pasta
+++ b/src/main/resources/default/taglib/t/textarea.html.pasta
@@ -22,7 +22,7 @@
     <textarea @id="@id" name="@name" rows="@rows" class="form-control input-block-level" @readonly="readonly">@UserContext.get().getFieldValue(name, value)</textarea>
 
     <i:if test="isFilled(help)">
-        <small class="form-text text-muted"><i:raw>@help</i:raw></small>
+        <small class="form-text text-muted"><i:raw>@expandMessage(help)</i:raw></small>
     </i:if>
     <i:if test="UserContext.get().hasError(name)">
         <small class="error-block form-text">@UserContext.get().getFieldErrorMessage(name)</small>

--- a/src/main/resources/default/templates/tycho/page-disaster.html.pasta
+++ b/src/main/resources/default/templates/tycho/page-disaster.html.pasta
@@ -5,7 +5,7 @@
             <div class="mt-4 mb-2">
                 <i:local name="currentScope" value="UserContext.getCurrentScope()"/>
                 <i:if test="currentScope.as(sirius.web.security.MaintenanceInfo.class).maintenanceMessage() != null">
-                    @currentScope.as(sirius.web.security.MaintenanceInfo.class).maintenanceMessage().getMessage()
+                    <i:raw>@currentScope.as(sirius.web.security.MaintenanceInfo.class).maintenanceMessage().getHtml()</i:raw>
                     <i:else>
                         @i18n("template.html.maintenanceInfo")
                     </i:else>

--- a/src/main/resources/default/templates/tycho/page-messages.html.pasta
+++ b/src/main/resources/default/templates/tycho/page-messages.html.pasta
@@ -3,7 +3,7 @@
         <i:for type="sirius.web.controller.Message" var="msg" items="UserContext.get().getMessages()">
             <div class="card full-border border-sirius-@msg.getType().getColor()-dark mb-4">
                 <div class="card-body">
-                    <i:raw>@msg.getMessage()</i:raw>
+                    <i:raw>@msg.getHtml()</i:raw>
                 </div>
             </div>
         </i:for>

--- a/src/main/resources/default/templates/wondergem/page-disaster.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-disaster.html.pasta
@@ -2,7 +2,7 @@
     <div class="well" style="margin-top: 50px; font-size: 16px">
         <i:local name="currentScope" value="UserContext.getCurrentScope()" />
         <i:if test="currentScope.as(sirius.web.security.MaintenanceInfo.class).maintenanceMessage() != null">
-            @currentScope.as(sirius.web.security.MaintenanceInfo.class).maintenanceMessage().getMessage()
+            <i:raw>@currentScope.as(sirius.web.security.MaintenanceInfo.class).maintenanceMessage().getHtml()</i:raw>
             <i:else>
                 @i18n("template.html.maintenanceInfo")
             </i:else>

--- a/src/main/resources/default/templates/wondergem/page-messages.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-messages.html.pasta
@@ -2,17 +2,7 @@
     <div class="col-md-12" id="messageBox">
         <i:for type="sirius.web.controller.Message" var="msg" items="UserContext.get().getMessages()">
             <div class="alert @msg.getType().getCssClass()">
-                <i:raw>@msg.getMessage()</i:raw>
-                <i:if test="msg.getAction() != null">
-                    <i:if test="msg.isActionJavascript()">
-                        <a onclick="@msg.getAction()"
-                           class="link link-info">@msg.getActionLabel()</a>
-                        <i:else>
-                            <a href="@msg.getAction()"
-                               class="link link-info">@msg.getActionLabel()</a>
-                        </i:else>
-                    </i:if>
-                </i:if>
+                <i:raw>@msg.getHtml()</i:raw>
             </div>
         </i:for>
     </div>


### PR DESCRIPTION
We previously more or less expected messages to be in plain text and
to optionally contain a single link.

We now refactored to inner workings of the whole framework to
essentially support any HTML contents as message. We also provide a
builder to properly control and decide if HTML content is present or
if plain text is being output (which requires proper escaping).

This also opens up the possibility to further process some error
messages (e.g. those by Tagliatelle) to ensure proper rendering.