### PR TITLE
Properly supports barcodes for GTIN-14 using the ITF format

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Used by the XHTMLRenderer (creating PDFs) to replace img elements by their references image.
+ * Used by the XHTMLRenderer (creating PDFs) to replace img elements by their referenced image.
  * <p>
  * Alongside http different URI protocols are supported. These are handled by classes extending
  * {@link PdfReplaceHandler}.

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -44,7 +44,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             throw new IllegalArgumentException("The URI is required to match the format 'barcode://type/content'");
         }
 
-        Image awtImage = BarcodeController.generateBarcodeImage(barcodeInfo[0], barcodeInfo[1]);
+        Image awtImage = BarcodeController.generateBarcodeImage(barcodeInfo[0], barcodeInfo[1], cssWidth, cssHeight);
 
         FSImage fsImage = new ITextFSImage(com.lowagie.text.Image.getInstance(awtImage, Color.WHITE, true));
 

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -53,12 +53,6 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
 
         Image awtImage = generateBarcodeImage(barcodeInfo[0], barcodeInfo[1]);
 
-        int scaleFactor = calculateBarcodeScaleFactor(cssWidth, cssHeight, awtImage);
-
-        awtImage = awtImage.getScaledInstance(awtImage.getWidth(null) * scaleFactor,
-                                              awtImage.getHeight(null) * scaleFactor,
-                                              Image.SCALE_REPLICATE);
-
         FSImage fsImage = new ITextFSImage(com.lowagie.text.Image.getInstance(awtImage, Color.WHITE, true));
 
         if (cssWidth != -1 || cssHeight != -1) {
@@ -83,11 +77,6 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         }
 
         return BarcodeController.generateBarcodeImage(barcodeType, content);
-    }
-
-    private int calculateBarcodeScaleFactor(int cssWidth, int cssHeight, Image awtImage) {
-        return (int) Math.max(Math.ceil(cssWidth / (float) awtImage.getWidth(null)),
-                              Math.ceil(cssHeight / (float) awtImage.getHeight(null)));
     }
 
     private void assertSupportedBarcodeType(String type) {

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -52,7 +52,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             throw new IllegalArgumentException("The URI is required to match the format 'barcode://type/content'");
         }
 
-        Image awtImage = getBarcodeImage(barcodeInfo[0], barcodeInfo[1], cssWidth, cssHeight);
+        Image awtImage = generateBarcodeImage(barcodeInfo[0], barcodeInfo[1], cssWidth, cssHeight);
 
         int scaleFactor = calculateBarcodeScaleFactor(cssWidth, cssHeight, awtImage);
 
@@ -69,7 +69,8 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         return fsImage;
     }
 
-    private Image getBarcodeImage(String barcodeType, String content, int width, int height) throws WriterException {
+    private Image generateBarcodeImage(String barcodeType, String content, int width, int height)
+            throws WriterException {
         assertSupportedBarcodeType(barcodeType);
 
         if (BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(barcodeType)) {
@@ -86,7 +87,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             content = "0" + content;
         }
 
-        return BarcodeController.getBarcodeImage(barcodeType, content, width, height);
+        return BarcodeController.generateBarcodeImage(barcodeType, content, width, height);
     }
 
     private int calculateBarcodeScaleFactor(int cssWidth, int cssHeight, Image awtImage) {

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -52,7 +52,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             throw new IllegalArgumentException("The URI is required to match the format 'barcode://type/content'");
         }
 
-        Image awtImage = generateBarcodeImage(barcodeInfo[0], barcodeInfo[1], cssWidth, cssHeight);
+        Image awtImage = generateBarcodeImage(barcodeInfo[0], barcodeInfo[1]);
 
         int scaleFactor = calculateBarcodeScaleFactor(cssWidth, cssHeight, awtImage);
 
@@ -69,7 +69,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         return fsImage;
     }
 
-    private Image generateBarcodeImage(String barcodeType, String content, int width, int height)
+    private Image generateBarcodeImage(String barcodeType, String content)
             throws WriterException {
         assertSupportedBarcodeType(barcodeType);
 
@@ -87,7 +87,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             content = "0" + content;
         }
 
-        return BarcodeController.generateBarcodeImage(barcodeType, content, width, height);
+        return BarcodeController.generateBarcodeImage(barcodeType, content);
     }
 
     private int calculateBarcodeScaleFactor(int cssWidth, int cssHeight, Image awtImage) {

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -8,8 +8,6 @@
 
 package sirius.web.templates.pdf.handlers;
 
-import com.google.zxing.WriterException;
-import com.lowagie.text.pdf.BarcodeInter25;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import org.xhtmlrenderer.pdf.ITextFSImage;
@@ -31,11 +29,6 @@ import java.awt.Image;
 @Register
 public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
 
-    private static final String BARCODE_TYPE_CODE128 = "code128";
-    private static final String BARCODE_TYPE_EAN = "ean";
-    private static final String BARCODE_TYPE_INTERLEAVED_2_OF_5 = "interleaved2of5";
-    private static final String BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED = "interleaved2of5checksummed";
-
     @Override
     public boolean accepts(String protocol) {
         return "barcode".equals(protocol);
@@ -51,7 +44,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             throw new IllegalArgumentException("The URI is required to match the format 'barcode://type/content'");
         }
 
-        Image awtImage = generateBarcodeImage(barcodeInfo[0], barcodeInfo[1]);
+        Image awtImage = BarcodeController.generateBarcodeImage(barcodeInfo[0], barcodeInfo[1]);
 
         FSImage fsImage = new ITextFSImage(com.lowagie.text.Image.getInstance(awtImage, Color.WHITE, true));
 
@@ -60,33 +53,5 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         }
 
         return fsImage;
-    }
-
-    private Image generateBarcodeImage(String barcodeType, String content) throws WriterException {
-        assertSupportedBarcodeType(barcodeType);
-
-        if (BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(barcodeType)) {
-            content += BarcodeInter25.getChecksum(content);
-        }
-
-        if ((BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(barcodeType)
-             || BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(barcodeType))
-            && BarcodeInter25.keepNumbers(content).length() % 2 != 0) {
-            // Pads the code if the length is uneven
-            content = "0" + content;
-        }
-
-        return BarcodeController.generateBarcodeImage(barcodeType, content);
-    }
-
-    private void assertSupportedBarcodeType(String type) {
-        if (!BARCODE_TYPE_CODE128.equalsIgnoreCase(type)
-            && !BARCODE_TYPE_EAN.equalsIgnoreCase(type)
-            && !BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(type)
-            && !BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(type)) {
-            throw new UnsupportedOperationException(Strings.apply(
-                    "Type '%s' is not supported. Supported types are: code128, ean, interleaved2of5, interleaved2of5checksummed.",
-                    type));
-        }
     }
 }

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -80,6 +80,12 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
             return code.createAwtImage(Color.BLACK, Color.WHITE);
         }
 
+        if (BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(barcodeType)
+            && BarcodeInter25.keepNumbers(content).length() % 2 != 0) {
+            // Pads the code if necessary: Length is uneven and no checksum will be added
+            content = "0" + content;
+        }
+
         return BarcodeController.getBarcodeImage(barcodeType, content, width, height);
     }
 

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -75,7 +75,8 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         if (BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(barcodeType)) {
             Barcode code = new BarcodeInter25();
             code.setGenerateChecksum(true);
-            code.setCode(padCodeIfNecessary(code, content));
+            // Pads the code if necessary: Length is even but a checksum will be added
+            code.setCode(BarcodeInter25.keepNumbers(content).length() % 2 == 0 ? "0" + content : content);
             return code.createAwtImage(Color.BLACK, Color.WHITE);
         }
 
@@ -96,33 +97,5 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
                     "Type '%s' is not supported. Supported types are: code128, ean, interleaved2of5, interleaved2of5checksummed.",
                     type));
         }
-    }
-
-    /**
-     * Pads the code if necessary.
-     * <p>
-     * Unfortunately padding will not be added automatically when using <b>interleaved2of5</b> or
-     * <b>interleaved2of5checksummed</b>. Thus we manually prepend a zero if the code length is uneven.
-     *
-     * @param code the instance of the barcode
-     * @param src  the code from the src attribute
-     * @return the padded code, or the original code if padding was not needed
-     */
-    private String padCodeIfNecessary(Barcode code, String src) {
-        if (code instanceof BarcodeInter25) {
-            int length = BarcodeInter25.keepNumbers(src).length();
-
-            // Length is uneven and no checksum will be added
-            if (length % 2 != 0 && !code.isGenerateChecksum()) {
-                return "0" + src;
-            }
-
-            // Length is even but a checksum will be added
-            if (length % 2 == 0 && code.isGenerateChecksum()) {
-                return "0" + src;
-            }
-        }
-
-        return src;
     }
 }

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -9,7 +9,6 @@
 package sirius.web.templates.pdf.handlers;
 
 import com.google.zxing.WriterException;
-import com.lowagie.text.pdf.Barcode;
 import com.lowagie.text.pdf.BarcodeInter25;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.UserAgentCallback;
@@ -69,21 +68,17 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         return fsImage;
     }
 
-    private Image generateBarcodeImage(String barcodeType, String content)
-            throws WriterException {
+    private Image generateBarcodeImage(String barcodeType, String content) throws WriterException {
         assertSupportedBarcodeType(barcodeType);
 
         if (BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(barcodeType)) {
-            Barcode code = new BarcodeInter25();
-            code.setGenerateChecksum(true);
-            // Pads the code if necessary: Length is even but a checksum will be added
-            code.setCode(BarcodeInter25.keepNumbers(content).length() % 2 == 0 ? "0" + content : content);
-            return code.createAwtImage(Color.BLACK, Color.WHITE);
+            content += BarcodeInter25.getChecksum(content);
         }
 
-        if (BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(barcodeType)
+        if ((BARCODE_TYPE_INTERLEAVED_2_OF_5.equalsIgnoreCase(barcodeType)
+             || BARCODE_TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED.equalsIgnoreCase(barcodeType))
             && BarcodeInter25.keepNumbers(content).length() % 2 != 0) {
-            // Pads the code if necessary: Length is uneven and no checksum will be added
+            // Pads the code if the length is uneven
             content = "0" + content;
         }
 

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -50,6 +50,16 @@ public class BarcodeController extends BasicController {
         barcode(ctx, BarcodeFormat.QR_CODE);
     }
 
+    /**
+     * Creates a barcode for the given content.
+     * <p>
+     * The parameter <tt>content</tt> determines the contents of the barcode. The parameters <tt>width</tt> and
+     * <tt>height</tt> determine its dimensions.
+     * </p>
+     *
+     * @param webContext the current request
+     * @throws Exception in case an error occurred when generating the barcode
+     */
     @Routed(value = "/barcode", priority = 999)
     public void barcode(WebContext webContext) throws Exception {
         barcode(webContext, determineFormat(webContext.get("type").asString()));

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -29,8 +29,10 @@ import sirius.web.http.MimeHelper;
 import sirius.web.http.WebContext;
 
 import java.awt.Image;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.regex.Pattern;
 
 /**
  * Used to generate barcodes by responding to "/qr" or "/barcode".
@@ -45,6 +47,8 @@ public class BarcodeController extends BasicController {
     private static final String TYPE_ITF = "itf";
     private static final String TYPE_INTERLEAVED_2_OF_5 = "interleaved2of5";
     private static final String TYPE_INTERLEAVED_2_OF_5_CHECKSUMMED = "interleaved2of5checksummed";
+
+    private static final Pattern NUMERIC = Pattern.compile("[0-9]+");
 
     /**
      * Creates a QR code for the given content.
@@ -108,6 +112,11 @@ public class BarcodeController extends BasicController {
      * @throws WriterException if generating the image fails
      */
     public static Image generateBarcodeImage(String type, String content) throws WriterException {
+        if (!NUMERIC.matcher(content).matches()) {
+            // contains characters other than digits 0-9 -> directly return a blank image to prevent running into exception
+            return new BufferedImage(200, 200, BufferedImage.TYPE_BYTE_GRAY);
+        }
+
         BarcodeFormat format = determineFormat(type);
 
         content = alignContentForItfFormat(content, type);

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -108,15 +108,20 @@ public class BarcodeController extends BasicController {
      *
      * @param type    the desired barcode type
      * @param content the content of the barcode
-     * @return a barcode of the given data as a 200x200 px image
+     * @param width   the desired width
+     * @param height  the desired height
+     * @return a barcode of the given data as an image
      * @throws WriterException if generating the image fails
      */
-    public static Image generateBarcodeImage(String type, String content) throws WriterException {
+    public static Image generateBarcodeImage(String type, String content, int width, int height)
+            throws WriterException {
         BarcodeFormat format = determineFormat(type);
 
         if (!NUMERIC.matcher(content).matches() && format != BarcodeFormat.QR_CODE) {
             // contains characters other than digits 0-9 -> directly return a blank image to prevent running into exception
-            return new BufferedImage(200, 200, BufferedImage.TYPE_BYTE_GRAY);
+            return new BufferedImage(width != -1 ? width : 200,
+                                     height != -1 ? height : 200,
+                                     BufferedImage.TYPE_BYTE_GRAY);
         }
 
         content = alignContentForItfFormat(content, type);
@@ -124,7 +129,7 @@ public class BarcodeController extends BasicController {
         format = useItfFormatForGtin14(content, format);
 
         Writer writer = determineWriter(format);
-        BitMatrix matrix = writer.encode(content, format, 200, 200);
+        BitMatrix matrix = writer.encode(content, format, width != -1 ? width : 200, height != -1 ? height : 200);
         return MatrixToImageWriter.toBufferedImage(matrix);
     }
 

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -93,19 +93,17 @@ public class BarcodeController extends BasicController {
      *
      * @param type    the desired barcode type
      * @param content the content of the barcode
-     * @param width   the desired image width
-     * @param height  the desired image height
-     * @return a barcode of the given data as an image
+     * @return a barcode of the given data as a 200x200 px image
      * @throws WriterException if generating the image fails
      */
-    public static Image generateBarcodeImage(String type, String content, int width, int height)
+    public static Image generateBarcodeImage(String type, String content)
             throws WriterException {
         BarcodeFormat format = determineFormat(type);
 
         format = useItfFormatForGtin14(content, format);
 
         Writer writer = determineWriter(format);
-        BitMatrix matrix = writer.encode(content, format, width != -1 ? width : 200, height != -1 ? height : 200);
+        BitMatrix matrix = writer.encode(content, format, 200, 200);
         return MatrixToImageWriter.toBufferedImage(matrix);
     }
 

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -108,7 +108,7 @@ public class BarcodeController extends BasicController {
         }
 
         Writer writer = determineWriter(format);
-        BitMatrix matrix = writer.encode(content, format, width, height);
+        BitMatrix matrix = writer.encode(content, format, width != -1 ? width : 200, height != -1 ? height : 200);
         return MatrixToImageWriter.toBufferedImage(matrix);
     }
 

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -112,12 +112,12 @@ public class BarcodeController extends BasicController {
      * @throws WriterException if generating the image fails
      */
     public static Image generateBarcodeImage(String type, String content) throws WriterException {
-        if (!NUMERIC.matcher(content).matches()) {
+        BarcodeFormat format = determineFormat(type);
+
+        if (!NUMERIC.matcher(content).matches() && format != BarcodeFormat.QR_CODE) {
             // contains characters other than digits 0-9 -> directly return a blank image to prevent running into exception
             return new BufferedImage(200, 200, BufferedImage.TYPE_BYTE_GRAY);
         }
-
-        BarcodeFormat format = determineFormat(type);
 
         content = alignContentForItfFormat(content, type);
 

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -36,10 +36,10 @@ import java.io.OutputStream;
 public class BarcodeController extends BasicController {
 
     /**
-     * Creates an QR code for the given content.
+     * Creates a QR code for the given content.
      * <p>
-     * The parameter <tt>content</tt> determines the contents of the qr code. The parameters <tt>with</tt> and
-     * <tt>height</tt> its dimensions.
+     * The parameter <tt>content</tt> determines the contents of the qr code. The parameters <tt>width</tt> and
+     * <tt>height</tt> determine its dimensions.
      * </p>
      *
      * @param ctx the current request

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -41,12 +41,12 @@ public class BarcodeController extends BasicController {
      * The parameter <tt>content</tt> determines the contents of the qr code. The parameters <tt>width</tt> and
      * <tt>height</tt> determine its dimensions.
      *
-     * @param ctx the current request
+     * @param webContext the current request
      * @throws Exception in case an error occurred when generating the qr code
      */
     @Routed(value = "/qr", priority = 999)
-    public void qr(WebContext ctx) throws Exception {
-        barcode(ctx, BarcodeFormat.QR_CODE);
+    public void qr(WebContext webContext) throws Exception {
+        barcode(webContext, BarcodeFormat.QR_CODE);
     }
 
     /**
@@ -68,12 +68,13 @@ public class BarcodeController extends BasicController {
         int height = webContext.getFirstFilled("h", "height").asInt(200);
         String content = webContext.getFirstFilled("c", "content").asString();
         if (Strings.isEmpty(content)) {
-            webContext.respondWith().direct(HttpResponseStatus.BAD_REQUEST, "Usage: /barcode?type=qr&content=...&w=200&h=200");
+            webContext.respondWith()
+                      .direct(HttpResponseStatus.BAD_REQUEST, "Usage: /barcode?type=qr&content=...&w=200&h=200");
             return;
         }
 
         // Adjust the barcode format, if "type=ean" was submitted with the request and a GTIN-14 was given
-        if(BarcodeFormat.EAN_13 == format && content.length() == 14) {
+        if (BarcodeFormat.EAN_13 == format && content.length() == 14) {
             format = BarcodeFormat.ITF;
         }
 
@@ -81,9 +82,9 @@ public class BarcodeController extends BasicController {
         Writer writer = determineWriter(format);
         BitMatrix matrix = writer.encode(content, format, width, height);
         try (OutputStream out = webContext.respondWith()
-                                   .infinitelyCached()
-                                   .outputStream(HttpResponseStatus.OK,
-                                                 MimeHelper.guessMimeType("barcode." + fileType))) {
+                                          .infinitelyCached()
+                                          .outputStream(HttpResponseStatus.OK,
+                                                        MimeHelper.guessMimeType("barcode." + fileType))) {
             MatrixToImageWriter.writeToStream(matrix, fileType, out);
         }
     }

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -89,7 +89,7 @@ public class BarcodeController extends BasicController {
     }
 
     /**
-     * Gets an image of a barcode
+     * Generates an image of a barcode
      *
      * @param type    the desired barcode type
      * @param content the content of the barcode
@@ -98,7 +98,8 @@ public class BarcodeController extends BasicController {
      * @return a barcode of the given data as an image
      * @throws WriterException if generating the image fails
      */
-    public static Image getBarcodeImage(String type, String content, int width, int height) throws WriterException {
+    public static Image generateBarcodeImage(String type, String content, int width, int height)
+            throws WriterException {
         BarcodeFormat format = determineFormat(type);
 
         format = useItfFormatForGtin14(content, format);

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -16,6 +16,7 @@ import com.google.zxing.common.BitMatrix;
 import com.google.zxing.datamatrix.DataMatrixWriter;
 import com.google.zxing.oned.Code128Writer;
 import com.google.zxing.oned.EAN13Writer;
+import com.google.zxing.oned.ITFWriter;
 import com.google.zxing.qrcode.QRCodeWriter;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.kernel.commons.Strings;
@@ -79,9 +80,10 @@ public class BarcodeController extends BasicController {
             case "qr" -> BarcodeFormat.QR_CODE;
             case "code128" -> BarcodeFormat.CODE_128;
             case "ean" -> BarcodeFormat.EAN_13;
+            case "itf" -> BarcodeFormat.ITF;
             case "datamatrix" -> BarcodeFormat.DATA_MATRIX;
             default -> throw new IllegalArgumentException(
-                    "Unsupported barcode type. Supported types are: qr, code128, ean, datamatrix");
+                    "Unsupported barcode type. Supported types are: qr, code128, ean, itf, datamatrix");
         };
     }
 
@@ -90,6 +92,7 @@ public class BarcodeController extends BasicController {
             case QR_CODE -> new QRCodeWriter();
             case CODE_128 -> new Code128Writer();
             case EAN_13 -> new EAN13Writer();
+            case ITF -> new ITFWriter();
             case DATA_MATRIX -> new DataMatrixWriter();
             default -> throw new IllegalArgumentException("Unsupported barcode type!");
         };

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -69,16 +69,8 @@ public class BarcodeController extends BasicController {
         int width = webContext.getFirstFilled("w", "width").asInt(200);
         int height = webContext.getFirstFilled("h", "height").asInt(200);
         String content = webContext.getFirstFilled("c", "content").asString();
-        if (Strings.isEmpty(content)) {
-            webContext.respondWith()
-                      .direct(HttpResponseStatus.BAD_REQUEST, "Usage: /barcode?type=qr&content=...&w=200&h=200");
-            return;
-        }
 
-        // Adjust the barcode format, if "type=ean" was submitted with the request and a GTIN-14 was given
-        if (BarcodeFormat.EAN_13 == format && content.length() == 14) {
-            format = BarcodeFormat.ITF;
-        }
+        format = validateContentAndFormat(content, format, webContext);
 
         String fileType = webContext.getFirstFilled("fileType").asString("jpg");
         Writer writer = determineWriter(format);
@@ -103,10 +95,8 @@ public class BarcodeController extends BasicController {
      */
     public static Image getBarcodeImage(String type, String content, int width, int height) throws WriterException {
         BarcodeFormat format = determineFormat(type);
-        // Adjust the barcode format, if "type=ean" was submitted with the request and a GTIN-14 was given
-        if (BarcodeFormat.EAN_13 == format && content.length() == 14) {
-            format = BarcodeFormat.ITF;
-        }
+
+        format = validateContentAndFormat(content, format, null);
 
         Writer writer = determineWriter(format);
         BitMatrix matrix = writer.encode(content, format, width != -1 ? width : 200, height != -1 ? height : 200);
@@ -134,5 +124,19 @@ public class BarcodeController extends BasicController {
             case DATA_MATRIX -> new DataMatrixWriter();
             default -> throw new IllegalArgumentException("Unsupported barcode type!");
         };
+    }
+
+    private static BarcodeFormat validateContentAndFormat(String content, BarcodeFormat format, WebContext webContext) {
+        if (Strings.isEmpty(content) && webContext != null) {
+            webContext.respondWith()
+                      .direct(HttpResponseStatus.BAD_REQUEST, "Usage: /barcode?type=qr&content=...&w=200&h=200");
+        }
+
+        // Adjust the barcode format, if "type=ean" was submitted with the request and a GTIN-14 was given
+        if (BarcodeFormat.EAN_13 == format && content.length() == 14) {
+            return BarcodeFormat.ITF;
+        }
+
+        return format;
     }
 }

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -40,7 +40,6 @@ public class BarcodeController extends BasicController {
      * <p>
      * The parameter <tt>content</tt> determines the contents of the qr code. The parameters <tt>width</tt> and
      * <tt>height</tt> determine its dimensions.
-     * </p>
      *
      * @param ctx the current request
      * @throws Exception in case an error occurred when generating the qr code
@@ -55,7 +54,6 @@ public class BarcodeController extends BasicController {
      * <p>
      * The parameter <tt>content</tt> determines the contents of the barcode. The parameters <tt>width</tt> and
      * <tt>height</tt> determine its dimensions.
-     * </p>
      *
      * @param webContext the current request
      * @throws Exception in case an error occurred when generating the barcode

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -20,6 +20,7 @@ import com.google.zxing.oned.ITFWriter;
 import com.google.zxing.qrcode.QRCodeWriter;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
 import sirius.web.controller.BasicController;
 import sirius.web.controller.Routed;
@@ -113,7 +114,7 @@ public class BarcodeController extends BasicController {
     }
 
     private static BarcodeFormat determineFormat(String format) {
-        return switch (format) {
+        return switch (Value.of(format).toLowerCase()) {
             case "qr" -> BarcodeFormat.QR_CODE;
             case "code128" -> BarcodeFormat.CODE_128;
             case "ean" -> BarcodeFormat.EAN_13;

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -88,7 +88,7 @@ public class BarcodeController extends BasicController {
             return;
         }
 
-        content = alignContentForItfFormat(content, format.name());
+        content = alignContentForItfFormat(content, webContext.get("type").asString());
 
         format = useItfFormatForGtin14(content, format);
 

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -64,6 +64,11 @@ public class BarcodeController extends BasicController {
             return;
         }
 
+        // Adjust the barcode format, if "type=ean" was submitted with the request and a GTIN-14 was given
+        if(BarcodeFormat.EAN_13 == format && content.length() == 14) {
+            format = BarcodeFormat.ITF;
+        }
+
         String fileType = webContext.getFirstFilled("fileType").asString("jpg");
         Writer writer = determineWriter(format);
         BitMatrix matrix = writer.encode(content, format, width, height);


### PR DESCRIPTION
This is commonly used to create barcodes for GTINs with 14 digits used for certain types of packaging (see https://en.wikipedia.org/wiki/ITF-14).

`BarcodePdfReplaceHandler` and `BarcodeController` now both use `zxing` to generate barcodes (except for `interleaved2of5checksummed` in PDF templates, which remains unchanged).

**NOTE:** `BarcodePdfReplaceHandler` did generate barcodes for such GTINs, but they were unreliable when scanning.

Example:
The previous PDF replace produced a barcode for `<img src="barcode://ean/12345678987654"/>`, that cannot be reliably resolved back to "12345678987654":
![12345678987654_old](https://user-images.githubusercontent.com/42942954/143855701-f2f7fb96-4d7e-4d88-86b1-c72ed167915c.png)

With these changes, the produced barcode looks like this and can be scanned reliably:
![12345678987654_new](https://user-images.githubusercontent.com/42942954/143855920-4f8f15a6-2c7c-447d-b637-c499a26c9905.png)


Fixes: SIRI-487