### PR TITLE
Correctly tunnels through last modified header

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -567,7 +567,7 @@ public class Response {
                                                    .map(date -> date.atZone(ZoneId.systemDefault())
                                                                     .toInstant()
                                                                     .getEpochSecond())
-                                                   .orElse(0L) / 1000;
+                                                   .orElse(0L);
         if (ifModifiedSinceDateSeconds > 0
             && lastModifiedInMillis > 0
             && ifModifiedSinceDateSeconds >= lastModifiedInMillis / 1000) {

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -180,14 +180,14 @@ public class TunnelHandler implements AsyncHandler<String> {
             WebServer.LOG.FINE("Tunnel - HEADERS for %s", webContext.getRequestedURI());
         }
 
-        long lastModified = forwardHeadersAndDetermineLastModified(httpHeaders);
-        if (response.handleIfModifiedSince(lastModified)) {
+        long lastModifiedMillis = forwardHeadersAndDetermineLastModified(httpHeaders);
+        if (response.handleIfModifiedSince(lastModifiedMillis)) {
             return State.ABORT;
         }
 
         overrideContentTypeIfNecessary();
 
-        response.setDateAndCacheHeaders(lastModified,
+        response.setDateAndCacheHeaders(lastModifiedMillis,
                                         response.cacheSeconds == null ? Response.HTTP_CACHE : response.cacheSeconds,
                                         response.isPrivate);
 
@@ -251,7 +251,7 @@ public class TunnelHandler implements AsyncHandler<String> {
     private long parseLastModified(Map.Entry<String, String> entry) {
         try {
             return WebServer.parseDateHeader(entry.getValue())
-                            .map(date -> date.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond())
+                            .map(date -> date.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
                             .orElse(0L);
         } catch (Exception e) {
             Exceptions.ignore(e);


### PR DESCRIPTION
Previously millis and seconds got confused which resulted in wrong header timestamps.

Before:
> last-modified: Tue, 20 Jan 1970 07:30:31 +0100

After:
> last-modified: Thu, 06 Oct 2022 06:47:39 GMT

Fixes: [SIRI-592](https://scireum.myjetbrains.com/youtrack/issue/SIRI-592)