### PR TITLE
ServiceCall: Properly handles `ClosedChannelExceptions`

### DIFF
--- a/src/main/java/sirius/web/services/ServiceCall.java
+++ b/src/main/java/sirius/web/services/ServiceCall.java
@@ -152,7 +152,7 @@ public abstract class ServiceCall {
                 ServiceCall.LOG.WARN("""
                                              Cannot send service error for: %s - %s
                                              A partially successful response has already been created and committed!
-                                                                                          
+
                                              %s
                                              """,
                                      ctx.getRequest().uri(),

--- a/src/main/java/sirius/web/services/ServiceCall.java
+++ b/src/main/java/sirius/web/services/ServiceCall.java
@@ -139,19 +139,24 @@ public abstract class ServiceCall {
         try {
             StructuredOutput output = createOutput();
             serv.call(this, output);
-        } catch (ClosedChannelException ex) {
-            // If the user unexpectedly closes the connection, we do not need to log an error...
-            Exceptions.ignore(ex);
         } catch (Exception exception) {
+            if (exception instanceof ClosedChannelException || exception.getCause() instanceof ClosedChannelException) {
+                // If the user unexpectedly closes the connection, we do not need to log an error...
+                Exceptions.ignore(exception);
+                return;
+            }
+
             HandledException handledException = handle(exception);
 
             if (ctx.isResponseCommitted()) {
                 ServiceCall.LOG.WARN("""
                                              Cannot send service error for: %s - %s
                                              A partially successful response has already been created and committed!
-                                             
+                                                                                          
                                              %s
-                                             """, ctx.getRequest().uri(), exception.getMessage(),
+                                             """,
+                                     ctx.getRequest().uri(),
+                                     exception.getMessage(),
                                      ExecutionPoint.snapshot().toString());
 
                 // Force underlying request / response to be closed...


### PR DESCRIPTION
This is a cherry-pick of #1146 