### PR TITLE
Permits to disable syntax checking within the ACE editor.

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -244,7 +244,7 @@ public class AssetsDispatcher implements WebDispatcher {
                   .filter(f -> f.getName().endsWith(".css"))
                   .forEach(File::delete);
         } catch (NullPointerException e) {
-            // Happens if the directy does not exist....
+            // Happens if the directly does not exist....
             Exceptions.ignore(e);
         } catch (Exception e) {
             Exceptions.handle(e);

--- a/src/main/java/sirius/web/resources/Resource.java
+++ b/src/main/java/sirius/web/resources/Resource.java
@@ -219,7 +219,7 @@ public class Resource {
      * Computes the last modified date.
      * <p>
      * This value will be cached if the resource is considered constant. However, in development systems
-     * the resource will sill be checked in a regular interval.
+     * the resource will still be checked in a regular interval.
      * <p>
      * Also note that the last modified timestamp is
      * at least the timestamp when the resource was resolved. This is required to manage dynamic resources which

--- a/src/main/resources/default/taglib/t/codeEditor.html.pasta
+++ b/src/main/resources/default/taglib/t/codeEditor.html.pasta
@@ -2,7 +2,7 @@
 <i:arg type="boolean" name="readonly" default="false" />
 <i:arg type="String" name="mode" default="html" description="Determines what kind of content is being highlighted." />
 <i:arg type="String" name="class" default="" description="May contain additional CSS classes to be added to the generated div." />
-
+<i:arg type="boolean" name="useWorker" default="false" description="Determines if local error/syntax checking is enabled"/>
 <i:pragma name="description">
     Provides a ACE based code editor. Note that "/assets/tycho/libs/ace/ace.js" needs to be present when using this.
 </i:pragma>
@@ -20,6 +20,7 @@
             editor.setReadOnly(true);
         }
         editor.session.setMode("ace/mode/@mode");
+        editor.session.setOption("useWorker", ___useWorker);
         _editorNode.aceEditor = editor;
     });
 </script>


### PR DESCRIPTION
This was already present in the Wondergem template and then falsely considered as "not needed".