### PR TITLE
Marks colors set by border color classes as important

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/sirius-colors.scss
+++ b/src/main/resources/default/assets/tycho/styles/sirius-colors.scss
@@ -65,7 +65,7 @@ $sirius-black: #000000;
   background-color: $sirius-red !important;
 }
 .sci-border-red, .border-sirius-red {
-  border-color: $sirius-red;
+  border-color: $sirius-red !important;
 }
 
 .sci-text-red-dark, .text-sirius-red-dark {
@@ -75,7 +75,7 @@ $sirius-black: #000000;
   background-color: $sirius-red-dark !important;
 }
 .sci-border-red-dark, .border-sirius-red-dark {
-  border-color: $sirius-red-dark;
+  border-color: $sirius-red-dark !important;
 }
 
 .sci-text-red-light, .text-sirius-red-light {
@@ -85,7 +85,7 @@ $sirius-black: #000000;
   background-color: $sirius-red-light !important;
 }
 .sci-border-red-light, .border-sirius-red-light {
-  border-color: $sirius-red-light;
+  border-color: $sirius-red-light !important;
 }
 
 .sci-text-green, .text-sirius-green {
@@ -95,7 +95,7 @@ $sirius-black: #000000;
   background-color: $sirius-green !important;
 }
 .sci-border-green, .border-sirius-green {
-  border-color: $sirius-green;
+  border-color: $sirius-green !important;
 }
 
 .sci-text-green-dark, .text-sirius-green-dark {
@@ -105,7 +105,7 @@ $sirius-black: #000000;
   background-color: $sirius-green-dark !important;
 }
 .sci-border-green-dark, .border-sirius-green-dark {
-  border-color: $sirius-green-dark;
+  border-color: $sirius-green-dark !important;
 }
 
 .sci-text-green-light, .text-sirius-green-light {
@@ -115,7 +115,7 @@ $sirius-black: #000000;
   background-color: $sirius-green-light !important;
 }
 .sci-border-green-light, .border-sirius-green-light {
-  border-color: $sirius-green-light;
+  border-color: $sirius-green-light !important;
 }
 
 .sci-text-blue, .text-sirius-blue {
@@ -125,7 +125,7 @@ $sirius-black: #000000;
   background-color: $sirius-blue !important;
 }
 .sci-border-blue, .border-sirius-blue {
-  border-color: $sirius-blue;
+  border-color: $sirius-blue !important;
 }
 
 .sci-text-blue-dark, .text-sirius-blue-dark {
@@ -135,7 +135,7 @@ $sirius-black: #000000;
   background-color: $sirius-blue-dark !important;
 }
 .sci-border-blue-dark, .border-sirius-blue-dark {
-  border-color: $sirius-blue-dark;
+  border-color: $sirius-blue-dark !important;
 }
 
 .sci-text-blue-light, .text-sirius-blue-light {
@@ -145,7 +145,7 @@ $sirius-black: #000000;
   background-color: $sirius-blue-light !important;
 }
 .sci-border-blue-light, .border-sirius-blue-light {
-  border-color: $sirius-blue-light;
+  border-color: $sirius-blue-light !important;
 }
 
 .sci-text-violet, .text-sirius-violet {
@@ -155,7 +155,7 @@ $sirius-black: #000000;
   background-color: $sirius-violet !important;
 }
 .sci-border-violet, .border-sirius-violet {
-  border-color: $sirius-violet;
+  border-color: $sirius-violet !important;
 }
 
 .sci-text-violet-dark, .text-sirius-violet-dark {
@@ -165,7 +165,7 @@ $sirius-black: #000000;
   background-color: $sirius-violet-dark !important;
 }
 .sci-border-violet-dark, .border-sirius-violet-dark {
-  border-color: $sirius-violet-dark;
+  border-color: $sirius-violet-dark !important;
 }
 
 .sci-text-violet-light, .text-sirius-violet-light {
@@ -175,7 +175,7 @@ $sirius-black: #000000;
   background-color: $sirius-violet-light !important;
 }
 .sci-border-violet-light, .border-sirius-violet-light {
-  border-color: $sirius-violet-light;
+  border-color: $sirius-violet-light !important;
 }
 
 .sci-text-orange, .text-sirius-orange {
@@ -185,7 +185,7 @@ $sirius-black: #000000;
   background-color: $sirius-orange !important;
 }
 .sci-border-orange, .border-sirius-orange {
-  border-color: $sirius-orange;
+  border-color: $sirius-orange !important;
 }
 
 .sci-text-orange-dark, .text-sirius-orange-dark {
@@ -195,7 +195,7 @@ $sirius-black: #000000;
   background-color: $sirius-orange-dark !important;
 }
 .sci-border-orange-dark, .border-sirius-orange-dark {
-  border-color: $sirius-orange-dark;
+  border-color: $sirius-orange-dark !important;
 }
 
 .sci-text-orange-light, .text-sirius-orange-light {
@@ -205,7 +205,7 @@ $sirius-black: #000000;
   background-color: $sirius-orange-light !important;
 }
 .sci-border-orange-light, .border-sirius-orange-light {
-  border-color: $sirius-orange-light;
+  border-color: $sirius-orange-light !important;
 }
 
 .sci-text-yellow, .text-sirius-yellow {
@@ -215,7 +215,7 @@ $sirius-black: #000000;
   background-color: $sirius-yellow !important;
 }
 .sci-border-yellow, .border-sirius-yellow {
-  border-color: $sirius-yellow;
+  border-color: $sirius-yellow !important;
 }
 
 .sci-text-yellow-dark, .text-sirius-yellow-dark {
@@ -225,7 +225,7 @@ $sirius-black: #000000;
   background-color: $sirius-yellow-dark !important;
 }
 .sci-border-yellow-dark, .border-sirius-yellow-dark {
-  border-color: $sirius-yellow-dark;
+  border-color: $sirius-yellow-dark !important;
 }
 
 .sci-text-yellow-light, .text-sirius-yellow-light {
@@ -235,7 +235,7 @@ $sirius-black: #000000;
   background-color: $sirius-yellow-light !important;
 }
 .sci-border-yellow-light, .border-sirius-yellow-light {
-  border-color: $sirius-yellow-light;
+  border-color: $sirius-yellow-light !important;
 }
 
 .sci-text-cyan, .text-sirius-cyan {
@@ -245,7 +245,7 @@ $sirius-black: #000000;
   background-color: $sirius-cyan !important;
 }
 .sci-border-cyan, .border-sirius-cyan {
-  border-color: $sirius-cyan;
+  border-color: $sirius-cyan !important;
 }
 
 .sci-text-cyan-dark, .text-sirius-cyan-dark {
@@ -255,7 +255,7 @@ $sirius-black: #000000;
   background-color: $sirius-cyan-dark !important;
 }
 .sci-border-cyan-dark, .border-sirius-cyan-dark {
-  border-color: $sirius-cyan-dark;
+  border-color: $sirius-cyan-dark !important;
 }
 
 .sci-text-cyan-light, .text-sirius-cyan-light {
@@ -265,7 +265,7 @@ $sirius-black: #000000;
   background-color: $sirius-cyan-light !important;
 }
 .sci-border-cyan-light, .border-sirius-cyan-light {
-  border-color: $sirius-cyan-light;
+  border-color: $sirius-cyan-light !important;
 }
 
 .sci-text-white, .text-sirius-white {
@@ -275,7 +275,7 @@ $sirius-black: #000000;
   background-color: $sirius-white !important;
 }
 .sci-border-white, .border-sirius-white {
-  border-color: $sirius-white;
+  border-color: $sirius-white !important;
 }
 
 .sci-text-white-dark, .text-sirius-white-dark {
@@ -285,7 +285,7 @@ $sirius-black: #000000;
   background-color: $sirius-white-dark !important;
 }
 .sci-border-white-dark, .border-sirius-white-dark {
-  border-color: $sirius-white-dark;
+  border-color: $sirius-white-dark !important;
 }
 
 .sci-text-gray-lighter, .sci-text-grey-lighter, .text-sirius-gray-lighter, .text-sirius-grey-lighter {
@@ -295,7 +295,7 @@ $sirius-black: #000000;
   background-color: $sirius-gray-lighter !important;
 }
 .sci-border-gray-lighter, .sci-border-grey-lighter, .border-sirius-gray-lighter, .border-sirius-grey-lighter {
-  border-color: $sirius-gray-lighter;
+  border-color: $sirius-gray-lighter !important;
 }
 
 .sci-text-gray-light, .sci-text-grey-light, .text-sirius-gray-light, .text-sirius-grey-light {
@@ -305,7 +305,7 @@ $sirius-black: #000000;
   background-color: $sirius-gray-light !important;
 }
 .sci-border-gray-light, .sci-border-grey-light, .border-sirius-gray-light, .border-sirius-grey-light {
-  border-color: $sirius-gray-light;
+  border-color: $sirius-gray-light !important;
 }
 
 .sci-text-gray, .sci-text-grey, .text-sirius-gray, .text-sirius-grey {
@@ -315,7 +315,7 @@ $sirius-black: #000000;
   background-color: $sirius-gray !important;
 }
 .sci-border-gray, .sci-border-grey, .border-sirius-gray, .border-sirius-grey {
-  border-color: $sirius-gray;
+  border-color: $sirius-gray !important;
 }
 
 .sci-text-gray-dark, .sci-text-grey-dark, .text-sirius-gray-dark, .text-sirius-grey-dark {
@@ -325,7 +325,7 @@ $sirius-black: #000000;
   background-color: $sirius-gray-dark !important;
 }
 .sci-border-gray-dark, .sci-border-grey-dark, .border-sirius-gray-dark, .border-sirius-grey-dark {
-  border-color: $sirius-gray-dark;
+  border-color: $sirius-gray-dark !important;
 }
 
 .sci-text-gray-darker, .sci-text-grey-darker, .text-sirius-gray-darker, .text-sirius-grey-darker {
@@ -335,7 +335,7 @@ $sirius-black: #000000;
   background-color: $sirius-gray-darker !important;
 }
 .sci-border-gray-darker, .sci-border-grey-darker, .border-sirius-gray-darker, .border-sirius-grey-darker {
-  border-color: $sirius-gray-darker;
+  border-color: $sirius-gray-darker !important;
 }
 
 .sci-text-black, .text-sirius-black {
@@ -345,7 +345,7 @@ $sirius-black: #000000;
   background-color: $sirius-black !important;
 }
 .sci-border-black, .border-sirius-black {
-  border-color: $sirius-black;
+  border-color: $sirius-black !important;
 }
 
 .sci-text-deep-blue, .text-sirius-deep-blue {
@@ -355,7 +355,7 @@ $sirius-black: #000000;
   background-color: $sirius-deep-blue !important;
 }
 .sci-border-deep-blue, .border-sirius-deep-blue {
-  border-color: $sirius-deep-blue;
+  border-color: $sirius-deep-blue !important;
 }
 
 .sci-text-deep-blue-dark, .text-sirius-deep-blue-dark {
@@ -365,5 +365,5 @@ $sirius-black: #000000;
   background-color: $sirius-deep-blue-dark !important;
 }
 .sci-border-deep-blue-dark, .border-sirius-deep-blue-dark {
-  border-color: $sirius-deep-blue-dark;
+  border-color: $sirius-deep-blue-dark !important;
 }


### PR DESCRIPTION
This allows to overwrite the border colors of other classes (for example sci-btn-outline) by applying one of the border color classes of this file. This also matches the behaviour of the text and background color classes.

Fixes: OX-9142