### PR TITLE
Disable (clean) CookieStore of AsyncHttpClient

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -1256,7 +1256,10 @@ public class Response {
      */
     protected static AsyncHttpClient getAsyncClient() {
         if (asyncClient == null) {
-            asyncClient = Dsl.asyncHttpClient(Dsl.config().setFollowRedirect(true).setRequestTimeout(-1));
+            asyncClient = Dsl.asyncHttpClient(Dsl.config()
+                                                 .setCookieStore(null)
+                                                 .setFollowRedirect(true)
+                                                 .setRequestTimeout(-1));
         }
         return asyncClient;
     }


### PR DESCRIPTION
The CookieStore shouldn't override the previously added cookies of the original client.