### PR TITLE
Replace javax.mail from 2013 with a version from 2015

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,9 @@
 
         <!-- Used to send and receive mails -->
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>1.4.7</version>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+            <version>1.5.5</version>
         </dependency>
         <dependency>
             <groupId>net.markenwerk</groupId>


### PR DESCRIPTION
net.markenwerk has 1.5.5 as dependency, depending on the system one or the other will be used. 1.4.7 always falls back to TLSv1.0 if the mail.smtp.ssl.protocols property is not set, but not all servers still support 1.0. Version 1.5.5 will use TLSv1.2 or TLSv1.3 by default.