### PR TITLE
Updates token-autocomplete to hide text overflow

### DIFF
--- a/src/main/resources/default/assets/tycho/libs/token-autocomplete/token-autocomplete.css
+++ b/src/main/resources/default/assets/tycho/libs/token-autocomplete/token-autocomplete.css
@@ -54,6 +54,9 @@
     width: 100%;
     position: relative;
     cursor: pointer;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .token-autocomplete-container.token-autocomplete-singleselect.token-autocomplete-readonly .token-autocomplete-input {


### PR DESCRIPTION
Includes the changes of https://github.com/scireum/token-autocomplete/pull/36

Fixes: OX-7398