### PR TITLE
Permits to perform automatic contention control when providing Respon…

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -1580,7 +1580,7 @@ public class Response {
      * @param contentType the content type to use. If <tt>null</tt>, we rely on a previously set header.
      * @return an output stream which will be sent as response
      */
-    public OutputStream outputStream(final HttpResponseStatus status, @Nullable final String contentType) {
+    public ChunkedOutputStream outputStream(HttpResponseStatus status, @Nullable String contentType) {
         if (wc.responseCommitted) {
             throw Exceptions.createHandled()
                             .withSystemErrorMessage("Response for %s was already committed!", wc.getRequestedURI())


### PR DESCRIPTION
…se.outputStream.

This essentially blocks if the outgoing data cannot be written/flushed into the channel.