### PR TITLE
Fixes color code for sirius-blue-light

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/sirius-colors.scss
+++ b/src/main/resources/default/assets/tycho/styles/sirius-colors.scss
@@ -21,7 +21,7 @@ $sirius-green-light: #77D9A3;
 
 $sirius-blue: #406FC7;
 $sirius-blue-dark: #33589F;
-$sirius-blue-light: #668;
+$sirius-blue-light: #668DC6;
 
 $sirius-violet: #DB397A;
 $sirius-violet-dark: #BD2461;


### PR DESCRIPTION
Before it was more some kind of purple:
![Bildschirmfoto 2022-01-28 um 12 11 34](https://user-images.githubusercontent.com/42942954/151538122-ea98326b-fb27-4fa4-8d09-1265797c8aa2.png)

Now it's actually light blue:
![Bildschirmfoto 2022-01-28 um 12 25 50](https://user-images.githubusercontent.com/42942954/151539033-3701385d-d84f-4003-a91b-34b621fe5ab6.png)


The color now matches the borders from sirius-search (e.g. https://github.com/scireum/sirius-search/blob/f6dbb2a83481f82dab6e9d110667d7ee1c64d5b7/src/main/resources/assets/es-head/src/app/ui/menuPanel/menuPanel.css#L2).