### PR TITLE
Consistently throws InterruptedIOException when input is closed

### DIFF
--- a/src/main/java/sirius/web/http/InputStreamHandler.java
+++ b/src/main/java/sirius/web/http/InputStreamHandler.java
@@ -339,7 +339,7 @@ public class InputStreamHandler extends InputStream implements ContentHandler {
                 //While we were waiting for the net buffer, the input side was closed - signal to reader...
                 error = true;
                 release();
-                throw new IOException(
+                throw new InterruptedIOException(
                         "An error occurred while waiting for upcoming data. Terminating due to possibly inconsistent data!");
             }
             if (currentBuffer.readableBytes() == 0) {


### PR DESCRIPTION
Fixes: SIRI-562