### PR TITLE
Improvs reporting for leftover raw class literals.

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/Parser.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Parser.java
@@ -627,6 +627,13 @@ public class Parser extends InputProcessor {
             }
         }
 
+        if (root instanceof RawClassLiteral) {
+            context.error(root.getPosition(),
+                          "Found an incomplete class literal '%s'. Add '.class' if you want to refer to the class object.",
+                          root.getConstantValue());
+            return new Constant(root.getPosition(), root.getConstantValue());
+        }
+
         return root;
     }
 

--- a/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/noodle/compiler/CompilerSpec.groovy
@@ -120,4 +120,14 @@ class CompilerSpec extends BaseSpecification {
         and:
         compile("Strings.join(' ', NoodleExample.INSTANCE.getRef().getTest(), 'World')").call(new SimpleEnvironment()) == "Hello World"
     }
+
+    def "incomplete class literals are detected and reported"() {
+        when:
+        def compilationContext = new CompilationContext(SourceCodeInfo.forInlineCode("part(sirius.pasta.tagliatelle.Tagliatelle).getExtensions(null)"))
+        new NoodleCompiler(compilationContext).compileScript()
+        then:
+        compilationContext.getErrors().size() == 1
+        and:
+        compilationContext.getErrors().get(0).getMessage() == "  1: 6: Found an incomplete class literal 'class sirius.pasta.tagliatelle.Tagliatelle'. Add '.class' if you want to refer to the class object."
+    }
 }


### PR DESCRIPTION
The most common case is a missing ".class" like in a @part(MyClass)
(instead of @part(MyClass.class).

We now report a proper error for this case.