### PR TITLE
Enhances history handling and make it cross-compatible with wondergem

### DIFF
--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -43,6 +43,9 @@ product {
 
     # Defines the root for legacy code (wondergem has been replaced by Tycho...)
     wondergemRoot = "/"
+
+    # Determines if tycho history should be used (even for legacy wondergem templates)
+    tychoHistory = true
 }
 
 # Contains the configuration for the web / http module

--- a/src/main/resources/default/assets/tycho/scripts/history.js
+++ b/src/main/resources/default/assets/tycho/scripts/history.js
@@ -48,7 +48,7 @@ function appendHistoryUrl(url) {
         // this site was restored from a state
         if (url === window.sessionStorage.getItem('tycho-history-skip-url')) {
             // we want to skip this state
-           window.history.back();
+            window.history.back();
         } else {
             window.sessionStorage.removeItem('tycho-history-skip-url')
         }
@@ -74,6 +74,8 @@ function appendHistoryUrl(url) {
         window.sessionStorage.setItem('tycho-history-skip-url', url);
         // We also want to skip it, if this state is called..
         url = '-';
+    } else {
+        window.sessionStorage.removeItem('tycho-history-skip-url')
     }
 
     if (url !== '-') {

--- a/src/main/resources/default/assets/tycho/scripts/history.js
+++ b/src/main/resources/default/assets/tycho/scripts/history.js
@@ -12,7 +12,7 @@ function currentUri() {
 
 function fetchTychoHistory() {
     try {
-        let urls = JSON.parse(window.localStorage.getItem("tycho-history"));
+        let urls = JSON.parse(window.sessionStorage.getItem("tycho-history"));
         if (urls == null || typeof urls !== "object") {
             return [];
         } else {
@@ -26,11 +26,11 @@ function fetchTychoHistory() {
 
 function storeTychoHistory(urls) {
     try {
-        while(urls.length > 25) {
+        while (urls.length > 25) {
             urls.shift()
         }
-        
-        window.localStorage.setItem("tycho-history", JSON.stringify(urls));
+
+        window.sessionStorage.setItem("tycho-history", JSON.stringify(urls));
     } catch (e) {
         console.log(e);
     }
@@ -41,14 +41,48 @@ function appendHistoryUrl(url) {
     if (url === '') {
         url = currentUri();
     }
+
     let urls = fetchTychoHistory();
-    if (urls.length === 0 || urls[urls.length - 1] !== url) {
+
+    if (window.history.state && window.history.state.url === url) {
+        // this site was restored from a state
+        if (url === window.sessionStorage.getItem('tycho-history-skip-url')) {
+            // we want to skip this state
+           window.history.back();
+        } else {
+            window.sessionStorage.removeItem('tycho-history-skip-url')
+        }
+        // search in local storage history for the url and rewind history to that stage
+        const lastIndexOf = urls.lastIndexOf(url);
+        if (lastIndexOf === -1) {
+            // Not in our history, probably 'forward' navigation make it the new 'newest'
+            urls.push(url);
+            // Also append the same entry again so we erase further forward navigation, as it will fail anyway
+            window.history.pushState({url: url}, document.title, window.location.href);
+            // As we duplicated the state, we need to skip the next back navigation
+            window.sessionStorage.setItem('tycho-history-skip-url', url);
+        } else {
+            // 'back' navigation, remove everything behind this url
+            urls.splice(lastIndexOf + 1);
+        }
+        storeTychoHistory(urls);
+        return;
+    }
+
+    if (urls.length !== 0 && urls[urls.length - 1] === url) {
+        // If the user navigates back from this state, we need to skip the entries with the same url
+        window.sessionStorage.setItem('tycho-history-skip-url', url);
+        // We also want to skip it, if this state is called..
+        url = '-';
+    }
+
+    if (url !== '-') {
         urls.push(url);
         storeTychoHistory(urls);
     }
 
-    // We just create a fake entry so that a popstate event is created if the back button is pressed...
-    window.history.pushState({}, document.title, window.location.href);
+    // Store the url to load in the current state
+    window.history.replaceState({url: url}, document.title, window.location.href);
 }
 
 function hasHistoryUrls() {
@@ -61,28 +95,23 @@ function hasHistoryUrls() {
     return false;
 }
 
-window.addEventListener("popstate", function (e) {
-    let urls = fetchTychoHistory();
-    while (urls.length > 0) {
-        let url = urls.pop();
-        if (url !== currentUri()) {
-            window.location.href = url;
-            storeTychoHistory(urls);
-            return;
-        }
-    }
-    storeTychoHistory(urls);
 
-    // We couldn't go anywhere, use the real history...
-    window.history.back();
-});
-
-sirius.ready(function() {
+sirius.ready(function () {
     if (hasHistoryUrls()) {
         document.querySelectorAll('.back-button').forEach(function (_node) {
             _node.style.display = 'inline-block';
             _node.parentNode.classList.remove('d-none');
         });
     }
-
 })
+
+// On page load, if we have a state with a different url, load it
+if (window.history.state) {
+    const url = window.history.state.url;
+    if (url === '-') {
+        window.sessionStorage.removeItem('tycho-history-skip-url');
+        window.history.back();
+    } else if (url !== currentUri()) {
+        window.location.href = url;
+    }
+}

--- a/src/main/resources/default/assets/wondergem/tycho-history.js
+++ b/src/main/resources/default/assets/wondergem/tycho-history.js
@@ -1,0 +1,71 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+function currentUri() {
+    return location.pathname + location.search;
+}
+
+function fetchTychoHistory() {
+    try {
+        let urls = JSON.parse(window.sessionStorage.getItem("tycho-history"));
+        if (urls == null || typeof urls !== "object") {
+            return [];
+        } else {
+            return urls;
+        }
+    } catch (e) {
+        console.log(e);
+        return [];
+    }
+}
+
+function storeTychoHistory(urls) {
+    try {
+        while (urls.length > 25) {
+            urls.shift()
+        }
+
+        window.sessionStorage.setItem("tycho-history", JSON.stringify(urls));
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+function appendHistoryUrl() {
+
+    // on wondergem, always remove potential tycho skips
+    window.sessionStorage.removeItem('tycho-history-skip-url')
+
+    // No explicit URL is given, use the current one...
+    let url = currentUri();
+
+    let urls = fetchTychoHistory();
+
+    if (window.history.state && window.history.state.url === url) {
+        // this site was restored from a state
+        // search in local storage history for the url and rewind history to that stage
+        const lastIndexOf = urls.lastIndexOf(url);
+        if (lastIndexOf === -1) {
+            // Not in our history, probably 'forward' navigation make it the new 'newest'
+            urls.push(url);
+        } else {
+            // 'back' navigation, remove everything behind this url
+            urls.splice(lastIndexOf + 1);
+        }
+        storeTychoHistory(urls);
+        return;
+    }
+
+    urls.push(url);
+    storeTychoHistory(urls);
+
+
+    // Store the url to load in the current state
+    window.history.replaceState({url: url}, document.title, window.location.href);
+}
+

--- a/src/main/resources/default/assets/wondergem/wondergem.js.pasta
+++ b/src/main/resources/default/assets/wondergem/wondergem.js.pasta
@@ -21,3 +21,5 @@
 <i:include name="/assets/wondergem/bootstrap-tokenfield/bootstrap-tokenfield.js"/>
 
 <i:include name="/assets/wondergem/autocomplete/multiselect.js"/>
+
+<i:include name="/assets/wondergem/tycho-history.js"/>

--- a/src/main/resources/default/taglib/t/page.html.pasta
+++ b/src/main/resources/default/taglib/t/page.html.pasta
@@ -101,7 +101,7 @@
 
 <i:invoke template="/templates/tycho/page-dialogs.html.pasta"/>
 <i:extensions target="tycho-page" point="footer"/>
-<i:if test="historyUri != '-'">
+<i:if test="config('product.tychoHistory').asBoolean()">
     <script type="text/javascript">
         appendHistoryUrl('@historyUri');
     </script>

--- a/src/main/resources/default/taglib/w/page.html.pasta
+++ b/src/main/resources/default/taglib/w/page.html.pasta
@@ -88,5 +88,10 @@
 
 <i:invoke template="/templates/wondergem/page-dialogs.html.pasta"/>
 <i:extensions target="wondergem-page" point="footer"/>
+<i:if test="config('product.tychoHistory').asBoolean()">
+    <script type="text/javascript">
+        appendHistoryUrl();
+    </script>
+</i:if>
 </body>
 </html>


### PR DESCRIPTION
If you're not using tycho yet, you should disable tycho history in wondergem via config.

The goal of the own history handling:
- Skip over multiple entries of the same page
- Skip over entries that explicitly want to be skipped (e.g. historyUri = '' in t:page)
- Redirect to a different historyUri

As the browser history API is pretty restricted and popstate calling is pretty inconsistent we implement this by reading state on page load and redirecting / skipping over urls as instructed.
This leads to some restrictions:
- Forward Navigation will only work once
- When reloading a page which already has multiple entries, a forward button will be shown, which doesn't do anything
- Navigation using the back menu (more than one step back) might fail in some rare circumstances