### PR TITLE
Limits the box shadow of input fields if they have siblings

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/forms.scss
+++ b/src/main/resources/default/assets/tycho/styles/forms.scss
@@ -50,6 +50,20 @@
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px $sirius-red-light;
 }
 
+// limit box shadow if input field has something appended or prepended
+
+.input-group>.custom-select:not(:last-child), .input-group>.form-control:not(:last-child) {
+  clip-path: inset(-5px 0px -5px -5px);
+}
+
+.input-group>.custom-select:not(:first-child), .input-group>.form-control:not(:first-child) {
+  clip-path: inset(-5px -5px -5px 0px);
+}
+
+.input-group>.custom-select:not(:first-child):not(:last-child), .input-group>.form-control:not(:first-child):not(:last-child) {
+  clip-path: inset(-5px 0px -5px 0px);
+}
+
 // --------------------------
 // Token Autocomplete
 // --------------------------


### PR DESCRIPTION
It looks a bit nicer if the blue focus glow on input fields is cut off on sides where are -append or -prepend is present


![Screenshot 2021-08-27 at 15 08 58](https://user-images.githubusercontent.com/10437176/131253209-885157e9-25e4-42a2-99d0-633be35af6e4.png)