### PR TITLE
Replaces navbar fixed-top with sticky-top

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/misc.scss
+++ b/src/main/resources/default/assets/tycho/styles/misc.scss
@@ -40,12 +40,11 @@ a {
 
 @media (min-width: 960px) {
 
-  .fixed-top-lg {
-    position: fixed;
+  .sticky-top-lg {
+    position: -webkit-sticky;
+    position: sticky;
     top: 0;
-    right: 0;
-    left: 0;
-    z-index: 1030;
+    z-index: 1020;
   }
 
   .fixed-bottom-lg {

--- a/src/main/resources/default/taglib/t/page.html.pasta
+++ b/src/main/resources/default/taglib/t/page.html.pasta
@@ -47,7 +47,7 @@
 </head>
 <body>
 <div id="wrapper">
-    <div id="wrapper-menu" class="fixed-top-lg">
+    <div id="wrapper-menu" class="sticky-top-lg">
         <i:render name="menu">
             <i:invoke template="/templates/tycho/page-menu.html.pasta"/>
         </i:render>
@@ -78,7 +78,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="main-container" class="container-fluid mb-2 pt-lg-5 pb-lg-5">
+                <div id="main-container" class="container-fluid mb-2 pb-lg-5">
                     <i:render name="page-header"/>
 
                     <i:render name="messages">

--- a/src/main/resources/default/taglib/t/pageHeader.html.pasta
+++ b/src/main/resources/default/taglib/t/pageHeader.html.pasta
@@ -1,5 +1,6 @@
 <i:arg type="String" name="titleKey" default=""/>
 <i:arg type="String" name="title" default="@i18n(titleKey)"/>
+<i:arg type="String" name="additionalActionsClass" default="" />
 
 <i:pragma name="description">
     Provides a header for a Tycho page. This element should most probably be placed in
@@ -28,7 +29,7 @@
                 </i:else>
             </i:if>
             <i:render name="actions" />
-            <t:additionalActions labelKey="template.html.additionalActions" class="ml-1" labelClass="d-none d-xl-inline-block">
+            <t:additionalActions labelKey="template.html.additionalActions" class="@('ml-1 ' + additionalActionsClass)" labelClass="d-none d-xl-inline-block">
                 <i:render name="additionalActions" />
             </t:additionalActions>
         </div>


### PR DESCRIPTION
While this makes it so that we never have a fixed navbar on IE11 this makes it way easier to implement, as we don't have to add additional padding (possibly changing) to the page.


Also adds a new parameter to the pageHeader to better control the display of the additionalActions by forwarding classes