### PR TITLE
Allows the browser to break long navbar links if necessary

### DIFF
--- a/src/main/resources/default/taglib/t/navboxLink.html.pasta
+++ b/src/main/resources/default/taglib/t/navboxLink.html.pasta
@@ -13,7 +13,7 @@
             <i:if test="isFilled(icon)">
                 <span class="nav-link-icon pr-2"><i class="@icon"></i></span>
             </i:if>
-            <span class="flex-grow-1 overflow-hidden">
+            <span class="flex-grow-1 overflow-hidden text-break">
                 @label
                 <i:render name="body"/>
             </span>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2427877/134353318-2de302d4-de2f-428a-9ed8-e081e07b4e8d.png)


After:
![image](https://user-images.githubusercontent.com/2427877/134353273-8545e16b-9a72-4111-bcad-f674258dad04.png)


Fixes: OX-7441