### PR TITLE
Properly "handles" calling /assets/dynamic

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -10,7 +10,6 @@ package sirius.web.dispatch;
 
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import sirius.web.sass.Output;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Files;
@@ -31,6 +30,7 @@ import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
+import sirius.web.sass.Output;
 import sirius.web.security.UserContext;
 import sirius.web.templates.Templates;
 
@@ -121,13 +121,13 @@ public class AssetsDispatcher implements WebDispatcher {
 
     private Tuple<String, Integer> getEffectiveURI(WebContext ctx) {
         String uri = ctx.getRequestedURI();
-        if (uri.startsWith("/assets/dynamic")) {
+        if (uri.startsWith("/assets/dynamic/")) {
             uri = uri.substring(16);
             Tuple<String, String> pair = Strings.split(uri, "/");
             return Tuple.create(ASSETS_PREFIX + pair.getSecond(), Response.HTTP_CACHE_INFINITE);
         }
 
-        if (uri.startsWith("/assets/no-cache")) {
+        if (uri.startsWith("/assets/no-cache/")) {
             return Tuple.create(ASSETS_PREFIX + uri.substring(17), 0);
         }
 


### PR DESCRIPTION
Previously directly calling /assets/dynamic - either by accident or when generating an invalid ID - rendered an excessive error page and also logged an ERROR to the system log.

We now just don't handle such a call via the asset dispatcher and let the controller dispatcher tell the user that no controller will handle the URL.

Before:

![image](https://user-images.githubusercontent.com/2427877/203994342-2b6528b0-6c5a-4f83-bd28-5867914fca6d.png)

After:

![image](https://user-images.githubusercontent.com/2427877/203994363-f99b74af-169f-412d-9572-6635af3badc9.png)


Fixes: [SIRI-669](https://scireum.myjetbrains.com/youtrack/issue/SIRI-669)