### PR TITLE
We now use RFC 822 date formats instead of RFC 1123 ones.

### DIFF
--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -53,8 +53,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.List;
@@ -318,7 +319,7 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
     }
 
     /**
-     * Parses a HTTP header string into a LocalDateTime.
+     * Parses an HTTP header string into a LocalDateTime.
      * <p>
      * The timestamp is expected to match the RFC 1123 format, as defined by the HTTP standard.
      *
@@ -331,7 +332,9 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
         }
 
         try {
-            return Optional.of(LocalDateTime.parse(httpDateHeader, DateTimeFormatter.RFC_1123_DATE_TIME));
+            return Optional.of(Instant.from(Response.RFC822_INSTANT.parse(httpDateHeader))
+                                      .atZone(ZoneId.systemDefault())
+                                      .toLocalDateTime());
         } catch (DateTimeParseException e) {
             Exceptions.ignore(e);
             return Optional.empty();


### PR DESCRIPTION
Both look almost the same except that 822 always uses UTC as zone where 1123 might output an offset like +0200.

This issue has been reported by the AWS driver for S3Ninja and the largest data center provider in the world is always right :)