### PR TITLE
Continuity: Allows to automatic disable the generation of deep-links entirely

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -5,6 +5,7 @@ window.sirius.Continuity = (function () {
      * @param {Object} [options] map specifying the behaviour of the library:
      * @param {string} options.stateParameterName Defines the parameter name the history state is written to in the deeplink URL.
      * @param {boolean} [options.debug] Allows to enable the printing of debugging messages to the console right from the start.
+     * @param {boolean} [options.disableAutoDeepLinks] Allows to disable the automatic generation and update of deep-links via the state parameter.
      * @param {function} [options.initialStateHook] Called during the parsing of the initial deep-linked state. Can be used to create intermediate states the user can navigate back to.
      * @param {Object} options.entryTypes Defines the list of known entry types that should be handled (state handlers can be registered later).
      * @param {boolean} [options.entryTypes.excludeFromParameter] Allows to exclude the information of a state entry type from the generated deep-link URL (to just keep it in the JS history).
@@ -295,6 +296,10 @@ window.sirius.Continuity = (function () {
      * @param {URLSearchParams} [searchParams] the URL parameters to include (or the ones stored in the lib scope when omitted)
      */
     Continuity.prototype.buildUrl = function (searchParams) {
+        if (this.options.disableAutoDeepLinks) {
+            return undefined;
+        }
+
         const effectiveSearchParams = searchParams || this.searchParams;
         let url = this.path + '?' + effectiveSearchParams;
         if (window.location.hash) {


### PR DESCRIPTION
The new startup parameter allows to disable the automatic alteration of the current URL via the state parameter to generate deep-links. This is mainly useful for pages where deep-links are already generated by other means.

Fixes: OX-8795