### PR TITLE
PublicServices: Prevents recording service documentations multiple times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>ga-6.0.0</sirius.kernel>
+        <sirius.kernel>dev-33.4.0</sirius.kernel>
     </properties>
 
     <repositories>
@@ -146,7 +146,13 @@
         <dependency>
             <groupId>com.github.pjfanning</groupId>
             <artifactId>excel-streaming-reader</artifactId>
-            <version>4.0.4</version>
+            <version>4.0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Swagger Annotations are used for API/Service documentation -->

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -38,6 +38,7 @@ import sirius.web.security.MaintenanceInfo;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
 import sirius.web.services.Format;
+import sirius.web.services.PublicServices;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
@@ -78,6 +79,9 @@ public class ControllerDispatcher implements WebDispatcher {
     @Part
     @Nullable
     private Firewall firewall;
+
+    @Part
+    private PublicServices publicServices;
 
     /**
      * The priority of this controller is {@code PriorityCollector.DEFAULT_PRIORITY + 10} as it is quite complex
@@ -329,7 +333,7 @@ public class ControllerDispatcher implements WebDispatcher {
         }
     }
 
-    /*
+    /**
      * Compiles all available controllers and their methods into a route table
      */
     private List<Route> buildRouter() {
@@ -340,6 +344,7 @@ public class ControllerDispatcher implements WebDispatcher {
 
         List<Route> allRoutes = collector.getData();
         optimizeRoutes(allRoutes);
+        allRoutes.forEach(route -> publicServices.recordPublicService(route.getMethod()));
 
         return allRoutes;
     }
@@ -410,7 +415,7 @@ public class ControllerDispatcher implements WebDispatcher {
         return Collections.unmodifiableList(routes);
     }
 
-    /*
+    /**
      * Compiles a method wearing a Routed annotation.
      */
     private Route compileMethod(Routed routed, final Controller controller, final Method method) {

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -71,8 +71,6 @@ public class ControllerDispatcher implements WebDispatcher {
 
     private List<Route> routes;
 
-    private final Monoflop routingInitialized = Monoflop.create();
-
     @PriorityParts(Interceptor.class)
     private List<Interceptor> interceptors;
 
@@ -82,9 +80,6 @@ public class ControllerDispatcher implements WebDispatcher {
     @Part
     @Nullable
     private Firewall firewall;
-
-    @Part
-    private PublicServices publicServices;
 
     /**
      * The priority of this controller is {@code PriorityCollector.DEFAULT_PRIORITY + 10} as it is quite complex
@@ -341,7 +336,7 @@ public class ControllerDispatcher implements WebDispatcher {
      *
      * @return a list holding all available {@link Route routes}
      */
-    private synchronized List<Route> buildRouter() {
+    private List<Route> buildRouter() {
         PriorityCollector<Route> collector = PriorityCollector.create();
         for (Controller controller : Injector.context().getParts(Controller.class)) {
             compileController(collector, controller);
@@ -349,7 +344,6 @@ public class ControllerDispatcher implements WebDispatcher {
 
         List<Route> allRoutes = collector.getData();
         optimizeRoutes(allRoutes);
-        allRoutes.forEach(route -> publicServices.recordPublicService(route.getMethod()));
 
         return allRoutes;
     }
@@ -414,11 +408,7 @@ public class ControllerDispatcher implements WebDispatcher {
      */
     public List<Route> getRoutes() {
         if (routes == null) {
-            synchronized (routingInitialized) {
-                if (routingInitialized.firstCall()) {
-                    routes = buildRouter();
-                }
-            }
+            routes = buildRouter();
         }
 
         return Collections.unmodifiableList(routes);

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -338,6 +338,8 @@ public class ControllerDispatcher implements WebDispatcher {
 
     /**
      * Compiles all available controllers and their methods into a route table
+     *
+     * @return a list holding all available {@link Route routes}
      */
     private synchronized List<Route> buildRouter() {
         PriorityCollector<Route> collector = PriorityCollector.create();
@@ -423,7 +425,9 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     /**
-     * Compiles a method wearing a Routed annotation.
+     * Compiles a method wearing a {@link Routed} annotation.
+     *
+     * @return a {@link Route} matching the annotated criteria
      */
     private Route compileMethod(Routed routed, final Controller controller, final Method method) {
         try {

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -17,7 +17,6 @@ import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.CachingSupplier;
 import sirius.kernel.commons.Callback;
 import sirius.kernel.commons.Explain;
-import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.PriorityCollector;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.Injector;
@@ -39,7 +38,6 @@ import sirius.web.security.MaintenanceInfo;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
 import sirius.web.services.Format;
-import sirius.web.services.PublicServices;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -50,9 +50,6 @@ import java.util.regex.Pattern;
  */
 public class Route {
 
-    @Part
-    private static PublicServices publicServices;
-
     protected static final List<Object> NO_MATCH = Collections.unmodifiableList(new ArrayList<>());
     private static final Class<?>[] CLASS_ARRAY = new Class[0];
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
@@ -162,7 +159,6 @@ public class Route {
             PublicService publicServiceAnnotation = method.getAnnotation(PublicService.class);
             result.enforceMaintenanceMode = publicServiceAnnotation.enforceMaintenanceMode();
             result.format = publicServiceAnnotation.format();
-            publicServices.recordPublicService(method);
         } else if (method.isAnnotationPresent(InternalService.class)) {
             result.format = method.getAnnotation(InternalService.class).format();
         } else if (routed.jsonCall()) {

--- a/src/main/java/sirius/web/services/PublicServices.java
+++ b/src/main/java/sirius/web/services/PublicServices.java
@@ -26,6 +26,7 @@ import sirius.web.http.WebServer;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
@@ -39,7 +40,7 @@ import java.util.stream.Stream;
 @Register(classes = PublicServices.class)
 public class PublicServices {
 
-    private final List<PublicApiInfo> apis = new ArrayList<>();
+    private List<PublicApiInfo> apis;
 
     @Part
     private GlobalContext globalContext;
@@ -53,22 +54,20 @@ public class PublicServices {
      * @return the list of all known public APIs
      */
     public List<PublicApiInfo> getApis() {
-        synchronized (apis) {
-            if (apis.isEmpty()) {
-                controllerDispatcher.getRoutes().forEach(route -> recordPublicService(route.getMethod()));
-            }
-            return new ArrayList<>(apis);
+        if (apis == null) {
+            this.apis = discoverPublicServices();
         }
+
+        return Collections.unmodifiableList(apis);
     }
 
-    /**
-     * Records a new public service for the given routed method.
-     * <p>
-     * Note that this is somewhat of an internal method and should not be invoked manually.
-     *
-     * @param route the routed method which is recognized as a public service
-     */
-    public void recordPublicService(Method route) {
+    private List<PublicApiInfo> discoverPublicServices() {
+        List<PublicApiInfo> modifiableApis = new ArrayList<>();
+        controllerDispatcher.getRoutes().forEach(route -> recordPublicService(route.getMethod(), modifiableApis));
+        return modifiableApis;
+    }
+
+    private void recordPublicService(Method route, List<PublicApiInfo> modifiableApis) {
         Routed routed = route.getAnnotation(Routed.class);
         if (routed == null) {
             return;
@@ -93,18 +92,18 @@ public class PublicServices {
                                                                     .sorted(Comparator.comparingInt(apiResponse -> Integer.parseInt(
                                                                             apiResponse.responseCode())))
                                                                     .toList());
-        synchronized (apis) {
-            PublicApiInfo apiInfo = apis.stream()
-                                        .filter(api -> Strings.areEqual(api.getApiName(), publicService.apiName()))
-                                        .findFirst()
-                                        .orElse(null);
-            if (apiInfo == null) {
-                apiInfo = buildApiInfo(publicService.apiName(), route);
-                apis.add(apiInfo);
-                apis.sort(Comparator.comparing(PublicApiInfo::getPriority).thenComparing(PublicApiInfo::getApiName));
-            }
-            apiInfo.addService(serviceInfo);
+        PublicApiInfo apiInfo = modifiableApis.stream()
+                                              .filter(api -> Strings.areEqual(api.getApiName(),
+                                                                              publicService.apiName()))
+                                              .findFirst()
+                                              .orElse(null);
+        if (apiInfo == null) {
+            apiInfo = buildApiInfo(publicService.apiName(), route);
+            modifiableApis.add(apiInfo);
+            modifiableApis.sort(Comparator.comparing(PublicApiInfo::getPriority)
+                                          .thenComparing(PublicApiInfo::getApiName));
         }
+        apiInfo.addService(serviceInfo);
     }
 
     private List<Parameter> collectSharedApiParameters(Method route) {

--- a/src/main/java/sirius/web/services/PublicServices.java
+++ b/src/main/java/sirius/web/services/PublicServices.java
@@ -20,7 +20,6 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.settings.Extension;
 import sirius.web.controller.ControllerDispatcher;
-import sirius.web.controller.Route;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebServer;
 
@@ -56,10 +55,7 @@ public class PublicServices {
     public List<PublicApiInfo> getApis() {
         synchronized (apis) {
             if (apis.isEmpty()) {
-                List<Route> knownRoutes = controllerDispatcher.getRoutes();
-                if (!knownRoutes.isEmpty()) {
-                    knownRoutes.forEach(route -> recordPublicService(route.getMethod()));
-                }
+                controllerDispatcher.getRoutes().forEach(route -> recordPublicService(route.getMethod()));
             }
             return new ArrayList<>(apis);
         }

--- a/src/main/java/sirius/web/services/PublicServices.java
+++ b/src/main/java/sirius/web/services/PublicServices.java
@@ -19,6 +19,8 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.settings.Extension;
+import sirius.web.controller.ControllerDispatcher;
+import sirius.web.controller.Route;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebServer;
 
@@ -43,6 +45,9 @@ public class PublicServices {
     @Part
     private GlobalContext globalContext;
 
+    @Part
+    private ControllerDispatcher controllerDispatcher;
+
     /**
      * Lists all known public APIs.
      *
@@ -50,6 +55,12 @@ public class PublicServices {
      */
     public List<PublicApiInfo> getApis() {
         synchronized (apis) {
+            if (apis.isEmpty()) {
+                List<Route> knownRoutes = controllerDispatcher.getRoutes();
+                if (!knownRoutes.isEmpty()) {
+                    knownRoutes.forEach(route -> recordPublicService(route.getMethod()));
+                }
+            }
             return new ArrayList<>(apis);
         }
     }


### PR DESCRIPTION
Service documentations could register multiple times during the initial collection of routes. This is an attempt to ensure that this collection and the accompanying Controller parsing is performed in a safe manner.

Fixes: [SIRI-680](https://scireum.myjetbrains.com/youtrack/issue/SIRI-680)