### PR TITLE
update dependencies, remove extra-import for poi-shared-strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,20 +140,14 @@
         <dependency>
             <groupId>com.github.pjfanning</groupId>
             <artifactId>excel-streaming-reader</artifactId>
-            <version>4.0.2</version>
-        </dependency>
-        <!-- Required as the version shipped with excel-streaming-reader has security issues. -->
-        <dependency>
-            <groupId>com.github.pjfanning</groupId>
-            <artifactId>poi-shared-strings</artifactId>
-            <version>2.5.4</version>
+            <version>4.0.4</version>
         </dependency>
 
         <!-- Swagger Annotations are used for API/Service documentation -->
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
initial, poi-shared-strings was added extra to fix security-issues shipped with excel-streaming-reader in an older version. Now with https://github.com/pjfanning/excel-streaming-reader/compare/v4.0.2...v4.0.3 poi-shared-strings was updated to the newest version and in the old version 2.5.4 there is CVE-2022-42889. Fixed now with https://github.com/pjfanning/poi-shared-strings/pull/53/files - details see https://commons.apache.org/proper/commons-text/security.html