### PR TITLE
Exposes pooled byte buffer mem usage

### DIFF
--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.multipart.DiskAttribute;
 import io.netty.handler.codec.http.multipart.DiskFileUpload;
 import io.netty.handler.codec.http.multipart.HttpDataFactory;
 import io.netty.util.ResourceLeakDetector;
+import io.netty.util.internal.PlatformDependent;
 import sirius.kernel.Killable;
 import sirius.kernel.Sirius;
 import sirius.kernel.Startable;
@@ -838,6 +839,11 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
                          "pooled-byte-buffer-used-direct-mem",
                          "Pooled byte buffer allocation used direct memory",
                          PooledByteBufAllocator.DEFAULT.metric().usedDirectMemory() / 1024d / 1024d,
+                         "MB");
+        collector.metric("max_direct_mem",
+                         "max-direct-mem",
+                         "Maximum direct memory",
+                         PlatformDependent.maxDirectMemory() / 1024d / 1024d,
                          "MB");
     }
 

--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -829,6 +829,16 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
                          queueTime.getAndClear(),
                          "ms");
         collector.metric("http_websockets", "http-websockets", "Open Websockets", websockets.get(), null);
+        collector.metric("pooled_byte_buffer_used_heap_mem",
+                         "pooled-byte-buffer-used-heap-mem",
+                         "Pooled byte buffer allocation used heap memory",
+                         PooledByteBufAllocator.DEFAULT.metric().usedHeapMemory() / 1024d / 1024d,
+                         "MB");
+        collector.metric("pooled_byte_buffer_used_direct_mem",
+                         "pooled-byte-buffer-used-direct-mem",
+                         "Pooled byte buffer allocation used direct memory",
+                         PooledByteBufAllocator.DEFAULT.metric().usedDirectMemory() / 1024d / 1024d,
+                         "MB");
     }
 
     /**


### PR DESCRIPTION
Exposes the current heap and direct memory used by the pooled byte buffer allocation, converted in MB.

Note that we are not defining threshold limits in the config (they are initialized with zero), and system can set those if needed as they strongly depend on the actual amount of memory allocated to both heap and direct memory.

Fixes: [OX-9027](https://scireum.myjetbrains.com/youtrack/issue/OX-9027)