### PR TITLE
Disable scss caching in dev environments

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -172,7 +172,8 @@ public class AssetsDispatcher implements WebDispatcher {
         String cacheKey = scopeId + "-" + Files.toSaneFileName(uri.substring(1)).orElse("");
         File file = new File(getCacheDirFile(), cacheKey);
 
-        if (Sirius.isStartedAsTest() || !file.exists() || file.lastModified() < resource.get().getLastModified()) {
+        if (Sirius.isStartedAsTest() || Sirius.isDev() || !file.exists() || file.lastModified() < resource.get()
+                                                                                                          .getLastModified()) {
             try {
                 compileSASS(scssUri, file);
             } catch (Exception t) {


### PR DESCRIPTION
The SCSS Caching breaks as soon as you use an `@include`, because the lastModified check does not check the included files.

In production environments, the scss files should not change usually, so it is enough to recompile them in dev environments.

(actually, scss files should not change in staging/prod environments at all, except on a redeploy, which is handled already)