### PR TITLE
Permits to fix and reload broken extensions in dev systems.

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/buttons.scss
+++ b/src/main/resources/default/assets/tycho/styles/buttons.scss
@@ -21,6 +21,7 @@
   color: #fff !important;
   background-color: $primary-color;
   border-color: $primary-color;
+  text-decoration: none;
 }
 
 .btn-primary {

--- a/src/main/resources/default/taglib/t/datacard.html.pasta
+++ b/src/main/resources/default/taglib/t/datacard.html.pasta
@@ -49,11 +49,17 @@
         </div>
 
         <i:local name="footer" value="@renderToString('footer')"/>
-        <i:if test="isFilled(footer)">
+        <i:local name="footerNavbox" value="@renderToString('footer-navbox')"/>
+        <i:if test="isFilled(footer) || isFilled(footerNavbox)">
             <div class="card-footer">
                 <span class="d-flex flex-row flex-wrap">
                     <i:raw>@footer</i:raw>
                 </span>
+                <i:if test="isFilled(footerNavbox)">
+                    <t:navbox class="mt-2">
+                        <i:raw>@footerNavbox</i:raw>
+                    </t:navbox>
+                </i:if>
             </div>
         </i:if>
     </div>

--- a/src/main/resources/default/taglib/t/navbox.html.pasta
+++ b/src/main/resources/default/taglib/t/navbox.html.pasta
@@ -1,9 +1,10 @@
 <i:arg type="String" name="labelKey" default="" />
 <i:arg type="String" name="label" default="@i18n(labelKey)" />
+<i:arg type="String" name="class" default="" />
 
 <i:pragma name="description" value="Renders navigation section within the sidebar or another card." />
 
-<ul class="nav flex-column nav-pills">
+<ul class="nav flex-column nav-pills flex-grow-1 @class">
     <i:if test="isFilled(label)">
         <li class="nav-header">@label</li>
     </i:if>

--- a/src/main/resources/default/taglib/t/navboxLink.html.pasta
+++ b/src/main/resources/default/taglib/t/navboxLink.html.pasta
@@ -9,7 +9,7 @@
 
 <i:if test="user().hasPermission(permission)">
     <li>
-        <a href="@url" class="nav-link @if(active) {active} d-flex flex-row">
+        <a href="@url" class="card-link nav-link @if(active) {active} d-flex flex-row">
             <i:if test="isFilled(icon)">
                 <span class="nav-link-icon pr-2"><i class="fa @icon"></i></span>
             </i:if>


### PR DESCRIPTION
We previously forced the list of extensions for a given point to be
empty, if one of the templates failed during compilation. We now
permit the developer to fix the template and we'll then recompile all
extensions properly.

Note that we still keep the empty list around in prod systems, as there
is no way of healing a broken template.