### PR TITLE
Removes a broadly applied style and replaces it with a more local limit.

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/page.scss
+++ b/src/main/resources/default/assets/tycho/styles/page.scss
@@ -10,17 +10,6 @@ body {
   background-color: $backgroundGray;
 }
 
-/* Makes flex items behavior more smooth by supplying them with a default min-width / min-height.
-   This prevents them from overflowing the flex container by giving them a baseline to shrink.
- */
-.d-flex, .d-inline-flex, .card {
-  & > * {
-    min-width: 0;
-    min-height: 0;
-  }
-}
-
-
 #wrapper {
   display: grid;
   height: 100vh;
@@ -30,7 +19,6 @@ body {
     min-width: 0;
   }
 }
-
 
 nav.navbar {
   z-index: 1000;

--- a/src/main/resources/default/assets/tycho/styles/typeface.scss
+++ b/src/main/resources/default/assets/tycho/styles/typeface.scss
@@ -10,6 +10,10 @@
   white-space: pre-line;
 }
 
+.text-ellipsis {
+  text-overflow: ellipsis;
+}
+
 .text-black-75 {
   color: rgba(33, 37, 41, 0.75) !important;
 }

--- a/src/main/resources/default/taglib/t/datacard.html.pasta
+++ b/src/main/resources/default/taglib/t/datacard.html.pasta
@@ -24,11 +24,11 @@
                 <div class="card-body">
                     <div class="d-flex justify-content-between">
                         <i:if test="isFilled(title)">
-                            <h5 class="card-title @titleClass">@title</h5>
+                            <h5 class="card-title overflow-hidden text-ellipsis @titleClass">@title</h5>
                             <i:else>
                                 <i:local name="markupTitle" value="@renderToString('title')"/>
                                 <i:if test="isFilled(markupTitle)">
-                                    <h5 class="card-title">
+                                    <h5 class="card-title overflow-hidden text-ellipsis">
                                         <i:raw>@markupTitle</i:raw>
                                     </h5>
                                 </i:if>


### PR DESCRIPTION
The previous change was also intended to limit the card title, however,
it screwed up icons etc. by applying a min-width on almost any element
within a card.

We now provide a proper overflow to limit the title width.
(Previous ticket: SIRI-470)

Fixes: OX-8388