### PR TITLE
Adds margin bottom to the dropzone bar/indicator in order to improve the look and feel of the bar

### DIFF
--- a/src/main/resources/default/taglib/t/fileUpload.html.pasta
+++ b/src/main/resources/default/taglib/t/fileUpload.html.pasta
@@ -42,7 +42,7 @@
         maxFilesize: null,
         acceptedFiles: '@raw {@acceptedFiles}' || null,
         previewTemplate: '' +
-            '<div class="dropzone-item">\n' +
+            '<div class="dropzone-item mb-3">\n' +
             '   <div class="dropzone-file">\n' +
             '       <div class="dropzone-filename">\n' +
             '           <span data-dz-name></span>\n' +


### PR DESCRIPTION
Before:
![Bildschirm­foto 2023-01-28 um 00 23 38](https://user-images.githubusercontent.com/106659278/215224323-cd26ea42-f127-48b2-8e1e-cccf9078045f.png)

After:
![Bildschirm­foto 2023-01-28 um 00 24 07](https://user-images.githubusercontent.com/106659278/215224360-9d6f6433-121b-4ebe-bc15-edcf4576bb4f.png)

Fixes: [9321](https://scireum.myjetbrains.com/youtrack/issue/OX-9321/Video-Modernisierung-Backend-User-Interface-Teil-3-Weitere-Seiten)