### PR TITLE
BREAKING: Uses new variants of renamed lang methods

### DIFF
--- a/src/main/java/sirius/pasta/noodle/macros/FormatDateTimeWithoutSecondsMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatDateTimeWithoutSecondsMacro.java
@@ -23,7 +23,7 @@ import java.util.Date;
  * <p>
  * The macro supports the datatypes {@code long} for epoch milliseconds, {@link Date} for legacy applications, and
  * {@link TemporalAccessor}. The invocation is forwarded to {@link NLS#getDateTimeFormatWithoutSeconds(String)#format}
- * via {@link Value#asLocalDateTime(java.time.LocalDateTime)} and using {@link NLS#getCurrentLang()}.
+ * via {@link Value#asLocalDateTime(java.time.LocalDateTime)} and using {@link NLS#getCurrentLanguage()}.
  */
 @Register
 @PublicApi
@@ -35,7 +35,7 @@ public class FormatDateTimeWithoutSecondsMacro extends FormatDateMacro {
         if (evalResult.isNull()) {
             return "";
         }
-        return NLS.getDateTimeFormatWithoutSeconds(NLS.getCurrentLang()).format(evalResult.asLocalDateTime(null));
+        return NLS.getDateTimeFormatWithoutSeconds(NLS.getCurrentLanguage()).format(evalResult.asLocalDateTime(null));
     }
 
     @Nonnull

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -42,7 +42,7 @@ public class HelpDispatcher implements WebDispatcher {
 
     private static final String HELP_PREFIX = "/help";
     private static final int HELP_PREFIX_LENGTH = "/help/".length();
-    private static final Pattern LANG_PATTERN = Pattern.compile("[a-z]{2}");
+    private static final Pattern LANGUAGE_PATTERN = Pattern.compile("[a-z]{2}");
     private static final String PASTA_SUFFIX = ".html.pasta";
 
     @ConfigValue("help.indexTemplate")
@@ -85,7 +85,7 @@ public class HelpDispatcher implements WebDispatcher {
 
         // cut /help/ and try to extract the locale
         Tuple<String, String> langAndTopic = Strings.split(uri.substring(HELP_PREFIX_LENGTH), "/");
-        boolean languageFound = setupLang(langAndTopic.getFirst());
+        boolean languageFound = setupLanguage(langAndTopic.getFirst());
 
         if (!languageFound || Strings.isFilled(langAndTopic.getSecond())) {
             DispatchDecision topicDecision = serveTopic(ctx, uri);
@@ -135,9 +135,9 @@ public class HelpDispatcher implements WebDispatcher {
         }
     }
 
-    private boolean setupLang(String lang) {
-        if (LANG_PATTERN.matcher(lang).matches() && helpSystemLanguageDirectories.contains(lang)) {
-            CallContext.getCurrent().setLang(lang);
+    private boolean setupLanguage(String language) {
+        if (LANGUAGE_PATTERN.matcher(language).matches() && helpSystemLanguageDirectories.contains(language)) {
+            CallContext.getCurrent().setLanguage(language);
             return true;
         }
 

--- a/src/main/java/sirius/web/mails/MailSender.java
+++ b/src/main/java/sirius/web/mails/MailSender.java
@@ -80,7 +80,7 @@ public class MailSender {
     protected String type;
     protected List<DataSource> attachments = new ArrayList<>();
     protected String bounceToken;
-    protected String lang;
+    protected String language;
     protected Map<String, String> headers = new TreeMap<>();
 
     @Part
@@ -362,10 +362,10 @@ public class MailSender {
      * @see #addResourceAsAttachment(String, String, String)
      */
     public String addResourceAsAttachment(@Nonnull String resource, @Nullable String filename) {
-        String cid = Strings.generateCode(16) + "@mail.local";
-        addResourceAsAttachment(resource, filename, cid);
+        String contentId = Strings.generateCode(16) + "@mail.local";
+        addResourceAsAttachment(resource, filename, contentId);
 
-        return cid;
+        return contentId;
     }
 
     /**
@@ -425,16 +425,16 @@ public class MailSender {
     /**
      * Sets the language used to perform {@link sirius.kernel.nls.NLS} lookups when rendering templates.
      *
-     * @param langs an array of languages. The first non-empty value is used.
+     * @param languages an array of languages. The first non-empty value is used.
      * @return the builder itself
      */
-    public MailSender setLang(String... langs) {
-        if (langs == null) {
+    public MailSender setLang(String... languages) {
+        if (languages == null) {
             return this;
         }
-        for (String language : langs) {
-            if (Strings.isFilled(language)) {
-                this.lang = language;
+        for (String newLanguage : languages) {
+            if (Strings.isFilled(newLanguage)) {
+                this.language = newLanguage;
                 return this;
             }
         }
@@ -452,8 +452,8 @@ public class MailSender {
         String tmpLanguage = NLS.getCurrentLanguage();
         try {
             try {
-                if (lang != null) {
-                    CallContext.getCurrent().setLanguage(lang);
+                if (language != null) {
+                    CallContext.getCurrent().setLanguage(language);
                 }
                 render();
                 buildSubject();
@@ -463,9 +463,9 @@ public class MailSender {
             } finally {
                 CallContext.getCurrent().setLanguage(tmpLanguage);
             }
-        } catch (HandledException e) {
-            throw e;
-        } catch (Exception e) {
+        } catch (HandledException exception) {
+            throw exception;
+        } catch (Exception exception) {
             throw Exceptions.handle()
                             .withSystemErrorMessage(
                                     "Cannot send mail to '%s (%s)' from '%s (%s)' with subject '%s': %s (%s)",
@@ -475,7 +475,7 @@ public class MailSender {
                                     senderName,
                                     subject)
                             .to(Mails.LOG)
-                            .error(e)
+                            .error(exception)
                             .handle();
         }
     }
@@ -536,10 +536,10 @@ public class MailSender {
         }
     }
 
-    private void logInvalidAddress(Exception e, String nlsKey, String name, String email) {
+    private void logInvalidAddress(Exception exception, String nlsKey, String name, String email) {
         throw Exceptions.handle()
                         .to(Mails.LOG)
-                        .error(e)
+                        .error(exception)
                         .withNLSKey(nlsKey)
                         .set("address", Strings.isFilled(name) ? email + " (" + name + ")" : email)
                         .handle();
@@ -614,6 +614,15 @@ public class MailSender {
      * @return the language
      */
     public String getLang() {
-        return lang;
+        return getLanguage();
+    }
+
+    /**
+     * Returns the language which is set for the mail for example to set NLS-keys in the context to the right language.
+     *
+     * @return the language
+     */
+    public String getLanguage() {
+        return language;
     }
 }

--- a/src/main/java/sirius/web/mails/MailSender.java
+++ b/src/main/java/sirius/web/mails/MailSender.java
@@ -449,11 +449,11 @@ public class MailSender {
      * of invalid settings (bad mail address etc.).
      */
     public void send() {
-        String tmpLang = NLS.getCurrentLang();
+        String tmpLanguage = NLS.getCurrentLanguage();
         try {
             try {
                 if (lang != null) {
-                    CallContext.getCurrent().setLang(lang);
+                    CallContext.getCurrent().setLanguage(lang);
                 }
                 render();
                 buildSubject();
@@ -461,7 +461,7 @@ public class MailSender {
                 check();
                 sendMailAsync();
             } finally {
-                CallContext.getCurrent().setLang(tmpLang);
+                CallContext.getCurrent().setLanguage(tmpLanguage);
             }
         } catch (HandledException e) {
             throw e;

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -410,7 +410,7 @@ public abstract class GenericUserManager implements UserManager {
                                .withUsername(computeUsername(webContext, userId.asString()))
                                .withTenantId(tenantId)
                                .withTenantName(computeTenantname(webContext, tenantId))
-                               .withLang(computeLang(webContext, userId.asString()))
+                               .withLanguage(computeLang(webContext, userId.asString()))
                                .withPermissions(roles)
                                .withSettingsSupplier(user -> getUserSettings(getScopeSettings(), user))
                                .withSubScopeCheck(this::checkSubScope)

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -410,7 +410,7 @@ public abstract class GenericUserManager implements UserManager {
                                .withUsername(computeUsername(webContext, userId.asString()))
                                .withTenantId(tenantId)
                                .withTenantName(computeTenantname(webContext, tenantId))
-                               .withLanguage(computeLang(webContext, userId.asString()))
+                               .withLanguage(computeLanguage(webContext, userId.asString()))
                                .withPermissions(roles)
                                .withSettingsSupplier(user -> getUserSettings(getScopeSettings(), user))
                                .withSubScopeCheck(this::checkSubScope)
@@ -495,7 +495,7 @@ public abstract class GenericUserManager implements UserManager {
      * @return the language code for the user
      */
     @Nonnull
-    protected abstract String computeLang(WebContext webContext, String userId);
+    protected abstract String computeLanguage(WebContext webContext, String userId);
 
     /**
      * Removes all stored user information from the current session.

--- a/src/main/java/sirius/web/security/PublicUserManager.java
+++ b/src/main/java/sirius/web/security/PublicUserManager.java
@@ -102,7 +102,7 @@ public class PublicUserManager extends GenericUserManager {
 
     @Nonnull
     @Override
-    protected String computeLang(WebContext webContext, String userId) {
+    protected String computeLanguage(WebContext webContext, String userId) {
         String language = scope.getDefaultLanguageOrFallback();
         return AUTO_LANGUAGE.equals(language) ? NLS.getSystemLanguage() : language;
     }

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * The scope is determined using the installed {@link sirius.web.security.ScopeDetector} (Any class
  * implementing the interface and wearing a {@link sirius.kernel.di.std.Register} annotation will do.)
  * <p>
- * The current scope is used to determine which {@link sirius.web.security.UserManager} is used. Therefore
+ * The current scope is used to determine which {@link sirius.web.security.UserManager} is used. Therefore,
  * a system consisting of a backend and frontend can use distinct scopes and a different user manager for each.
  */
 public class ScopeInfo extends Composable {
@@ -402,7 +402,7 @@ public class ScopeInfo extends Composable {
     /**
      * Returns the default config for all scopes.
      * <p>
-     * This is built by loading all <tt>scope-*.conf</tt> files. Additionally the <tt>scope-settings.conf</tt> for
+     * This is built by loading all <tt>scope-*.conf</tt> files. Additionally, the <tt>scope-settings.conf</tt> for
      * all active customizations are used as well (if present).
      *
      * @return the default config object shared by all scopes
@@ -575,7 +575,7 @@ public class ScopeInfo extends Composable {
      * Checks if the given language is supported. Returns the default language otherwise.
      * <p>
      * Note that if the given language is empty or <tt>null</tt>, this method will also return <tt>null</tt> as a call
-     * to {@link sirius.kernel.async.CallContext#setLang(String)} with <tt>null</tt> as parameter won't change
+     * to {@link sirius.kernel.async.CallContext#setLanguage(String)} with <tt>null</tt> as parameter won't change
      * the language at all.
      *
      * @param language the language to check
@@ -591,7 +591,7 @@ public class ScopeInfo extends Composable {
      * Checks if the given language is supported. Returns the default language otherwise.
      * <p>
      * Note that if the given language is empty or <tt>null</tt>, this method will also return <tt>null</tt> as a call
-     * to {@link sirius.kernel.async.CallContext#setLang(String)} with <tt>null</tt> as parameter won't change
+     * to {@link sirius.kernel.async.CallContext#setLanguage(String)} with <tt>null</tt> as parameter won't change
      * the language at all.
      *
      * @param language the language to check

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -267,7 +267,7 @@ public class UserContext implements SubContext {
         CallContext call = CallContext.getCurrent();
         call.addToMDC(MDC_USER_ID, currentUser::getUserId);
         call.addToMDC(MDC_USER_NAME, currentUser::getUserName);
-        call.setLanguageIfEmpty(currentUser.getLang());
+        call.setLanguageIfEmpty(currentUser.getLanguage());
     }
 
     /**

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -186,7 +186,7 @@ public class UserContext implements SubContext {
         if (webContext != null && webContext.isValid() && detector != null) {
             ScopeInfo scope = detector.detectScope(webContext);
             setCurrentScope(scope);
-            CallContext.getCurrent().setLanguageIfEmpty(scope.getLang());
+            CallContext.getCurrent().setLanguageIfEmpty(scope.getLanguage());
         } else {
             setCurrentScope(ScopeInfo.DEFAULT_SCOPE);
         }

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -186,7 +186,7 @@ public class UserContext implements SubContext {
         if (ctx != null && ctx.isValid() && detector != null) {
             ScopeInfo scope = detector.detectScope(ctx);
             setCurrentScope(scope);
-            CallContext.getCurrent().setLangIfEmpty(scope.getLang());
+            CallContext.getCurrent().setLanguageIfEmpty(scope.getLang());
         } else {
             setCurrentScope(ScopeInfo.DEFAULT_SCOPE);
         }

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -43,20 +43,20 @@ import java.util.Optional;
 public class UserContext implements SubContext {
 
     /**
-     * The key used to store the current scope in the MDC
+     * The key used to store the current scope in the MDC.
      */
     public static final String MDC_SCOPE = "scope";
     /**
-     * The key used to store the current user id in the MDC
+     * The key used to store the current user id in the MDC.
      */
     public static final String MDC_USER_ID = "userId";
     /**
-     * The key used to store the current user name in the MDC
+     * The key used to store the current username in the MDC.
      */
     public static final String MDC_USER_NAME = "username";
 
     /**
-     * Contains the logger <tt>user</tt> used by the auth framework
+     * Contains the logger <tt>user</tt> used by the auth framework.
      */
     public static final Log LOG = Log.get("user");
 
@@ -83,7 +83,7 @@ public class UserContext implements SubContext {
 
     private ScopeInfo currentScope = null;
     private boolean fetchingCurrentScope = false;
-    private List<Message> msgList = new ArrayList<>();
+    private List<Message> messages = new ArrayList<>();
     private Map<String, String> fieldErrors = new HashMap<>();
     private Map<String, String> fieldErrorMessages = new HashMap<>();
     private boolean addedAdditionalMessages = false;
@@ -122,7 +122,7 @@ public class UserContext implements SubContext {
     /**
      * Returns the helper of the given class for the current scope.
      * <p>
-     * NOTE: This helper is per {@link ScopeInfo} not per {@link UserInfo}! Therefore no user dependent data may be kept
+     * NOTE: This helper is per {@link ScopeInfo} not per {@link UserInfo}! Therefore, no user dependent data may be kept
      * in its state.
      *
      * @param helperType the type of the helper to fetch
@@ -163,10 +163,10 @@ public class UserContext implements SubContext {
     /**
      * Adds a message to the current UserContext.
      *
-     * @param msg the message to add
+     * @param message the message to add
      */
-    public static void message(Message msg) {
-        get().addMessage(msg);
+    public static void message(Message message) {
+        get().addMessage(message);
     }
 
     /**
@@ -182,9 +182,9 @@ public class UserContext implements SubContext {
     /*
      * Loads the current scope from the given web context.
      */
-    private void bindScopeToRequest(WebContext ctx) {
-        if (ctx != null && ctx.isValid() && detector != null) {
-            ScopeInfo scope = detector.detectScope(ctx);
+    private void bindScopeToRequest(WebContext webContext) {
+        if (webContext != null && webContext.isValid() && detector != null) {
+            ScopeInfo scope = detector.detectScope(webContext);
             setCurrentScope(scope);
             CallContext.getCurrent().setLanguageIfEmpty(scope.getLang());
         } else {
@@ -195,9 +195,9 @@ public class UserContext implements SubContext {
     /*
      * Loads the current user from the given web context.
      */
-    private void bindUserToRequest(WebContext ctx) {
-        if (ctx != null && ctx.isValid()) {
-            setCurrentUser(getUserManager().bindToRequest(ctx));
+    private void bindUserToRequest(WebContext webContext) {
+        if (webContext != null && webContext.isValid()) {
+            setCurrentUser(getUserManager().bindToRequest(webContext));
         } else {
             setCurrentUser(UserInfo.NOBODY);
         }
@@ -209,11 +209,11 @@ public class UserContext implements SubContext {
      * If no user is available (currently logged in) nothing will happen. User {@link #getUser()}
      * to fully bind a user and attempt a login.
      *
-     * @param ctx the current web context to bind against
+     * @param webContext the current web context to bind against
      * @return the user which was found in the session or an empty optional if none is present
      */
-    public Optional<UserInfo> bindUserIfPresent(WebContext ctx) {
-        if (ctx == null || !ctx.isValid()) {
+    public Optional<UserInfo> bindUserIfPresent(WebContext webContext) {
+        if (webContext == null || !webContext.isValid()) {
             return Optional.empty();
         }
 
@@ -228,7 +228,7 @@ public class UserContext implements SubContext {
         }
 
         UserManager manager = getUserManager();
-        UserInfo user = manager.findUserForRequest(ctx);
+        UserInfo user = manager.findUserForRequest(webContext);
         if (user.isLoggedIn()) {
             setCurrentUser(user);
             return Optional.of(user);
@@ -267,7 +267,7 @@ public class UserContext implements SubContext {
         CallContext call = CallContext.getCurrent();
         call.addToMDC(MDC_USER_ID, currentUser::getUserId);
         call.addToMDC(MDC_USER_NAME, currentUser::getUserName);
-        call.setLangIfEmpty(currentUser.getLang());
+        call.setLanguageIfEmpty(currentUser.getLang());
     }
 
     /**
@@ -282,11 +282,11 @@ public class UserContext implements SubContext {
         UserInfo lastUser = getCurrentUser();
         CallContext call = CallContext.getCurrent();
         try {
-            call.resetLang();
+            call.resetLanguage();
             setCurrentUser(user);
             section.run();
         } finally {
-            call.resetLang();
+            call.resetLanguage();
             setCurrentUser(lastUser);
         }
     }
@@ -294,10 +294,10 @@ public class UserContext implements SubContext {
     /**
      * Adds a message to be shown to the user.
      *
-     * @param msg the message to be shown to the user
+     * @param message the message to be shown to the user
      */
-    public void addMessage(Message msg) {
-        msgList.add(msg);
+    public void addMessage(Message message) {
+        messages.add(message);
     }
 
     /**
@@ -320,7 +320,7 @@ public class UserContext implements SubContext {
             messageProviders.forEach(provider -> provider.addMessages(this::addMessage));
         }
 
-        return Collections.unmodifiableList(msgList);
+        return Collections.unmodifiableList(messages);
     }
 
     /**
@@ -329,7 +329,7 @@ public class UserContext implements SubContext {
      * @return a list of "real" messages which were created while processing the current request
      */
     public List<Message> getUserSpecificMessages() {
-        return Collections.unmodifiableList(msgList);
+        return Collections.unmodifiableList(messages);
     }
 
     /**
@@ -524,12 +524,12 @@ public class UserContext implements SubContext {
      * This can be considered a <tt>logout</tt>.
      */
     public void detachUserFromSession() {
-        WebContext ctx = CallContext.getCurrent().get(WebContext.class);
-        if (!ctx.isValid()) {
+        WebContext webContext = CallContext.getCurrent().get(WebContext.class);
+        if (!webContext.isValid()) {
             return;
         }
         UserManager manager = getUserManager();
-        manager.logout(ctx);
+        manager.logout(webContext);
     }
 
     /**
@@ -558,12 +558,12 @@ public class UserContext implements SubContext {
     @Override
     public SubContext fork() {
         // We return a copy which keeps the same user and scope - but which can be change independently.
-        // Otherwise a UserContext.runAs(...) which forks a task, would run into trouble as the
+        // Otherwise, a UserContext.runAs(...) which forks a task, would run into trouble as the
         // context is immediately switched back.
         UserContext child = new UserContext();
         child.currentUser = currentUser;
         child.currentScope = currentScope;
-        child.msgList = msgList;
+        child.messages = messages;
         child.fieldErrors = fieldErrors;
         child.fieldErrorMessages = fieldErrorMessages;
         child.addedAdditionalMessages = addedAdditionalMessages;

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -155,12 +155,22 @@ public class UserInfo extends Composable {
         /**
          * Sets the language code of the user.
          *
-         * @param lang a two-letter language code which should be understood by {@link sirius.kernel.nls.NLS}.
+         * @param language a two-letter language code which should be understood by {@link sirius.kernel.nls.NLS}.
          * @return the builder itself for fluent method calls
          */
-        public Builder withLang(String lang) {
+        public Builder withLang(String language) {
+            return withLanguage(language);
+        }
+
+        /**
+         * Sets the language code of the user.
+         *
+         * @param language a two-letter language code which should be understood by {@link sirius.kernel.nls.NLS}.
+         * @return the builder itself for fluent method calls
+         */
+        public Builder withLanguage(String language) {
             verifyState();
-            user.lang = lang;
+            user.lang = language;
             return this;
         }
 
@@ -292,6 +302,15 @@ public class UserInfo extends Composable {
      * @return the two-letter language code of the user
      */
     public String getLang() {
+        return getLanguage();
+    }
+
+    /**
+     * The language code of the user.
+     *
+     * @return the two-letter language code of the user
+     */
+    public String getLanguage() {
         return lang;
     }
 

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -49,7 +49,7 @@ public class UserInfo extends Composable {
     protected String tenantName;
     protected String userId;
     protected String username;
-    protected String lang;
+    protected String language;
     protected Set<String> permissions = new HashSet<>();
     protected boolean hasEveryPermission = false;
     protected Supplier<String> nameAppendixSupplier;
@@ -88,7 +88,7 @@ public class UserInfo extends Composable {
          * @return the builder itself for fluent method calls
          */
         public static Builder withUser(@Nonnull UserInfo info) {
-            return createUser(info.getUserId()).withLang(info.getLang())
+            return createUser(info.getUserId()).withLanguage(info.getLanguage())
                                                .withUsername(info.getUserName())
                                                .withNameAppendixSupplier(info.getNameAppendixSupplier())
                                                .withTenantId(info.getTenantId())
@@ -170,7 +170,7 @@ public class UserInfo extends Composable {
          */
         public Builder withLanguage(String language) {
             verifyState();
-            user.lang = language;
+            user.language = language;
             return this;
         }
 
@@ -311,7 +311,7 @@ public class UserInfo extends Composable {
      * @return the two-letter language code of the user
      */
     public String getLanguage() {
-        return lang;
+        return language;
     }
 
     /**

--- a/src/main/java/sirius/web/templates/DefaultGlobalContextExtender.java
+++ b/src/main/java/sirius/web/templates/DefaultGlobalContextExtender.java
@@ -58,7 +58,7 @@ public class DefaultGlobalContextExtender implements GlobalContextExtender {
         parameterCollector.collect("isDev", Sirius.isDev());
         parameterCollector.collect("call", ctx.get(WebContext.class));
         parameterCollector.collect("watch", ctx.getWatch());
-        parameterCollector.collect("lang", NLS.getCurrentLang());
+        parameterCollector.collect("lang", NLS.getCurrentLanguage());
         parameterCollector.collect("contentHelper", ContentHelper.INSTANCE);
         parameterCollector.collect("wondergemRoot", wondergemRoot, String.class);
         parameterCollector.collect("tychoRoot", wondergemRoot, String.class);


### PR DESCRIPTION
BREAKING CHANGE:
- Subclasses of `UserInfo` that access the internal `lang` (without using the getter function) have to be changed to access the `language` field, as it was renamed.
- Subclasses of `ScopeInfo` that access the internal `lang` (without using the getter function) have to be changed to access the `language` field, as it was renamed.
- Subclasses of `GenericUserManager` that overwrite the internal `computeLang` have to be changed to overwrite the `computeLanguage` method instead, as it was renamed.