### PR TITLE
Prevents flex items becoming bigger than the flex container

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/page.scss
+++ b/src/main/resources/default/assets/tycho/styles/page.scss
@@ -10,6 +10,17 @@ body {
   background-color: $backgroundGray;
 }
 
+/* Makes flex items behavior more smooth by supplying them with a default min-width / min-height.
+   This prevents them from overflowing the flex container by giving them a baseline to shrink.
+ */
+.d-flex, .d-inline-flex {
+  & > * {
+    min-width: 0;
+    min-height: 0;
+  }
+}
+
+
 #wrapper {
   display: grid;
   height: 100vh;


### PR DESCRIPTION
By giving all direct descendants of .d-flex and .d-inline-flex a min-width or min-height, they will be able to actually shrink, as else they often will have a width/height: auto, which also implies a flex-basis of auto - which prevents shrinking/limiting the width/height of the flex item.

Fixes: OX-7614

Before
<img width="837" alt="Screenshot 2021-11-08 at 15 10 36" src="https://user-images.githubusercontent.com/10437176/140756780-7734ab23-dc99-48b1-8c3a-db0428ca0af8.png">
After
<img width="709" alt="Screenshot 2021-11-08 at 15 10 58" src="https://user-images.githubusercontent.com/10437176/140756795-42f1f193-e5d7-483c-9b68-504e848c8a89.png">

Also happend in all layouts with a sidebar and searchheader


See https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis for some more info
