### PR TITLE
SAML: Namespaces Fix (OX-8635)

### DIFF
--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -79,6 +79,8 @@ public class SAMLHelper {
      */
     public static final int MAX_TIMESTAMP_DELTA_IN_HOURS = 3;
 
+    private static final String SAML_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:assertion";
+
     /**
      * Generates a base64 encoded XML request which can be POSTed to a SAML 2 identity provider.
      *
@@ -165,7 +167,7 @@ public class SAMLHelper {
         try {
             Document doc = getResponseDocument(input);
 
-            Element assertion = selectSingleElement(doc, null, "Assertion");
+            Element assertion = selectSingleElement(doc, SAML_NAMESPACE, "Assertion");
             if (checkTime) {
                 verifyTimestamp(assertion);
             }

--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -99,7 +99,7 @@ public class SAMLHelper {
         XMLStructuredOutput out = new XMLStructuredOutput(buffer);
         out.beginOutput("samlp:AuthnRequest",
                         Attribute.set("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol"),
-                        Attribute.set("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion"),
+                        Attribute.set("xmlns:saml", SAML_NAMESPACE),
                         Attribute.set("ID", "identifier_" + System.currentTimeMillis()),
                         Attribute.set("Version", "2.0"),
                         Attribute.set("IssueInstant",

--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -218,7 +218,7 @@ public class SAMLHelper {
     private void verifyTimestamp(Element assertion) {
         String issueInstant = assertion.getAttribute("IssueInstant");
         Instant parsedIssueInstant = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(issueInstant));
-        if (Duration.between(Instant.now(), parsedIssueInstant).toHours() > MAX_TIMESTAMP_DELTA_IN_HOURS) {
+        if (Duration.between(parsedIssueInstant, Instant.now()).toHours() >= MAX_TIMESTAMP_DELTA_IN_HOURS) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage("Invalid SAML Response: Invalid IssueInstant: %s", issueInstant)
                             .handle();

--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -81,6 +81,8 @@ public class SAMLHelper {
 
     private static final String SAML_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:assertion";
 
+    private static final String SAMLP_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:protocol";
+
     /**
      * Generates a base64 encoded XML request which can be POSTed to a SAML 2 identity provider.
      *
@@ -98,7 +100,7 @@ public class SAMLHelper {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         XMLStructuredOutput out = new XMLStructuredOutput(buffer);
         out.beginOutput("samlp:AuthnRequest",
-                        Attribute.set("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol"),
+                        Attribute.set("xmlns:samlp", SAMLP_NAMESPACE),
                         Attribute.set("xmlns:saml", SAML_NAMESPACE),
                         Attribute.set("ID", "identifier_" + System.currentTimeMillis()),
                         Attribute.set("Version", "2.0"),

--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -159,7 +159,7 @@ public class SAMLHelper {
      * Note that the fingerprint <b>must</b> be verified in some way or another, as this method only checks if
      * the signature is valid, not <b>who</b> created it.
      *
-     * @param input a stream containing the SAML XML response to parse
+     * @param input     a stream containing the SAML XML response to parse
      * @param checkTime a flag indicating whether to check for expired timestamps
      * @return the parsed response which has been verified
      */
@@ -195,7 +195,7 @@ public class SAMLHelper {
      * @param namespace the optional namespace URI
      * @param nodeName  the name of the node
      * @return the element with the given name
-     * @throws HandledException if there are zero or more thant one nodes found
+     * @throws HandledException if there are either no or multiple nodes of the given name
      */
     private Element selectSingleElement(Document doc, @Nullable String namespace, String nodeName) {
         NodeList nl = Strings.isFilled(namespace) ?


### PR DESCRIPTION
> https://scireum.myjetbrains.com/youtrack/issue/OX-8635

- Fixes namespace support (enabling third-party SAML Authentication Servers – provided they can be convinced to us a hashing algorithm other than SHA1)
- Fixes time check
- Prepares interface for unit testing

**A unit test will be added once anonymised data is available.**