### PR TITLE
Tunnel no longer following redirecting and set-cookies handling

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -849,7 +849,7 @@ public class Response {
                 Exceptions.handle()
                           .to(WebServer.LOG)
                           .withSystemErrorMessage(
-                                  "An excption occurred while responding to: %s - %s (%s) [Debug-Message: %s]",
+                                  "An exception occurred while responding to: %s - %s (%s) [Debug-Message: %s]",
                                   requestUri,
                                   debugMessage)
                           .handle();

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -48,11 +48,12 @@ import java.util.stream.Collectors;
  */
 class TunnelHandler implements AsyncHandler<String> {
 
-    private static final Set<String> NON_TUNNELLED_HEADERS = Set.of(HttpHeaderNames.TRANSFER_ENCODING.toString(),
-                                                                    HttpHeaderNames.SERVER.toString(),
-                                                                    HttpHeaderNames.CONTENT_ENCODING.toString(),
-                                                                    HttpHeaderNames.EXPIRES.toString(),
-                                                                    HttpHeaderNames.CACHE_CONTROL.toString());
+    private static final Set<String> NON_TUNNELLED_HEADERS =
+            Set.of(HttpHeaderNames.TRANSFER_ENCODING.toString().toLowerCase(),
+                   HttpHeaderNames.SERVER.toString().toLowerCase(),
+                   HttpHeaderNames.CONTENT_ENCODING.toString().toLowerCase(),
+                   HttpHeaderNames.EXPIRES.toString().toLowerCase(),
+                   HttpHeaderNames.CACHE_CONTROL.toString().toLowerCase());
 
     private static final Set<Integer> PASS_THROUGH_STATUS = Set.of(HttpResponseStatus.FOUND.code(),
                                                                    HttpResponseStatus.NOT_MODIFIED.code(),
@@ -226,7 +227,7 @@ class TunnelHandler implements AsyncHandler<String> {
             return Sirius.isDev();
         }
 
-        return !NON_TUNNELLED_HEADERS.contains(entry.getKey());
+        return !NON_TUNNELLED_HEADERS.contains(entry.getKey().toLowerCase());
     }
 
     private void forwardHeaderValues(Map.Entry<String, String> entry) {


### PR DESCRIPTION
- Changes the default tunnel following redirect behavior back to don't follow. This can be overridden using sirius.web.http.Response#tunnel's requestTuner 
- Allows multiple set-cookie response headers to be passed
- Header blocking becomes case-insensitive