### PR TITLE
Only binds logged in user to the context

### DIFF
--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -219,7 +219,6 @@ public class UserContext implements SubContext {
 
         if (currentUser != null) {
             if (currentUser.isLoggedIn()) {
-                setCurrentUser(currentUser);
                 return Optional.of(currentUser);
             } else {
                 return Optional.empty();

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -218,7 +218,12 @@ public class UserContext implements SubContext {
         }
 
         if (currentUser != null) {
-            return Optional.of(currentUser);
+            if (currentUser.isLoggedIn()) {
+                setCurrentUser(currentUser);
+                return Optional.of(currentUser);
+            } else {
+                return Optional.empty();
+            }
         }
 
         // As this method might be called concurrently (e.g. by the deferred language installer of the WebServerHandler),

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -218,11 +218,7 @@ public class UserContext implements SubContext {
         }
 
         if (currentUser != null) {
-            if (currentUser.isLoggedIn()) {
-                return Optional.of(currentUser);
-            } else {
-                return Optional.empty();
-            }
+            return Optional.of(currentUser).filter(UserInfo::isLoggedIn);
         }
 
         // As this method might be called concurrently (e.g. by the deferred language installer of the WebServerHandler),


### PR DESCRIPTION
Returns the current user, only if they are logged in. 
Otherwise, calls without active login were resolved with an incorrect and inconsistent language (e.g. login page displayed in German -> submit invalid user data -> login page switched to English)

Fixes: SIRI-376