### PR TITLE
Improves detection of hazardous header combinations.

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -399,11 +399,6 @@ public class WebContext implements SubContext {
     private static CSRFHelper csrfHelper;
 
     /**
-     * Date format used by HTTP date headers
-     */
-    public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
-
-    /**
      * Provides access to the underlying ChannelHandlerContext
      *
      * @return the underlying channel handler context
@@ -1475,7 +1470,7 @@ public class WebContext implements SubContext {
     /**
      * Determines if a response was already committed.
      * <p>
-     * If a response is committed a HTTP state and some headers have already been sent. Therefore a new / other
+     * If a response is committed a HTTP state and some headers have already been sent. Therefore, a new / other
      * response
      * cannot be created to this request.
      *
@@ -1518,14 +1513,16 @@ public class WebContext implements SubContext {
      *
      * @param header the name of the header to fetch
      * @return the value in milliseconds of the submitted date or 0 if the header was not present.
+     * @deprecated Use {@link WebServer#parseDateHeader(String)} instead.
      */
+    @Deprecated
     public long getDateHeader(CharSequence header) {
         String value = request.headers().get(header);
         if (Strings.isEmpty(value)) {
             return 0;
         }
         try {
-            SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+            SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
             return dateFormatter.parse(value).getTime();
         } catch (ParseException e) {
             Exceptions.ignore(e);

--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -45,13 +45,18 @@ import sirius.kernel.health.metrics.MetricProvider;
 import sirius.kernel.health.metrics.MetricsCollector;
 import sirius.kernel.timer.EveryTenSeconds;
 
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -306,6 +311,27 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
                     e.getMessage(),
                     e.getClass().getName()));
             return ip;
+        }
+    }
+
+    /**
+     * Parses a HTTP header string into a LocalDateTime.
+     * <p>
+     * The timestamp is expected to match the RFC 1123 format, as defined by the HTTP standard.
+     *
+     * @param httpDateHeader the header value to parse
+     * @return the timestamp wrapped as optional or an empty optional if an empty or malformed string was given
+     */
+    public static Optional<LocalDateTime> parseDateHeader(@Nullable String httpDateHeader) {
+        if (Strings.isEmpty(httpDateHeader)) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(LocalDateTime.parse(httpDateHeader, DateTimeFormatter.RFC_1123_DATE_TIME));
+        } catch (DateTimeParseException e) {
+            Exceptions.ignore(e);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
This hopefully reduces the size of WebContext and Response a bit
(which are too large anyway). Also it gets rid of uses of Calendar
and Date while providing a generic helper for parsing HTTP dates
(RFC 1123)

Also:
We observed horrible behavior of downstream proxies if both, set-cookie
and Cache-Control/Expires headers (which instruct a proxy to cache the
response) are present. As per HTTP a response containing a set-cookie
header must never be publicly cached, however, some did.

We therefore built a detection to recognize and warn about hazardous
header combination. However, this check was too harsh and warned about
some "safe" scenarios.