### PR TITLE
Performs some consistency work on Tycho and minor cleanups.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>dev-23.5.0</sirius.kernel>
+        <sirius.kernel>dev-23.6.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/resources/default/assets/tycho/styles/misc.scss
+++ b/src/main/resources/default/assets/tycho/styles/misc.scss
@@ -74,3 +74,13 @@ a {
 .back-button {
   display: none;
 }
+
+.link {
+  cursor: pointer;
+  position: relative;
+  z-index: 2;
+}
+
+.link:hover {
+  text-decoration: underline;
+}

--- a/src/main/resources/default/assets/tycho/styles/typeface.scss
+++ b/src/main/resources/default/assets/tycho/styles/typeface.scss
@@ -10,6 +10,10 @@
   color: rgba(0, 0, 0, 0.75) !important;
 }
 
+.text-black {
+  color: #000000 !important;
+}
+
 .display-5 {
   font-size: 2.5rem;
 }

--- a/src/main/resources/default/taglib/t/backButton.html.pasta
+++ b/src/main/resources/default/taglib/t/backButton.html.pasta
@@ -1,6 +1,7 @@
+<i:arg type="String" name="class" default="" description="Permits adding additional styles to the button"/>
 <i:pragma name="description" value="Renders a back button within a Tycho template. This is only shown, if a tycho history is present." />
 
-<a href="javascript:window.history.back()" class="btn btn-outline-secondary back-button">
+<a href="javascript:window.history.back()" class="btn btn-outline-secondary back-button @class">
     <i class="fa fa-chevron-left"></i>
     @i18n("NLS.back")
 </a>

--- a/src/main/resources/default/taglib/t/dropdown.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdown.html.pasta
@@ -1,5 +1,5 @@
-<i:arg type="String" name="titleKey" default=""/>
-<i:arg type="String" name="title" default="@i18n(titleKey)"/>
+<i:arg type="String" name="labelKey" default=""/>
+<i:arg type="String" name="label" default="@i18n(labelKey)"/>
 <i:arg type="String" name="icon" default=""/>
 <i:arg type="String" name="labelClass" default=""
        description="Defines addition classes to add to the label."/>
@@ -19,10 +19,10 @@
            aria-expanded="false">
             <span class="d-flex flex-row">
                 <i:if test="isFilled(icon)">
-                    <span class="pr-2"><i class="fa @icon"></i></span>
+                    <span class="pr-2"><i class="@icon"></i></span>
                 </i:if>
-                <i:if test="isFilled(title)">
-                    <span class="@labelClass">@title</span>
+                <i:if test="isFilled(label)">
+                    <span class="@labelClass">@label</span>
                 </i:if>
             </span>
         </a>

--- a/src/main/resources/default/taglib/t/dropdownItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownItem.html.pasta
@@ -13,7 +13,7 @@
     <t:permission permission="@permission">
         <a href="@url" class="dropdown-item @class">
             <i:if test="isFilled(icon)">
-                <i class="@icon fa-fw"></i>
+                <i class="@icon"></i>
             </i:if>
             @label
             <i:if test="adminOnly">

--- a/src/main/resources/default/taglib/t/dropdownItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownItem.html.pasta
@@ -1,5 +1,5 @@
-<i:arg type="String" name="titleKey" default=""/>
-<i:arg type="String" name="title" default="@i18n(titleKey)"/>
+<i:arg type="String" name="labelKey" default=""/>
+<i:arg type="String" name="label" default="@i18n(labelKey)"/>
 <i:arg type="String" name="icon" default=""/>
 <i:arg type="String" name="permission" default=""/>
 <i:arg type="String" name="framework" default=""/>
@@ -13,9 +13,9 @@
     <t:permission permission="@permission">
         <a href="@url" class="dropdown-item @class">
             <i:if test="isFilled(icon)">
-                <i class="fa fa-fw @icon"></i>
+                <i class="@icon fa-fw"></i>
             </i:if>
-            @title
+            @label
             <i:if test="adminOnly">
                 <i class="fa fa-fw fa-lock admin-link-icon"></i>
             </i:if>

--- a/src/main/resources/default/taglib/t/filterbox.html.pasta
+++ b/src/main/resources/default/taglib/t/filterbox.html.pasta
@@ -1,24 +1,26 @@
-<i:arg type="Page" name="page" />
-<i:arg type="String" name="baseUrl" />
+<i:arg type="Page" name="page"/>
+<i:arg type="String" name="baseUrl"/>
 
-<i:pragma name="description" value="Renders a filter box within a Tycho template" />
-<i:for type="sirius.web.controller.Facet" var="facet" items="page.getFacets()">
-    <i:if test="facet.hasItems()">
-        <t:navbox label="@facet.getTitle()">
-            <i:for type="sirius.web.controller.FacetItem" var="item" items="facet.getItems()">
-                <t:navboxLink url="@facet.linkToPageWithToggledItem(baseUrl, item)"
-                              active="item.isActive()"
-                              icon="@item.isActive() ? 'far fa-check-square' : 'far fa-square'">
-                    <div class="d-flex flex-row justify-content-between">
+<i:pragma name="description" value="Renders a filter box within a Tycho template"/>
+<div class="mb-4">
+    <i:for type="sirius.web.controller.Facet" var="facet" items="page.getFacets()">
+        <i:if test="facet.hasItems()">
+            <t:navbox label="@facet.getTitle()">
+                <i:for type="sirius.web.controller.FacetItem" var="item" items="facet.getItems()">
+                    <t:navboxLink url="@facet.linkToPageWithToggledItem(baseUrl, item)"
+                                  active="item.isActive()"
+                                  icon="@item.isActive() ? 'far fa-check-square' : 'far fa-square'">
+                        <div class="d-flex flex-row justify-content-between">
                         <span>
                             @item.getTitle()
                         </span>
-                        <i:if test="item.getCount() >= 0">
-                            <span class="badge badge-light">@item.getCount()</span>
-                        </i:if>
-                    </div>
-                </t:navboxLink>
-            </i:for>
-        </t:navbox>
-    </i:if>
-</i:for>
+                            <i:if test="item.getCount() >= 0">
+                                <span class="badge badge-light">@item.getCount()</span>
+                            </i:if>
+                        </div>
+                    </t:navboxLink>
+                </i:for>
+            </t:navbox>
+        </i:if>
+    </i:for>
+</div>

--- a/src/main/resources/default/taglib/t/formBar.html.pasta
+++ b/src/main/resources/default/taglib/t/formBar.html.pasta
@@ -2,7 +2,7 @@
 <i:arg name="singleClick" type="boolean" default="true" />
 <i:arg name="btnLabelKey" type="String" default="NLS.save" />
 <i:arg name="btnLabel" type="String" default="@i18n(btnLabelKey)" />
-<i:arg name="icon" type="String" default="fa-check" />
+<i:arg name="icon" type="String" default="fa fa-check" />
 <i:arg name="class" type="String" default="" />
 
 <i:pragma name="description" value="Renders a footer bar for forms within a Tycho template" />
@@ -10,7 +10,7 @@
 <div class="bt-gray mt-4 pt-3 mb-4 @class">
     <i:if test="isFilled(btnLabel)">
     <a class="btn btn-primary submit-link @if (singleClick) { single-click-link }">
-        <i class="fa @icon"></i> @btnLabel
+        <i class="@icon"></i> @btnLabel
     </a>
     </i:if>
     <i:if test="backButton">

--- a/src/main/resources/default/taglib/t/heading.html.pasta
+++ b/src/main/resources/default/taglib/t/heading.html.pasta
@@ -1,12 +1,12 @@
-<i:arg type="String" name="titleKey" default=""/>
-<i:arg type="String" name="title" default="@i18n(titleKey)"/>
+<i:arg type="String" name="labelKey" default=""/>
+<i:arg type="String" name="label" default="@i18n(labelKey)"/>
 <i:arg type="String" name="class" default="" />
-<i:local name="markupTitle" value="@renderToString('body')" />
-<i:if test="isFilled(title)">
-    <div class="bb-gray pb-2 mb-4 h5 text-black-75 @class">@title</div>
+<i:local name="markupLabel" value="@renderToString('body')" />
+<i:if test="isFilled(label)">
+    <div class="bb-gray pb-2 mb-4 h5 text-black-75 @class">@label</div>
     <i:else>
-        <i:if test="isFilled(markupTitle)">
-            <div class="bb-gray pb-2 mb-4 h5 text-black-75 @class"><i:raw>@markupTitle</i:raw></div>
+        <i:if test="isFilled(markupLabel)">
+            <div class="bb-gray pb-2 mb-4 h5 text-black-75 @class"><i:raw>@markupLabel</i:raw></div>
         </i:if>
     </i:else>
 </i:if>

--- a/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
+++ b/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
@@ -12,7 +12,7 @@
         <span class="text-sirius-gray-dark ">
             <i class="@icon"></i>
         </span>
-        <span class="pl-1 overflow-hidden">
+        <span class="pl-2 overflow-hidden">
             <i:if test="isFilled(value)">
                 @value
                 <i:else>

--- a/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
+++ b/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
@@ -10,7 +10,7 @@
 <i:if test="isFilled(effectiveValue)">
     <span class="d-flex flew-row text-small mb-2 mr-3 @class">
         <span class="text-sirius-gray-dark ">
-            <i class="fa @icon"></i>
+            <i class="@icon"></i>
         </span>
         <span class="pl-1 overflow-hidden">
             <i:if test="isFilled(value)">

--- a/src/main/resources/default/taglib/t/infobox.html.pasta
+++ b/src/main/resources/default/taglib/t/infobox.html.pasta
@@ -1,0 +1,12 @@
+<i:arg type="String" name="labelKey" default="" />
+<i:arg type="String" name="label" default="@i18n(labelKey)" />
+<i:arg type="String" name="class" default="" />
+
+<i:pragma name="description" value="Renders an information section within the sidebar or another card." />
+
+<div class="d-flex flex-column @class">
+    <i:if test="isFilled(label)">
+        <div class="nav-header">@label</div>
+    </i:if>
+    <i:render name="body" />
+</div>

--- a/src/main/resources/default/taglib/t/menuDropdown.html.pasta
+++ b/src/main/resources/default/taglib/t/menuDropdown.html.pasta
@@ -1,5 +1,5 @@
-<i:arg type="String" name="titleKey" default=""/>
-<i:arg type="String" name="title" default="@i18n(titleKey)"/>
+<i:arg type="String" name="labelKey" default=""/>
+<i:arg type="String" name="label" default="@i18n(labelKey)"/>
 <i:arg type="String" name="icon" default=""/>
 <i:arg type="String" name="permission" default=""/>
 <i:arg type="String" name="framework" default=""/>
@@ -20,9 +20,9 @@
                    aria-haspopup="true"
                    aria-expanded="false">
                     <i:if test="isFilled(icon)">
-                        <i class="fa @icon"></i>
+                        <i class="@icon"></i>
                     </i:if>
-                    @title
+                    @label
                 </a>
                 <div class="dropdown-menu @class" aria-labelledby="navbarDropdown">
                     <i:raw>@contents</i:raw>

--- a/src/main/resources/default/taglib/t/menuItem.html.pasta
+++ b/src/main/resources/default/taglib/t/menuItem.html.pasta
@@ -14,7 +14,7 @@
         <li class="nav-item">
             <a href="@url" class="nav-link @class">
                 <i:if test="isFilled(icon)">
-                    <i class="fa-fw @icon"></i>
+                    <i class="@icon"></i>
                 </i:if>
                 @label
                 <i:if test="adminOnly">

--- a/src/main/resources/default/taglib/t/menuItem.html.pasta
+++ b/src/main/resources/default/taglib/t/menuItem.html.pasta
@@ -1,5 +1,5 @@
-<i:arg type="String" name="titleKey" default=""/>
-<i:arg type="String" name="title" default="@i18n(titleKey)"/>
+<i:arg type="String" name="labelKey" default=""/>
+<i:arg type="String" name="label" default="@i18n(labelKey)"/>
 <i:arg type="String" name="icon" default=""/>
 <i:arg type="String" name="permission" default=""/>
 <i:arg type="String" name="framework" default=""/>
@@ -14,9 +14,9 @@
         <li class="nav-item">
             <a href="@url" class="nav-link @class">
                 <i:if test="isFilled(icon)">
-                    <i class="fa fa-fw @icon"></i>
+                    <i class="fa-fw @icon"></i>
                 </i:if>
-                @title
+                @label
                 <i:if test="adminOnly">
                     <i class="fa fa-fw fa-lock admin-link-icon"></i>
                 </i:if>

--- a/src/main/resources/default/taglib/t/navbox.html.pasta
+++ b/src/main/resources/default/taglib/t/navbox.html.pasta
@@ -2,7 +2,7 @@
 <i:arg type="String" name="label" default="@i18n(labelKey)" />
 <i:arg type="String" name="class" default="" />
 
-<i:pragma name="description" value="Renders navigation section within the sidebar or another card." />
+<i:pragma name="description" value="Renders a navigation section within the sidebar or another card." />
 
 <ul class="nav flex-column nav-pills flex-grow-1 @class">
     <i:if test="isFilled(label)">

--- a/src/main/resources/default/taglib/t/navboxLink.html.pasta
+++ b/src/main/resources/default/taglib/t/navboxLink.html.pasta
@@ -9,7 +9,7 @@
 
 <i:if test="user().hasPermission(permission)">
     <li>
-        <a href="@url" class="card-link nav-link @if (active) { active } d-flex flex-row">
+        <a href="@url" class="card-link nav-link @if (active) { active } d-flex flex-row mb-1">
             <i:if test="isFilled(icon)">
                 <span class="nav-link-icon pr-2"><i class="@icon"></i></span>
             </i:if>

--- a/src/main/resources/default/taglib/t/pagination.html.pasta
+++ b/src/main/resources/default/taglib/t/pagination.html.pasta
@@ -9,7 +9,7 @@
     <div class="input-group justify-content-center mb-4">
         <div class="input-group-prepend">
             <i:if test="page.hasLess()">
-                <a href="page.linkToPreviousPage(baseUrl)" class="btn btn-outline-secondary">&#8592;</a>
+                <a href="@page.linkToPreviousPage(baseUrl)" class="btn btn-outline-secondary">&#8592;</a>
                 <i:else>
                     <a class="btn btn-outline-secondary disabled">&#8592;</a>
                 </i:else>
@@ -18,7 +18,7 @@
         <input type="text" id="@id" placeholder="@page.getRange()" class="text-center">
         <div class="input-group-append">
             <i:if test="page.hasMore()">
-                <a href="page.linkToNextPage(baseUrl)" class="btn btn-outline-secondary">&#8594;</a>
+                <a href="@page.linkToNextPage(baseUrl)" class="btn btn-outline-secondary">&#8594;</a>
                 <i:else>
                     <a class="btn btn-outline-secondary disabled">&#8594;</a>
                 </i:else>

--- a/src/main/resources/default/taglib/t/sidebar.html.pasta
+++ b/src/main/resources/default/taglib/t/sidebar.html.pasta
@@ -1,28 +1,24 @@
-<i:arg type="String" name="class" default="" description="Permits to add additional classes to the sidebar."/>
+<i:arg type="String" name="class" default="" description="Permits adding additional classes to the sidebar."/>
 
-<i:local name="sidebarContents" value="@renderToString('sidebar')"/>
-
-<i:if test="isFilled(sidebarContents)">
-    <div class="row flex-grow-0 flex-lg-grow-1">
-        <div class="col-12 col-lg-4 col-xl-3 mb-4 sidebar d-none d-lg-block @class">
-            <div class="card h-100 shadow">
-                <img src="/assets/tycho/svg/sidebar-bg.svg" class="d-none d-lg-block"/>
-
-                <div class="card-body">
-                    <div class="d-flex flex-column">
-                        <i:raw>@sidebarContents</i:raw>
-                    </div>
+<div class="row flex-grow-0 flex-lg-grow-1">
+    <div class="col-12 col-lg-4 col-xl-3 sidebar d-none d-lg-block @class">
+        <div class="card h-100 shadow">
+            <div class="card-body">
+                <div class="d-flex flex-column">
+                    <i:render name="sidebar"/>
                 </div>
             </div>
-        </div>
-        <div class="col-12 col-lg-8 col-xl-9 d-flex mb-4">
-            <div class="flex-grow-1">
-                <i:render name="body"/>
+            <div class="card-footer">
+                <i:render name="sidebar-footer">
+                    <t:backButton class="mt-4 d-block" />
+                </i:render>
             </div>
         </div>
     </div>
+    <div class="col-12 col-lg-8 col-xl-9 d-flex mb-4">
+        <div class="flex-grow-1">
+            <i:render name="body"/>
+        </div>
+    </div>
+</div>
 
-    <i:else>
-        <i:render name="body"/>
-    </i:else>
-</i:if>

--- a/src/main/resources/default/taglib/t/smartFormatTemporal.html.pasta
+++ b/src/main/resources/default/taglib/t/smartFormatTemporal.html.pasta
@@ -2,8 +2,7 @@
 <i:arg type="String" name="class" default="" />
 
 <i:if test="date != null">
-    <span class="cycle cursor-pointer position-relative @class"
-          style="z-index: 2"
+    <span class="cycle link @class"
           data-cycle="@toUserString(date)">
         @NLS.toSpokenDate(date)
     </span>

--- a/src/main/resources/default/templates/system/tag.html.pasta
+++ b/src/main/resources/default/templates/system/tag.html.pasta
@@ -60,7 +60,7 @@
     </i:if>
 
     <i:if test="isFilled(source)">
-        <t:heading title="Source Code"/>
+        <t:heading label="Source Code"/>
         <t:codeEditor readonly="true">@source</t:codeEditor>
     </i:if>
 

--- a/src/main/resources/default/templates/system/tags-state.html.pasta
+++ b/src/main/resources/default/templates/system/tags-state.html.pasta
@@ -37,7 +37,7 @@
                 </t:dropdown>
             </i:block>
             <i:block name="additionalActions">
-                <t:dropdownItem label="Reset Statistics" icon="fa fa-trash" url="/system/tags/state?reset" />
+                <t:dropdownItem label="Reset Statistics" icon="fa fa-fw fa-trash" url="/system/tags/state?reset" />
             </i:block>
         </t:pageHeader>
     </i:block>

--- a/src/main/resources/default/templates/system/tags-state.html.pasta
+++ b/src/main/resources/default/templates/system/tags-state.html.pasta
@@ -30,14 +30,14 @@
                 <a href="/system/tags/state" class="btn btn-link">
                     <i class="fa fa-sync"></i> <span class="d-none d-lg-inline-block">@i18n("NLS.refresh")</span>
                 </a>
-                <t:dropdown title="Debug" icon="fa-bug" labelClass="debug-text d-none d-lg-inline-block">
-                    <t:dropdownItem title="OFF" url="javascript:setDebugLevel('OFF')" />
-                    <t:dropdownItem title="DEBUG" url="javascript:setDebugLevel('DEBUG')" />
-                    <t:dropdownItem title="TRACE" url="javascript:setDebugLevel('TRACE')" />
+                <t:dropdown label="Debug" icon="fa fa-bug" labelClass="debug-text d-none d-lg-inline-block">
+                    <t:dropdownItem label="OFF" url="javascript:setDebugLevel('OFF')" />
+                    <t:dropdownItem label="DEBUG" url="javascript:setDebugLevel('DEBUG')" />
+                    <t:dropdownItem label="TRACE" url="javascript:setDebugLevel('TRACE')" />
                 </t:dropdown>
             </i:block>
             <i:block name="additionalActions">
-                <t:dropdownItem title="Reset Statistics" icon="fa-trash" url="/system/tags/state?reset" />
+                <t:dropdownItem label="Reset Statistics" icon="fa fa-trash" url="/system/tags/state?reset" />
             </i:block>
         </t:pageHeader>
     </i:block>

--- a/src/main/resources/default/templates/system/tags.html.pasta
+++ b/src/main/resources/default/templates/system/tags.html.pasta
@@ -46,7 +46,7 @@
         </div>
     </div>
 
-    <t:heading title="Tag Libraries"/>
+    <t:heading label="Tag Libraries"/>
 
     <t:datacards>
         <t:datacard title="Build-Ins">


### PR DESCRIPTION
Some tags used "label" and others used "title" for the same purpose.
We now switched all tags to "label" with the exception or real titles
like for "page" or "modal".

Also, we previously auto-added a "fa" prefix to all icon attributes.
This has now been removed (as some icons require "far" as prefix).

In short, to migrate these changes, change titleKey/title to
labelKey/label where ever the compiler complains and add a "fa " to
all icon attributes of all Tycho tag invocations.