### PR TITLE
Continuity: Allows to base64 encode the history state param

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -181,11 +181,7 @@ window.sirius.Continuity = (function () {
         this.log('[CONTINUITY] [ACTION] Pushing new state for type "%s": %o', type, entry);
 
         this.lastState = this.currentState;
-        if (entry) {
-            this.currentState[type] = entry;
-        } else {
-            delete this.currentState[type];
-        }
+        this.currentState[type] = entry;
         this.searchParams.set(this.options.stateParameterName, this.buildStateUrlParam(this.currentState));
 
         // Creates a new history instance, and saves state on it

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -181,7 +181,11 @@ window.sirius.Continuity = (function () {
         this.log('[CONTINUITY] [ACTION] Pushing new state for type "%s": %o', type, entry);
 
         this.lastState = this.currentState;
-        this.currentState[type] = entry;
+        if (entry) {
+            this.currentState[type] = entry;
+        } else {
+            delete this.currentState[type];
+        }
         this.searchParams.set(this.options.stateParameterName, this.buildStateUrlParam(this.currentState));
 
         // Creates a new history instance, and saves state on it
@@ -282,7 +286,7 @@ window.sirius.Continuity = (function () {
         return this.options.encodeStateParameter ? convertToBinary(paramStateText) : paramStateText;
     };
 
-    /**
+    /**@
      * Converts the given UTF-8 text to a binary base64 encoded representation.
      *
      * @param string the text to encode
@@ -307,7 +311,7 @@ window.sirius.Continuity = (function () {
         return JSON.parse(paramStateText);
     };
 
-    /**
+    /**@
      * Converts the given binary base64 encoded representation into its original UTF-8 text.
      *
      * @param string the binary base64 encoded representation of a text

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -282,6 +282,12 @@ window.sirius.Continuity = (function () {
         return this.options.encodeStateParameter ? convertToBinary(paramStateText) : paramStateText;
     };
 
+    /**
+     * Converts the given UTF-8 text to a binary base64 encoded representation.
+     *
+     * @param string the text to encode
+     * @returns {string} the binary base64 encoded representation of the text
+     */
     function convertToBinary(string) {
         const codeUnits = new Uint16Array(string.length);
         for (let i = 0; i < codeUnits.length; i++) {
@@ -301,6 +307,12 @@ window.sirius.Continuity = (function () {
         return JSON.parse(paramStateText);
     };
 
+    /**
+     * Converts the given binary base64 encoded representation into its original UTF-8 text.
+     *
+     * @param string the binary base64 encoded representation of a text
+     * @returns {string} the original text
+     */
     function convertFromBinary(encoded) {
         const binary = atob(encoded);
         const bytes = new Uint8Array(binary.length);

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -4,6 +4,7 @@ window.sirius.Continuity = (function () {
      *
      * @param {Object} [options] map specifying the behaviour of the library:
      * @param {string} options.stateParameterName Defines the parameter name the history state is written to in the deeplink URL.
+     * @param {boolean} [options.encodeStateParameter] Allows to enable base64 encoding of the history state parameter in the URL instead of plain text.
      * @param {boolean} [options.debug] Allows to enable the printing of debugging messages to the console right from the start.
      * @param {boolean} [options.disableAutoDeepLinks] Allows to disable the automatic generation and update of deep-links via the state parameter.
      * @param {function} [options.initialStateHook] Called during the parsing of the initial deep-linked state. Can be used to create intermediate states the user can navigate back to.
@@ -277,8 +278,17 @@ window.sirius.Continuity = (function () {
             }
         }
 
-        return JSON.stringify(paramState);
+        const paramStateText = JSON.stringify(paramState);
+        return this.options.encodeStateParameter ? convertToBinary(paramStateText) : paramStateText;
     };
+
+    function convertToBinary(string) {
+        const codeUnits = new Uint16Array(string.length);
+        for (let i = 0; i < codeUnits.length; i++) {
+            codeUnits[i] = string.charCodeAt(i);
+        }
+        return btoa(String.fromCharCode.apply(this, new Uint8Array(codeUnits.buffer)));
+    }
 
     /**@
      * Parses the value of our history state deep-link parameter from the URL and transforms it into a JS Object.
@@ -287,8 +297,18 @@ window.sirius.Continuity = (function () {
      * @returns {Object} the history state as an object
      */
     Continuity.prototype.parseStateUrlParam = function (param) {
-        return JSON.parse(param);
+        const paramStateText = this.options.encodeStateParameter ? convertFromBinary(param) : param;
+        return JSON.parse(paramStateText);
     };
+
+    function convertFromBinary(encoded) {
+        const binary = atob(encoded);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < bytes.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return String.fromCharCode.apply(this, new Uint16Array(bytes.buffer));
+    }
 
     /**@
      * Generates the new URL by combining the given search parameters and hash (if present).


### PR DESCRIPTION
We now allow to choose between the two modes:
- plain text (including escaped curly braces, ...) which is the default mode
- base64 encoded (a bit longer but normal characters and non readable)

Sample of plain text mode:
```
https://oxomi.test.scireum.com/p/3000470/products?oxHistory=%7B%22navPro%22%3A%7B%22view%22%3A%22filtered%22%2C%22filters%22%3A%7B%22brand%22%3A%5B%227QG3KIAUULBC476FCR7RE322L4%22%5D%2C%22metaclass%22%3A%5B%22metaclass%7CEC011550%22%5D%7D%2C%22query%22%3A%22%22%2C%22hiddenFilters%22%3A%7B%7D%7D%2C%22overlay%22%3A%7B%22type%22%3A%22openProductDatasheet%22%2C%22args%22%3A%7B%22productId%22%3A%22T7UAJHAIVIVIVG38IHVVHQTR7G%22%2C%22supplierItemNumber%22%3A%2203005000001%22%2C%22supplierNumber%22%3A%22DUHO80%22%2C%22supplierNumbers%22%3A%22DUHO80%2CDU%22%7D%7D%7D
```

Sample of base64 mode:
```
http://localhost:9000/p/TRADETEST/products?oxDeeplink=ewAiAG4AYQB2AFAAcgBvACIAOgB7ACIAdgBpAGUAdwAiADoAIgBmAGkAbAB0AGUAcgBlAGQAIgAsACIAZgBpAGwAdABlAHIAcwAiADoAewAiAGIAcgBhAG4AZAAiADoAWwAiADIASwBMAEIASABCAFEAQwA3AEgASgA2AFUATAA1AEEANgA4AEwANQBVADAAQQBSAEoARwAiAF0AfQAsACIAcQB1AGUAcgB5ACIAOgAiACIALAAiAGgAaQBkAGQAZQBuAEYAaQBsAHQAZQByAHMAIgA6AHsAfQB9ACwAIgBvAHYAZQByAGwAYQB5ACIAOgB7ACIAdAB5AHAAZQAiADoAIgBvAHAAZQBuAFAAcgBvAGQAdQBjAHQARABhAHQAYQBzAGgAZQBlAHQAIgAsACIAYQByAGcAcwAiADoAewAiAHAAcgBvAGQAdQBjAHQASQBkACIAOgAiADkANQBVADIAQQA0ADkAUwBRAEcANQAyADMAVgBGAEsAQwBOAEsANAA3AEMARQBGADgAMAAiACwAIgBzAHUAcABwAGwAaQBlAHIASQB0AGUAbQBOAHUAbQBiAGUAcgAiADoAIgBNAEUARwAiACwAIgBzAHUAcABwAGwAaQBlAHIATgB1AG0AYgBlAHIAIgA6ACIALQAiACwAIgBzAHUAcABwAGwAaQBlAHIATgB1AG0AYgBlAHIAcwAiADoAIgAtACIAfQB9AH0A
```

Fixes: [OX-8928](https://scireum.myjetbrains.com/youtrack/issue/OX-8928)