### PR TITLE
Overlay: Allows to detect an overlay actively being closed by the user

### DIFF
--- a/src/main/resources/default/assets/common/scripts/overlay.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/overlay.js.pasta
@@ -73,6 +73,7 @@
 
         if (closable) {
             _overlay.querySelector('.sci-overlay-button-close-js').addEventListener('click', function () {
+                sirius.dispatchEvent('sci-overlay-dismissed');
                 overlay.destroyOverlay();
             });
         }
@@ -80,6 +81,7 @@
         if (yieldable) {
             _overlay.addEventListener('click', function (event) {
                 if (event.target === _overlay) {
+                    sirius.dispatchEvent('sci-overlay-dismissed');
                     overlay.destroyOverlay();
                 }
             });
@@ -134,6 +136,7 @@
 
     const destroyOverlayEventHandler = function (event) {
         if (event.key === 'Escape' && (shouldEscClose == null || shouldEscClose())) {
+            sirius.dispatchEvent('sci-overlay-dismissed');
             overlay.destroyOverlay();
         }
     }


### PR DESCRIPTION
We trigger the `sci-overlay-destroyed` in the following scenarios:
- Overlay closed via x button
- Overlay closed via background click
- Overlay closed via ESC key
- Overlay closed as new one was opened

The last one of these is the only one that is not triggered by the user actively trying to close the overlay but can also occur when the currently open overlay triggers a new overlay that replaces the old one.

To differentiate these we now trigger a new event `sci-overlay-dismissed` in those 3 cases where the user tries to close the overlay.

Fixes: OX-8917