### PR TITLE
Trimming of Parsed HTML Templates (SIRI-618)

### DIFF
--- a/src/main/java/sirius/pasta/tagliatelle/Template.java
+++ b/src/main/java/sirius/pasta/tagliatelle/Template.java
@@ -182,12 +182,23 @@ public class Template {
         renderWithContext(context);
     }
 
+    /**
+     * Checks whether the template is supposed to have an XML-like structure, based on the extension of the
+     * {@linkplain #getEffectiveFileName() effective file name}.
+     * <p>
+     * This is obviously the case for HTML and XML files. We also treat PDF templates as such, though, as we use
+     * <i>flying saucer</i> to generate PDFs — which internally renders HTML as well.
+     *
+     * @return <b>true</b> if the template's content is expected to have an XML-like structure, <b>false</b> else
+     */
+    public boolean isXmlContentExpected() {
+        String effectiveFileName = getEffectiveFileName();
+        return effectiveFileName.endsWith(".html") || effectiveFileName.endsWith(".xml") || effectiveFileName.endsWith(
+                ".pdf");
+    }
+
     private void setupEscaper(GlobalRenderContext ctx) {
-        // For XML and HTML we obviously use an XML escaper. As we use flying saucer to generate PDFs
-        // which internally renders HTML, we also enable the escaper there.
-        if (getEffectiveFileName().endsWith(".html")
-            || getEffectiveFileName().endsWith(".xml")
-            || getEffectiveFileName().endsWith(".pdf")) {
+        if (isXmlContentExpected()) {
             ctx.setEscaper(GlobalRenderContext::escapeXML);
         }
     }

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -253,14 +253,11 @@ public class TemplateCompiler extends InputProcessor {
      * <p>
      * If the tag is built-in (<tt>i:</tt>) or one in a taglib, an appropriate {@link TagHandler} is created and
      * invoked. Otherwise, the tag is parsed as static text.
-     * <p>
-     * Note that the return value indicates whether an emitter was created, thus indicating the need to create a new
-     * {@link ConstantEmitter}.
      *
      * @param parentHandler the outer tag handler
      * @param block         the block to which the tag should be added
      * @param staticText    the emitter which is responsible for consuming static text
-     * @return <b>true</b> if an {@link Emitter} was generated, <b>false</b> otherwise
+     * @return <b>true</b> if the tag was handled, <b>false</b> else
      */
     private boolean processTag(TagHandler parentHandler, CompositeEmitter block, ConstantEmitter staticText) {
         if (!reader.current().is('<')) {

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -28,6 +28,7 @@ import sirius.pasta.noodle.compiler.NoodleCompiler;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 import sirius.pasta.tagliatelle.emitter.ConstantEmitter;
 import sirius.pasta.tagliatelle.emitter.Emitter;
+import sirius.pasta.tagliatelle.tags.ArgTag;
 import sirius.pasta.tagliatelle.tags.TagHandler;
 import sirius.web.services.JSONStructuredOutput;
 
@@ -238,13 +239,16 @@ public class TemplateCompiler extends InputProcessor {
     /**
      * Processes a tag.
      * <p>
-     * If the tag is built-in (i:) or a one in a taglib, an appropriate {@link TagHandler} is created and invoked.
-     * Otherwise the tag is parsed as static text.
+     * If the tag is built-in (<tt>i:</tt>) or one in a taglib, an appropriate {@link TagHandler} is created and
+     * invoked. Otherwise, the tag is parsed as static text.
+     * <p>
+     * Note that the return value indicates whether an emitter was created, thus indicating the need to create a new
+     * {@link ConstantEmitter}.
      *
      * @param parentHandler the outer tag handler
      * @param block         the block to which the tag should be added
      * @param staticText    the emitter which is responsible for consuming static text
-     * @return <tt>true</tt> if the tag was handled, <tt>false</tt> otherwise
+     * @return <b>true</b> if an {@link Emitter} was generated, <b>false</b> otherwise
      */
     private boolean processTag(TagHandler parentHandler, CompositeEmitter block, ConstantEmitter staticText) {
         if (!reader.current().is('<')) {
@@ -261,7 +265,7 @@ public class TemplateCompiler extends InputProcessor {
                 handler.setCompilationContext(getContext());
                 handler.setTagName(tagName);
                 handleTag(handler, block);
-                return true;
+                return !(handler instanceof ArgTag);
             }
 
             staticText.append("<");

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -79,7 +79,16 @@ public class TemplateCompiler extends InputProcessor {
         }
 
         try {
-            Emitter emitter = parseBlock(null, null).reduce();
+            // identify content type via file extension, as is done in Template.setupEscaper(GlobalRenderContext), in
+            // order to decide whether to trim whitespace after parsing
+            String effectiveFileName = getContext().getTemplate().getEffectiveFileName();
+            boolean trimWhitespace = effectiveFileName.endsWith(".html") || effectiveFileName.endsWith(".xml");
+
+            CompositeEmitter compositeEmitter = parseBlock(null, null);
+            if (trimWhitespace) {
+                compositeEmitter.stripWhitespace();
+            }
+            Emitter emitter = compositeEmitter.reduce();
             getContext().getTemplate().setEmitter(emitter);
         } catch (Exception e) {
             context.error(Position.UNKNOWN, Exceptions.handle(e).getMessage());

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -79,13 +79,8 @@ public class TemplateCompiler extends InputProcessor {
         }
 
         try {
-            // identify content type via file extension, as is done in Template.setupEscaper(GlobalRenderContext), in
-            // order to decide whether to trim whitespace after parsing
-            String effectiveFileName = getContext().getTemplate().getEffectiveFileName();
-            boolean trimWhitespace = effectiveFileName.endsWith(".html") || effectiveFileName.endsWith(".xml");
-
             CompositeEmitter compositeEmitter = parseBlock(null, null);
-            if (trimWhitespace) {
+            if (getContext().getTemplate().isXmlContentExpected()) {
                 compositeEmitter.stripWhitespace();
             }
             Emitter emitter = compositeEmitter.reduce();

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -79,11 +79,12 @@ public class TemplateCompiler extends InputProcessor {
         }
 
         try {
-            CompositeEmitter compositeEmitter = parseBlock(null, null);
+            Emitter emitter = parseBlock(null, null);
+            emitter = emitter.reduce();
             if (getContext().getTemplate().isXmlContentExpected()) {
-                compositeEmitter.stripWhitespace();
+                emitter = stripWhitespace(emitter);
+                emitter = emitter.reduce();
             }
-            Emitter emitter = compositeEmitter.reduce();
             getContext().getTemplate().setEmitter(emitter);
         } catch (Exception e) {
             context.error(Position.UNKNOWN, Exceptions.handle(e).getMessage());
@@ -93,6 +94,18 @@ public class TemplateCompiler extends InputProcessor {
         reader = null;
 
         return context.processCollectedErrors();
+    }
+
+    private Emitter stripWhitespace(Emitter emitter) {
+        if (emitter instanceof ConstantEmitter constantEmitter) {
+            return constantEmitter.stripLeadingLineBreak().stripTrailingLineBreak();
+        }
+
+        if (emitter instanceof CompositeEmitter compositeEmitter) {
+            return compositeEmitter.stripWhitespace();
+        }
+
+        return emitter;
     }
 
     /**

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -82,7 +82,7 @@ public class TemplateCompiler extends InputProcessor {
             Emitter emitter = parseBlock(null, null);
             emitter = emitter.reduce();
             if (getContext().getTemplate().isXmlContentExpected()) {
-                emitter = stripWhitespace(emitter);
+                emitter = stripLeadingAndTrailingLineBreaks(emitter);
                 emitter = emitter.reduce();
             }
             getContext().getTemplate().setEmitter(emitter);
@@ -96,13 +96,13 @@ public class TemplateCompiler extends InputProcessor {
         return context.processCollectedErrors();
     }
 
-    private Emitter stripWhitespace(Emitter emitter) {
+    private Emitter stripLeadingAndTrailingLineBreaks(Emitter emitter) {
         if (emitter instanceof ConstantEmitter constantEmitter) {
             return constantEmitter.stripLeadingLineBreak().stripTrailingLineBreak();
         }
 
         if (emitter instanceof CompositeEmitter compositeEmitter) {
-            return compositeEmitter.stripWhitespace();
+            return compositeEmitter.stripLeadingAndTrailingLineBreaks();
         }
 
         return emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -28,7 +28,6 @@ import sirius.pasta.noodle.compiler.NoodleCompiler;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 import sirius.pasta.tagliatelle.emitter.ConstantEmitter;
 import sirius.pasta.tagliatelle.emitter.Emitter;
-import sirius.pasta.tagliatelle.tags.ArgTag;
 import sirius.pasta.tagliatelle.tags.TagHandler;
 import sirius.web.services.JSONStructuredOutput;
 
@@ -265,7 +264,7 @@ public class TemplateCompiler extends InputProcessor {
                 handler.setCompilationContext(getContext());
                 handler.setTagName(tagName);
                 handleTag(handler, block);
-                return !(handler instanceof ArgTag);
+                return true;
             }
 
             staticText.append("<");

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
@@ -64,11 +64,11 @@ public class CompositeEmitter extends Emitter {
      */
     @Override
     public Emitter reduce() {
-        List<Emitter> children = sortChildren(this.children);
+        List<Emitter> sortedChildren = sortChildren(children);
 
         CompositeEmitter result = new CompositeEmitter(startOfBlock);
         ConstantEmitter lastConstantChild = null;
-        for (Emitter child : children) {
+        for (Emitter child : sortedChildren) {
             child = child.reduce();
             if (child instanceof CompositeEmitter childComposite) {
                 for (Emitter inner : childComposite.children) {

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
@@ -145,6 +145,12 @@ public class CompositeEmitter extends Emitter {
         }
     }
 
+    /**
+     * Checks if the first and last children are {@link ConstantEmitter} instances, and trims leading or trailing line
+     * breaks, respectively.
+     *
+     * @return a convenience reference to <b><tt>this</tt></b>
+     */
     public CompositeEmitter stripLeadingAndTrailingLineBreaks() {
         if (children == null || children.isEmpty()) {
             return this;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
@@ -117,6 +117,24 @@ public class CompositeEmitter extends Emitter {
         }
     }
 
+    public CompositeEmitter stripWhitespace() {
+        if (children == null || children.isEmpty()) {
+            return this;
+        }
+
+        // trim the first child from the front
+        if (children.get(0) instanceof ConstantEmitter firstConstantEmitter) {
+            firstConstantEmitter.stripLeading();
+        }
+
+        // trim the last child from the back
+        if (children.get(children.size() - 1) instanceof ConstantEmitter lastConstantEmitter) {
+            lastConstantEmitter.stripTrailing();
+        }
+
+        return this;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
@@ -124,12 +124,12 @@ public class CompositeEmitter extends Emitter {
 
         // trim the first child from the front
         if (children.get(0) instanceof ConstantEmitter firstConstantEmitter) {
-            firstConstantEmitter.stripLeading();
+            firstConstantEmitter.stripLeadingLineBreak();
         }
 
         // trim the last child from the back
         if (children.get(children.size() - 1) instanceof ConstantEmitter lastConstantEmitter) {
-            lastConstantEmitter.stripTrailing();
+            lastConstantEmitter.stripTrailingLineBreak();
         }
 
         return this;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
@@ -145,7 +145,7 @@ public class CompositeEmitter extends Emitter {
         }
     }
 
-    public CompositeEmitter stripWhitespace() {
+    public CompositeEmitter stripLeadingAndTrailingLineBreaks() {
         if (children == null || children.isEmpty()) {
             return this;
         }

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
@@ -62,6 +62,33 @@ public class ConstantEmitter extends Emitter {
         return this;
     }
 
+    public ConstantEmitter stripLeading() {
+        if (Strings.isEmpty(value)) {
+            return this;
+        }
+
+        value = value.stripLeading();
+        return this;
+    }
+
+    public ConstantEmitter stripTrailing() {
+        if (Strings.isEmpty(value)) {
+            return this;
+        }
+
+        value = value.stripTrailing();
+        return this;
+    }
+
+    public ConstantEmitter strip() {
+        if (Strings.isEmpty(value)) {
+            return this;
+        }
+
+        value = value.strip();
+        return this;
+    }
+
     @Override
     protected void emitToContext(LocalRenderContext context) throws Exception {
         context.outputRaw(getValue());

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
@@ -62,6 +62,12 @@ public class ConstantEmitter extends Emitter {
         return this;
     }
 
+    /**
+     * Removes a single leading UNIX-style line break <tt>&lt;LF&gt;</tt> from the beginning of the block if one is
+     * found.
+     *
+     * @return a convenience reference to <b><tt>this</tt></b>
+     */
     public ConstantEmitter stripLeadingLineBreak() {
         if (Strings.isEmpty(value)) {
             return this;
@@ -74,6 +80,11 @@ public class ConstantEmitter extends Emitter {
         return this;
     }
 
+    /**
+     * Removes a single trailing UNIX-style line break <tt>&lt;LF&gt;</tt> from the end of the block if one is found.
+     *
+     * @return a convenience reference to <b><tt>this</tt></b>
+     */
     public ConstantEmitter stripTrailingLineBreak() {
         if (Strings.isEmpty(value)) {
             return this;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
@@ -62,30 +62,28 @@ public class ConstantEmitter extends Emitter {
         return this;
     }
 
-    public ConstantEmitter stripLeading() {
+    public ConstantEmitter stripLeadingLineBreak() {
         if (Strings.isEmpty(value)) {
             return this;
         }
 
-        value = value.stripLeading();
+        if (value.charAt(0) == '\n') {
+            value = value.substring(1);
+        }
+
         return this;
     }
 
-    public ConstantEmitter stripTrailing() {
+    public ConstantEmitter stripTrailingLineBreak() {
         if (Strings.isEmpty(value)) {
             return this;
         }
 
-        value = value.stripTrailing();
-        return this;
-    }
-
-    public ConstantEmitter strip() {
-        if (Strings.isEmpty(value)) {
-            return this;
+        int last = value.length() - 1;
+        if (value.charAt(last) == '\n') {
+            value = value.substring(0, last);
         }
 
-        value = value.strip();
         return this;
     }
 

--- a/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
@@ -478,4 +478,18 @@ class CompilerSpec extends BaseSpecification {
         and: "An i:extraBlock is expected to do the same - independently of its nesting and location"
         globalRenderContext.getExtraBlock("extra-test") == "Extra Test"
     }
+
+    def "Minimal leading and trailing whitespace is trimmed"() {
+        when:
+        def source = "<i:arg type=\"String\" name=\"test\" />\n" +
+                "\n" +
+                "<i>@test</i>\n" +
+                "\n"
+        def ctx = new TemplateCompilationContext(new Template("test.html.pasta", null), SourceCodeInfo.forInlineCode(source), null)
+        List<CompileError> errors = new TemplateCompiler(ctx).compile()
+        then:
+        errors.size() == 0
+        and:
+        ctx.getTemplate().renderToString("hello") == "<i>hello</i>\n"
+    }
 }


### PR DESCRIPTION
> https://scireum.myjetbrains.com/youtrack/issue/SIRI-618

- Trims HTML and XML templates after parsing, in order to enable punctuation without whitespace after custom tags
- **JavaDoc will be done** once we agree on the entire thing 😅