### PR TITLE
Ensures already existing autocompletes are still working

### DIFF
--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -145,6 +145,7 @@ public class AutocompleteHelper {
                 out.property("completionDescription", completionDescription);
 
                 // LEGACY SUPPORT....
+                out.property("id", value);
                 out.property("text", fieldLabel == null ? "" : fieldLabel);
                 out.property("description",  Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
                 // END OF LEGACY SUPPORT


### PR DESCRIPTION
The legacy support of the enhanced autocomplete helper needs to include all fields that the old autocomplete helper wrote to the JSON response so already existing autocomplete fields in the UI are not broken.

Fixes: OX-7001