### PR TITLE
Makes JSONStructuredOutput create jsons without objects on root level

### DIFF
--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -218,13 +218,13 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
 
     @Override
     public void writeProperty(String name, Object data) {
-        if (data instanceof JSONObject) {
+        if (data instanceof JSONObject jsonObject) {
             beginObject(name);
-            ((JSONObject) data).forEach(this::property);
+            jsonObject.forEach(this::property);
             endObject();
-        } else if (data instanceof JSONArray) {
+        } else if (data instanceof JSONArray jsonArray) {
             beginArray(name);
-            ((JSONArray) data).forEach(element -> property("", element));
+            jsonArray.forEach(element -> property("", element));
             endArray();
         } else {
             writePlainProperty(name, data);

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -272,6 +272,11 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
         finalizeOutput();
     }
 
+    /**
+     * Finalizes the output and closes the stream.
+     * <p>
+     * In constrast to {@link #endResult()} this does not require an open result object.
+     */
     public void finalizeOutput() {
         try {
             super.endResult();

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -268,8 +268,12 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
 
     @Override
     public void endResult() {
+        endObject();
+        finalizeOutput();
+    }
+
+    public void finalizeOutput() {
         try {
-            endObject();
             super.endResult();
             if (Strings.isFilled(callback)) {
                 writer.write(")");

--- a/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
+++ b/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
@@ -1,0 +1,32 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.service;
+
+import org.junit.jupiter.api.Test;
+import sirius.web.services.JSONStructuredOutput;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONStructuredOutputTest {
+
+    @Test
+    public void writeEmptyArray() {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, null, StandardCharsets.UTF_8.name());
+
+        out.beginArray("");
+        out.endArray();
+        out.finalizeOutput();
+
+        assertEquals("[]", byteArrayOutputStream.toString());
+    }
+}


### PR DESCRIPTION
- previous endResult required an open object
- now e.g. [{}] can be created