### PR TITLE
make console work again scrollable and also for small widths

### DIFF
--- a/src/main/resources/default/templates/system/console.html.pasta
+++ b/src/main/resources/default/templates/system/console.html.pasta
@@ -54,6 +54,12 @@
                 background: url('/assets/terminal/low_contrast_linen.png');
             }
 
+            #wrapper {
+                height: 100vh;
+                display: grid;
+                grid-template-rows: 80px 1fr 40px;
+            }
+
             #wrapper-body {
                 max-height: 100%;
                 overflow: hidden;


### PR DESCRIPTION
with removing the 100vh in https://github.com/scireum/sirius-web/pull/1118/files this does not work anymore, so we add it here in custom styles only for the console-page.
<img width="806" alt="Bildschirm­foto 2022-11-08 um 14 05 16" src="https://user-images.githubusercontent.com/55080004/200572312-13c1b969-3bf3-4336-8f39-2a9a23997fec.png">
 -->
<img width="730" alt="Bildschirm­foto 2022-11-08 um 14 02 13" src="https://user-images.githubusercontent.com/55080004/200571634-f58c7abb-e82a-4c85-beb1-6bf64dbe29d3.png">
