### PR TITLE
adjust css-classes to not crash the layout on small lists with long titles

### DIFF
--- a/src/main/resources/default/taglib/t/filterbox.html.pasta
+++ b/src/main/resources/default/taglib/t/filterbox.html.pasta
@@ -10,10 +10,10 @@
                     <t:navboxLink url="@facet.linkToPageWithToggledItem(baseUrl, item)"
                                   active="item.isActive()"
                                   icon="@item.isActive() ? 'far fa-check-square' : 'far fa-square'">
-                        <div class="d-flex flex-row justify-content-between">
-                        <span>
-                            @item.getTitle()
-                        </span>
+                        <div class="d-flex flex-row justify-content-between align-items-center">
+                            <span>
+                                @item.getTitle()
+                            </span>
                             <i:if test="item.getCount() >= 0">
                                 <span class="badge badge-light">@item.getCount()</span>
                             </i:if>

--- a/src/main/resources/default/taglib/t/navboxLink.html.pasta
+++ b/src/main/resources/default/taglib/t/navboxLink.html.pasta
@@ -9,11 +9,11 @@
 
 <i:if test="user().hasPermission(permission)">
     <li>
-        <a href="@url" class="card-link nav-link @if (active) { active } d-flex flex-row mb-1">
+        <a href="@url" class="card-link nav-link @if (active) { active } d-flex flex-row mb-1 align-items-center">
             <i:if test="isFilled(icon)">
                 <span class="nav-link-icon pr-2"><i class="@icon"></i></span>
             </i:if>
-            <span class="flex-grow-1 text-nowrap overflow-hidden">
+            <span class="flex-grow-1 overflow-hidden">
                 @label
                 <i:render name="body"/>
             </span>


### PR DESCRIPTION
<img width="1227" alt="Bildschirmfoto 2021-09-15 um 12 57 56" src="https://user-images.githubusercontent.com/55080004/133421523-8910d5f6-5147-462d-ab2a-ab5c7ffdd85f.png">
before fix <--> after fix