### PR TITLE
Prevents long iconInlineInfo values from breaking out of cards

### DIFF
--- a/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
+++ b/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
@@ -12,7 +12,7 @@
         <span class="text-sirius-gray-dark ">
             <i class="@icon"></i>
         </span>
-        <span class="pl-1 overflow-hidden">
+        <span class="pl-1 overflow-hidden text-break">
             <i:if test="isFilled(value)">
                 @value
                 <i:else>


### PR DESCRIPTION
The iconInlineInfo component is most of the time used inside of cards to show various information about the entity the card is about.
Having long text (like a url or filename) without easy ways for CSS to determine where to wrap the text meant those could easily break out of the card body.
We now tell CSS it can break the value wherever necessary.

## Before
![image](https://user-images.githubusercontent.com/2427877/166690952-3c37779a-26b7-41b6-a22f-7f1c071dc975.png)

## After
![image](https://user-images.githubusercontent.com/2427877/166690876-eafadb6d-e008-4fdd-b116-853dac6478ce.png)

Fixes: OX-8531