### PR TITLE
Allows accessing the value of a specific response header

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -664,6 +664,19 @@ public class Response {
     }
 
     /**
+     * Returns the value of a header with the specified name. If there are
+     * more than one values for the specified name, the first value is returned.
+     *
+     * @param name The name of the header to search
+     * @return The first header value or {@code null} if there is no such header
+     * @see io.netty.handler.codec.http.HttpHeaders#get(java.lang.CharSequence)
+     */
+    @Nullable
+    public String getHeader(CharSequence name) {
+        return headers().get(name);
+    }
+
+    /**
      * Sets the specified header.
      *
      * @param name  name of the header

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -200,7 +200,7 @@ public class TunnelHandler implements AsyncHandler<String> {
      * Overrides the {@link HttpHeaderNames#CONTENT_TYPE} header if the current value is not clearly specified.
      */
     private void overrideContentTypeIfNecessary() {
-        String currentType = response.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        String currentType = response.getHeader(HttpHeaderNames.CONTENT_TYPE);
 
         if (Strings.isEmpty(currentType) || MimeHelper.APPLICATION_OCTET_STREAM.equals(currentType)) {
             response.setHeader(HttpHeaderNames.CONTENT_TYPE,


### PR DESCRIPTION
...while avoiding changing the visibility of `headers()` from `protected` to `public`.

Fixes: OX-8364