### PR TITLE
Properly links to the /licenses page in the footer.

### DIFF
--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -36,7 +36,7 @@ product {
     }
 
     # Contains the tag line show in the footer and login screen
-    tagLine = "This Product is based on <a href=\"http://sirius-lib.net\">Sirius Lib</a>"
+    tagLine = "This Product is based on <a href=\"http://sirius-lib.net\">Sirius Lib</a> | <a href=\"/licenses\">Licenses</a>"
 
     # Determines if base URI of Tycho. Used for links to "home"...
     tychoRoot = "/"


### PR DESCRIPTION
Although this setting will most probably be overwritten in all products, this is at least a good source of inspiration...