### PR TITLE
BREAKING: Aligns behaviour of postJSON with the one of replaced jQuery AJAX

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -135,7 +135,7 @@ sirius.getJSON = function (url, params) {
  * Calls the given URL, posts the given params and retrieves the resulting JSON.
  *
  * @param url the URL to invoke
- * @param params the parameters to send POST data
+ * @param params the parameters to send POST data (parameters with 'undefined' values are not send to the server)
  * @returns {Promise<any>} the received JSON data
  */
 sirius.postJSON = function (url, params) {

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -142,7 +142,11 @@ sirius.postJSON = function (url, params) {
     let formData = new FormData();
     Object.keys(params).forEach(function (key) {
         const value = params[key];
-        if (typeof value !== 'undefined') {
+        if (Array.isArray(value)) {
+            value.forEach(function (entry) {
+                formData.append(key, entry);
+            });
+        } else if (typeof value !== 'undefined') {
             formData.append(key, value);
         }
     });

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -135,7 +135,7 @@ sirius.getJSON = function (url, params) {
  * Calls the given URL, posts the given params and retrieves the resulting JSON.
  *
  * @param url the URL to invoke
- * @param params the parameters to send POST data (parameters with 'undefined' values are not send to the server)
+ * @param params the parameters to send POST data (parameters with 'undefined' values are not sent to the server)
  * @returns {Promise<any>} the received JSON data
  */
 sirius.postJSON = function (url, params) {

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -141,7 +141,10 @@ sirius.getJSON = function (url, params) {
 sirius.postJSON = function (url, params) {
     let formData = new FormData();
     Object.keys(params).forEach(function (key) {
-        formData.append(key, params[key]);
+        const value = params[key];
+        if (typeof value !== 'undefined') {
+            formData.append(key, value);
+        }
     });
 
     return fetch(url, {


### PR DESCRIPTION
**BREAKING CHANGE:** This is potentially breaking when existing calls to `postJSON` are made with `undefined` parameters that are expected to be passed on the server-side.
But current calls to `postJSON` in our projects don't seem to pass empty parameters.

This is quite useful when building complex request payloads as no extensive filtering has to occur outside of the postJSON call.

Fixes: OX-8650