### PR TITLE
BREAKING: Cleanup of the Page/Facet/FacetItem framework.

### DIFF
--- a/src/main/java/sirius/web/controller/Facet.java
+++ b/src/main/java/sirius/web/controller/Facet.java
@@ -22,13 +22,15 @@ import java.util.List;
  */
 public class Facet {
     protected Page<?> parent;
-    private String name;
-    private String title;
-    private List<String> values;
+    private final String name;
+    private final String title;
+    protected final List<String> values = new ArrayList<>();
     private final ValueComputer<String, String> translator;
     private boolean facetCollapsingEnabled = false;
     private int maxVisibleFacetItems;
-    private List<FacetItem> items = new ArrayList<>();
+    private final List<FacetItem> items = new ArrayList<>();
+
+    @Deprecated
     private FacetRange facetRange;
 
     /**
@@ -45,7 +47,6 @@ public class Facet {
                  @Nullable ValueComputer<String, String> translator) {
         this.name = field;
         this.title = title;
-        this.values = new ArrayList<>();
         if (value != null) {
             this.values.add(value);
         }
@@ -58,6 +59,8 @@ public class Facet {
      * @return a list of all items of this facet
      */
     public List<FacetItem> getAllItems() {
+        // Note that we intentionally return the list here as the list of items might be filtered after a
+        // query or aggregation has been performed.
         return items;
     }
 
@@ -133,17 +136,14 @@ public class Facet {
      *
      * @param key   the filter value of the item
      * @param title the public visible name of the item
-     * @param count the number of matched for this item
+     * @param count the number of matched for this item or <b>-1</b> if no proper count is available
      * @return the facet itself for fluent method calls
      */
     public Facet addItem(String key, String title, int count) {
         if (Strings.isFilled(key)) {
             String effectiveTitle = translator == null ? title : translator.compute(key);
             if (effectiveTitle != null) {
-                items.add(new FacetItem(key,
-                                        effectiveTitle,
-                                        count,
-                                        values.stream().anyMatch(value -> Strings.areEqual(value, key))));
+                items.add(new FacetItem(this, key, effectiveTitle, count));
             }
         }
         return this;
@@ -283,7 +283,8 @@ public class Facet {
      * @return the facet itself for fluent method calls
      */
     public Facet withValues(List<String> values) {
-        this.values = values;
+        this.values.clear();
+        this.values.addAll(values);
 
         return this;
     }
@@ -292,7 +293,9 @@ public class Facet {
      * Returns the used facet range.
      *
      * @return the facet range
+     * @deprecated FacetRange has been deprecated.
      */
+    @Deprecated
     public FacetRange getRange() {
         return facetRange;
     }
@@ -302,7 +305,9 @@ public class Facet {
      *
      * @param facetRange the facet range to use
      * @return the facet itself for fluent method calls
+     * @deprecated FacetRange has been deprecated.
      */
+    @Deprecated
     public Facet withRange(FacetRange facetRange) {
         this.facetRange = facetRange;
 

--- a/src/main/java/sirius/web/controller/FacetItem.java
+++ b/src/main/java/sirius/web/controller/FacetItem.java
@@ -8,28 +8,24 @@
 
 package sirius.web.controller;
 
+import sirius.kernel.commons.Strings;
+
 /**
  * Represents a single item of a {@link Facet}.
  */
 public class FacetItem {
-    private String key;
-    private String title;
-    private int count;
-    private boolean active;
 
-    /**
-     * Creates a new FacesItem.
-     *
-     * @param key    the content value represented by this item
-     * @param title  the visual item used to display this item to the user
-     * @param count  the number of matches found
-     * @param active determines if this item is an active filter setting
-     */
-    public FacetItem(String key, String title, int count, boolean active) {
+    private final Facet facet;
+    private final String key;
+    private final String title;
+    private int count;
+    private boolean forceActive;
+
+    protected FacetItem(Facet facet, String key, String title, int count) {
+        this.facet = facet;
         this.key = key;
         this.title = title;
         this.count = count;
-        this.active = active;
     }
 
     /**
@@ -42,30 +38,12 @@ public class FacetItem {
     }
 
     /**
-     * Sets the key or content represented by this item.
-     *
-     * @param key the content to set
-     */
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    /**
      * Returns the title shown to the user when displaying this item.
      *
      * @return the user representation of this item
      */
     public String getTitle() {
         return title;
-    }
-
-    /**
-     * Sets the title shown to the user when displaying this item.
-     *
-     * @param title the new title
-     */
-    public void setTitle(String title) {
-        this.title = title;
     }
 
     /**
@@ -78,30 +56,37 @@ public class FacetItem {
     }
 
     /**
-     * Sets the number of matches.
+     * Permits to update the count of this facet item.
+     * <p>
+     * This might be used if a facet is built first and later updated using aggregation results of a query.
      *
-     * @param count the new number of matches
+     * @param count the new count to apply
+     * @return the item itself for fluent method calls
      */
-    public void setCount(int count) {
+    public FacetItem withCount(int count) {
         this.count = count;
+        return this;
     }
 
     /**
-     * Determines if this item is an currently active filter.
+     * Forces the item to be active, even if its value isn't selected in the underlying {@link Facet}.
+     * <p>
+     * This might be used if this item represents the default value which isn't <tt>null</tt> internally.
+     *
+     * @return the item itself for fluent method calls
+     */
+    public FacetItem forceActive() {
+        this.forceActive = true;
+        return this;
+    }
+
+    /**
+     * Determines if this item is currently an active filter.
      *
      * @return <tt>true</tt> if this is currently an active filter, <tt>false</tt> otherwise
      */
     public boolean isActive() {
-        return active;
-    }
-
-    /**
-     * Sets the active flag indicating if this is currently an active filter.
-     *
-     * @param active <tt>true</tt> to mark this as an active filter, <tt>false</tt> otherwise
-     */
-    public void setActive(boolean active) {
-        this.active = active;
+        return forceActive || facet.values.stream().anyMatch(value -> Strings.areEqual(value, key));
     }
 
     @Override

--- a/src/main/java/sirius/web/controller/FacetRange.java
+++ b/src/main/java/sirius/web/controller/FacetRange.java
@@ -12,10 +12,12 @@ import sirius.kernel.commons.Amount;
 
 /**
  * Represents a range filter for a {@link Facet} used for filtering on lower and/or upper bounds.
+ * @deprecated This makes the API overly complex and the only use-case is about to vanish
  */
+@Deprecated
 public class FacetRange {
-    private Amount min;
-    private Amount max;
+    private final Amount min;
+    private final Amount max;
     private Amount from = Amount.NOTHING;
     private Amount to = Amount.NOTHING;
 


### PR DESCRIPTION
- Dropped some overly complex or unused methods
- A FacetItem now properly checks if it is active instead of doing
  so only once during its construction (which was more than often the
  wrong point in time).