### PR TITLE
Records and outputs contention blocks.

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -1587,6 +1587,10 @@ public class Response {
             ChannelFuture future = ctx.writeAndFlush(message);
             while (!ctx.channel().isWritable() && ctx.channel().isOpen()) {
                 try {
+                    if (WebServer.channelContentions.incrementAndGet() < 0) {
+                        WebServer.channelContentions.set(0);
+                    }
+
                     future.await(5, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     ctx.channel().close();

--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -167,10 +167,12 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
      * Indicates that netty itself will compute the optimal number of threads in the event loop
      */
     private static final int AUTOSELECT_EVENT_LOOP_SIZE = 0;
+
     private EventLoopGroup eventLoop;
 
     protected static AtomicLong bytesIn = new AtomicLong();
     protected static AtomicLong bytesOut = new AtomicLong();
+    protected static AtomicLong channelContentions = new AtomicLong();
     protected static AtomicLong messagesIn = new AtomicLong();
     protected static AtomicLong messagesOut = new AtomicLong();
     protected static AtomicLong connections = new AtomicLong();
@@ -758,6 +760,11 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
                                      "HTTP Bytes-Out",
                                      bytesOut.get() / 1024d / 60,
                                      "KB/s");
+        collector.differentialMetric("http_contention_blocks",
+                                     "http-contention-blocks",
+                                     "HTTP ConentionBlocks",
+                                     channelContentions.get(),
+                                     "/min");
         collector.differentialMetric("http_connects", "http-connects", "HTTP Connects", connections.get(), "/min");
         collector.differentialMetric("http_requests", "http-requests", "HTTP Requests", requests.get(), "/min");
         collector.differentialMetric("http_slow_requests",
@@ -788,7 +795,7 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
                          null);
         collector.metric("http_response_time",
                          "http-response-time",
-                         "HTTP Avg. Reponse Time",
+                         "HTTP Avg. Response Time",
                          responseTime.getAndClear(),
                          "ms");
         collector.metric("http_response_ttfb",

--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -762,7 +762,7 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
                                      "KB/s");
         collector.differentialMetric("http_contention_blocks",
                                      "http-contention-blocks",
-                                     "HTTP ConentionBlocks",
+                                     "HTTP Connection Blocks",
                                      channelContentions.get(),
                                      "/min");
         collector.differentialMetric("http_connects", "http-connects", "HTTP Connects", connections.get(), "/min");

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -350,6 +350,11 @@ health {
         http-bytes-out.warning = 0
         http-bytes-out.error = 0
 
+        # Outgoing Contention Blocks
+        http-contention-blocks.gray = 0
+        http-contention-blocks.warning = 0
+        http-contention-blocks.error = 0
+
         # HTTP Connections opened
         http-connects.gray = 100
         http-connects.warning = 0


### PR DESCRIPTION
If a channel is not writeable, we actually block and await for it to
become writable. As we figured, this might slow down tunneling in
high load conditions, we added some loggings to check if there is a
correlations.