### PR TITLE
Enforces the maintenance mode on public services (if requested).

### DIFF
--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -70,6 +70,7 @@ public class Route {
     private Controller controller;
     private boolean preDispatchable;
     private Format format;
+    private boolean enforceMaintenanceMode;
     private Set<String> permissions = null;
     private String subScope;
 
@@ -157,7 +158,9 @@ public class Route {
     @SuppressWarnings("deprecation")
     private static void determineAPIFormat(Method method, Routed routed, Route result) {
         if (method.isAnnotationPresent(PublicService.class)) {
-            result.format = method.getAnnotation(PublicService.class).format();
+            PublicService publicServiceAnnotation = method.getAnnotation(PublicService.class);
+            result.enforceMaintenanceMode = publicServiceAnnotation.enforceMaintenanceMode();
+            result.format = publicServiceAnnotation.format();
             publicServices.recordPublicService(method);
         } else if (method.isAnnotationPresent(InternalService.class)) {
             result.format = method.getAnnotation(InternalService.class).format();
@@ -410,6 +413,10 @@ public class Route {
 
     public Format getApiResponseFormat() {
         return format;
+    }
+
+    public boolean isEnforceMaintenanceMode() {
+        return enforceMaintenanceMode;
     }
 
     /**

--- a/src/main/java/sirius/web/services/PublicService.java
+++ b/src/main/java/sirius/web/services/PublicService.java
@@ -8,6 +8,8 @@
 
 package sirius.web.services;
 
+import sirius.web.security.MaintenanceInfo;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -65,6 +67,14 @@ public @interface PublicService {
      * @return the response format of this service
      */
     Format format() default Format.JSON;
+
+    /**
+     * Prevents calls to this service if set to <tt>true</tt> and the enclosing {@link sirius.web.security.ScopeInfo}
+     * is {@link MaintenanceInfo#isLocked() locked} for maintenance.
+     *
+     * @return <tt>true</tt> if this service must not be called during maintenance, <tt>false</tt> otherwise
+     */
+    boolean enforceMaintenanceMode() default false;
 
     /**
      * Specifies the visible name of this service.

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -91,6 +91,14 @@ http {
     # agents caring about that). A detailed description of P3P can be found here: http://en.wikipedia.org/wiki/P3P
     addP3PHeader = true
 
+    # If a maintenance mode is enabled and locked, we send a 503 response for public services which declare that
+    # the must not be called during maintenance (see PublicService.enforceMaintenanceMode). Along with the 503,
+    # we send a 'Retry-After' header with the delay given in this config. This is done to signal that the given
+    # downtime is of temporal nature and that clients might want to retry later. We choose a generous default here,
+    # as this is most probably be used for patches which normally impose a shorter downtime. Therefore the retury
+    # promised here will most probably be successful.
+    maintenanceRetryAfter = 1 day
+
     # Determines the content security policy, i.e. which internet resources to load from which locations. By default,
     # an insecure "allow everything" policy is set. A more secure value could be "script-src 'self' 'unsafe-inline'", or
     # even "script-src 'self'". Inline code can be verified via hashing. When loading script files from external


### PR DESCRIPTION
Services can now signal, that they should not be called during system
maintenance (which commonly tries to keep the system in a read-only
mode).

This is done via PublicService.enforceMaintenanceMode().

If a service is called during maintenance, a proper error (503) along
with a retry header are sent.

Fixes: SIRI-413