### PR TITLE
Ignores IllegalReferenceCountException transforming HTTP data

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.multipart.HttpData;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.multipart.InterfaceHttpPostRequestDecoder;
+import io.netty.util.IllegalReferenceCountException;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Promise;
@@ -602,7 +603,7 @@ public class WebContext implements SubContext {
                     return byteBuf.toString(attr.getCharset());
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | IllegalReferenceCountException e) {
             Exceptions.ignore(e);
         }
         return null;


### PR DESCRIPTION
Calling toString in a released buffer (refCnt = 0) throws an IllegalReferenceCountException, which will write an unnecessary exception in the system logs. If the buffer has been released, very likely the connection was already destroyed.

Fixes: [OX-9250](https://scireum.myjetbrains.com/youtrack/issue/OX-9250)