### PR TITLE
Makes continuity.js.pasta IE11 compatible

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -57,7 +57,7 @@ window.sirius.Continuity = (function () {
             try {
                 this.currentState = this.parseStateUrlParam(urlState);
                 this.handleStateChange(this.currentState, true);
-            } catch {
+            } catch (e) {
                 this.currentState = {};
                 this.log('[CONTINUITY] [ERROR] Parsing the initial state url parameter failed!');
                 if (this.options.initialStateParseErrorHandler) {


### PR DESCRIPTION
Needed to specify the error in the catch block.

![Bildschirmfoto 2022-10-07 um 16 08 07](https://user-images.githubusercontent.com/42942954/194573145-e323992e-dc90-4db4-b777-ee544a95e7d2.png)
