### PR TITLE
Adds support for scrollable containers to the visible event listener

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -42,8 +42,6 @@ sirius.ready = function (callback) {
  * @param type the element type to search for (Note that the type is UPPERCASE like 'FORM').
  * @returns {null|*} the first matching element (nearest parent) or null if none is found
  */
-//
-// Note that the type is UPPERCASE like 'FORM'.
 sirius.findParentOfType = function (_node, type) {
     let _parent = _node.parentNode;
     while (_parent != null) {

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -194,7 +194,9 @@ sirius.addElementVisibleListener = function (selector, listener, distanceFactor)
     // Check after the page is loaded and when resizing or scrolling the page
     sirius.ready(handleVisibleElements);
     window.addEventListener('resize', sirius.throttle(handleVisibleElements, 20));
-    document.addEventListener('scroll', sirius.throttle(handleVisibleElements, 20));
+    document.addEventListener('scroll', sirius.throttle(handleVisibleElements, 20), {
+        capture: true
+    });
 
     // Listen for DOM changes that might influence the position of other elements
     const observer = new MutationObserver(sirius.throttle(handleVisibleElements, 20));


### PR DESCRIPTION
We have a scrollable table where each cell needs to trigger an event once it becomes visible. In order for this to work in scrollable containers, we need to enable capturing on the scroll event.