### PR TITLE
Allows to add classes to the title of a Tycho data card

### DIFF
--- a/src/main/resources/default/taglib/t/datacard.html.pasta
+++ b/src/main/resources/default/taglib/t/datacard.html.pasta
@@ -7,6 +7,7 @@
        name="link"
        default=""
        description="Specifies the target this card points to. Use the CSS class card-link for links within the card to win over this link."/>
+<i:arg type="String" name="titleClass" default="" description="Permits adding additional classes to the card title."/>
 
 <i:pragma name="description">
     Renders a data centric card which has a title an optional subtitle and body contents.
@@ -23,7 +24,7 @@
                 <div class="card-body">
                     <div class="d-flex justify-content-between">
                         <i:if test="isFilled(title)">
-                            <h5 class="card-title">@title</h5>
+                            <h5 class="card-title @titleClass">@title</h5>
                             <i:else>
                                 <i:local name="markupTitle" value="@renderToString('title')"/>
                                 <i:if test="isFilled(markupTitle)">


### PR DESCRIPTION
One example use case for this could be to truncate the title text if it exceeds the width of the card.

Fixes: OX-7614