### PR TITLE
No longer assigns the autocomplete value to the completionLabel

### DIFF
--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -49,7 +49,6 @@ public class AutocompleteHelper {
         protected Completion(String value) {
             this.value = value;
             this.fieldLabel = value;
-            this.completionLabel = value;
         }
 
         /**

--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -58,7 +58,7 @@ public class AutocompleteHelper {
          * @param label the text to display to the user
          * @deprecated Use the simple constructor and the withXXX methods.
          */
-        @Deprecated
+        @Deprecated(forRemoval = true)
         public Completion(String value, String label) {
             this.value = value;
             this.fieldLabel = label;
@@ -72,7 +72,7 @@ public class AutocompleteHelper {
          * @param description the text shown in the autocomplete-dropdown
          * @deprecated Use the simple constructor and the withXXX methods.
          */
-        @Deprecated
+        @Deprecated(forRemoval = true)
         public Completion(String value, String label, @Nullable String description) {
             this.value = value;
             this.fieldLabel = label;
@@ -119,7 +119,7 @@ public class AutocompleteHelper {
          * @return the completion itself for fluent method calls
          * @deprecated Use {@link #markDisabled()}.
          */
-        @Deprecated
+        @Deprecated(forRemoval = true)
         public Completion setDisabled(boolean disabled) {
             this.disabled = disabled;
             return this;
@@ -146,7 +146,7 @@ public class AutocompleteHelper {
                 // LEGACY SUPPORT....
                 out.property("id", value);
                 out.property("text", fieldLabel == null ? "" : fieldLabel);
-                out.property("description", Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
+                out.property("description",  Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
                 // END OF LEGACY SUPPORT
 
                 if (disabled) {

--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -146,7 +146,7 @@ public class AutocompleteHelper {
                 // LEGACY SUPPORT....
                 out.property("id", value);
                 out.property("text", fieldLabel == null ? "" : fieldLabel);
-                out.property("description",  Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
+                out.property("description", Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
                 // END OF LEGACY SUPPORT
 
                 if (disabled) {
@@ -180,7 +180,7 @@ public class AutocompleteHelper {
      * @return the completion for the given code
      */
     public static Completion suggest(String code) {
-        return new AutocompleteHelper.Completion(code);
+        return new Completion(code);
     }
 
     /**


### PR DESCRIPTION
When not filled, the completion label falls back to the fieldLabel which is more accurate than using the value for cases where the completionLabel has not been set.