### PR TITLE
Overhauls the security sandbox of Noodle

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
@@ -8,8 +8,8 @@
 
 package sirius.pasta.noodle.compiler;
 
-import sirius.kernel.tokenizer.Position;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.InterpreterCall;
 import sirius.pasta.noodle.Invocation;
 import sirius.pasta.noodle.OpCode;
@@ -29,8 +29,8 @@ public class Assembler {
     /**
      * Represents the maximum internal index or offset which can be encoded in a bytecode.
      * <p>
-     * A bytecode is a 32 bit integer, where the 16 "MSBs" are used to encode the {@link OpCode} and
-     * the lower 16 bits are used to store the index, we cannot store more than 2^16.
+     * A bytecode is a 32-bit integer, where the 16 "MSBs" are used to encode the {@link OpCode} and
+     * the lower 16 bits are used to store the index (we cannot store more than 2^16).
      */
     private static final int MAX_INDEX = (1 << 16) - 1;
 
@@ -38,6 +38,7 @@ public class Assembler {
      * Represents a label which can be used to generate a jump instruction to jump to the label.
      */
     public class Label {
+
         protected int id;
         protected int targetIP = -1;
         protected List<Integer> waitingIPs = new ArrayList<>();

--- a/src/main/java/sirius/pasta/noodle/compiler/LegacyGlobalsHandler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/LegacyGlobalsHandler.java
@@ -51,7 +51,7 @@ public abstract class LegacyGlobalsHandler {
             return result;
         }
 
-        result = compileReplacement(name);
+        result = compileReplacement(name, compilationContext);
         if (result != null) {
             cache.put(name, result);
         }
@@ -59,7 +59,7 @@ public abstract class LegacyGlobalsHandler {
         return result;
     }
 
-    protected Tuple<String, Node> compileReplacement(String name) {
+    protected Tuple<String, Node> compileReplacement(String name, CompilationContext compilationContext) {
         String replacementText = determineReplacement(name);
         if (replacementText == null) {
             return null;
@@ -67,6 +67,7 @@ public abstract class LegacyGlobalsHandler {
 
         CompilationContext context = new CompilationContext(new SourceCodeInfo(getClass().getSimpleName(),
                                                                                getClass().getName(),
+                                                                               compilationContext.getSandboxMode(),
                                                                                () -> new StringReader(replacementText)));
         Parser parser = new Parser(context, context.getSourceCodeInfo().createReader());
         Tuple<String, Node> result = Tuple.create(replacementText, parser.parseExpression(true));

--- a/src/main/java/sirius/pasta/noodle/compiler/LegacyGlobalsHandler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/LegacyGlobalsHandler.java
@@ -25,11 +25,11 @@ import java.util.Map;
  * <p>
  * If previous versions of <tt>Tagliatelle</tt> there were <tt>GlobalContextExtenders</tt>. These could
  * provide magic global variables which were "just there". This proved to be confusing and a maintenance
- * nightmare. Now with a more powerful expression system we can replace these varibles with appropriate
+ * nightmare. Now with a more powerful expression system we can replace these variables with appropriate
  * expressions so that legacy templates remain compilable. However, we log a warning so that one can
  * easily identify the places to update.
  * <p>
- * To provide a custom handler, sub class this and add a {@link sirius.kernel.di.std.Register} annotation to it.
+ * To provide a custom handler, subclass this and add a {@link sirius.kernel.di.std.Register} annotation to it.
  */
 @AutoRegister
 public abstract class LegacyGlobalsHandler {

--- a/src/main/java/sirius/pasta/noodle/compiler/SourceCodeInfo.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/SourceCodeInfo.java
@@ -17,6 +17,8 @@ import sirius.pasta.noodle.sandbox.Sandbox;
 import sirius.pasta.noodle.sandbox.SandboxMode;
 import sirius.web.resources.Resource;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -76,10 +78,28 @@ public class SourceCodeInfo {
     }
 
     /**
+     * Creates a new instance representing custom named code.
+     * <p>
+     * If no sandbox mode is given, the {@link sirius.pasta.noodle.sandbox.Sandbox sandbox} is usef, if enabled for this
+     * system.
+     *
+     * @param code the code to wrap
+     * @return the newly created source code info
+     */
+    public static SourceCodeInfo forCustomCode(@Nonnull String name,
+                                               @Nonnull String code,
+                                               @Nullable SandboxMode sandboxMode) {
+        return new SourceCodeInfo(name,
+                                  null,
+                                  sandboxMode != null ? sandboxMode : sandbox.getMode(),
+                                  () -> new StringReader(code));
+    }
+
+    /**
      * Creates a new instance representing inline or ad-hoc source code.
      * <p>
      * Note that this will enable the built-in {@link sirius.pasta.noodle.sandbox.Sandbox sandbox} if enabled for this
-     * system
+     * system.
      *
      * @param code the code to wrap
      * @return the newly created source code info

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MacroCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MacroCall.java
@@ -8,9 +8,9 @@
 
 package sirius.pasta.noodle.compiler.ir;
 
-import sirius.kernel.tokenizer.Position;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.OpCode;
 import sirius.pasta.noodle.compiler.Assembler;
 import sirius.pasta.noodle.compiler.CompilationContext;
@@ -18,11 +18,14 @@ import sirius.pasta.noodle.macros.HelperMacro;
 import sirius.pasta.noodle.macros.I18nMacro;
 import sirius.pasta.noodle.macros.Macro;
 import sirius.pasta.noodle.macros.UserMacro;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
+import sirius.pasta.noodle.sandbox.Sandbox;
+import sirius.pasta.noodle.sandbox.SandboxMode;
 import sirius.web.security.UserInfo;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -156,13 +159,22 @@ public class MacroCall extends Call {
                                        macro.getClass().getName());
         }
 
-        if (compilationContext.isSandboxEnabled() && !macro.getClass().isAnnotationPresent(PublicApi.class)) {
-            compilationContext.error(position,
-                                     "The macro %s (%s) cannot be accessed due to sandbox restrictions.",
-                                     macro.getName(),
-                                     macro.getClass().getName());
-            this.macro = null;
-        }
+        compilationContext.ifEnforceSandbox(() -> Optional.ofNullable(macro.getClass().getAnnotation(NoodleSandbox.class))
+                                                    .filter(annotation -> !Sandbox.isAccessGranted(annotation))
+                                                    .isPresent(), mode -> {
+            if (mode == SandboxMode.ENABLED) {
+                compilationContext.error(position,
+                                         "The macro %s (%s) cannot be accessed due to sandbox restrictions.",
+                                         macro.getName(),
+                                         macro.getClass().getName());
+                this.macro = null;
+            } else if (mode == SandboxMode.WARN_ONLY) {
+                compilationContext.warning(position,
+                                           "The macro %s (%s) cannot be accessed due to sandbox restrictions.",
+                                           macro.getName(),
+                                           macro.getClass().getName());
+            }
+        });
 
         return macro != null;
     }

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/PushField.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/PushField.java
@@ -13,7 +13,9 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.pasta.noodle.OpCode;
 import sirius.pasta.noodle.compiler.Assembler;
+import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.TypeTools;
+import sirius.pasta.noodle.sandbox.SandboxMode;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -33,9 +35,23 @@ public class PushField extends Node {
      * @param position the position in the source code
      * @param field    the field to push
      */
-    public PushField(Position position, Field field) {
+    public PushField(CompilationContext compilationContext, Position position, Field field) {
         super(position);
         this.field = field;
+
+        if (!Modifier.isPublic(field.getModifiers())) {
+            if (compilationContext.getSandboxMode() == SandboxMode.ENABLED) {
+                compilationContext.error(position,
+                              "The field '%s' of '%s' is not public accessible.",
+                              field.getName(),
+                              field.getDeclaringClass().getName());
+            } else if (compilationContext.getSandboxMode() == SandboxMode.WARN_ONLY) {
+                compilationContext.warning(position,
+                                "The field '%s' of '%s' is not public accessible.",
+                                field.getName(),
+                                field.getDeclaringClass().getName());
+            }
+        }
     }
 
     public Node getSelfExpression() {

--- a/src/main/java/sirius/pasta/noodle/macros/ApplyMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ApplyMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.List;
  * @see Strings#apply(String, Object...)
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class ApplyMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/BlockwiseMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/BlockwiseMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import java.util.List;
  * be a solution as well but is not fully supported on all relevant platforms yet.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class BlockwiseMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/EnumValuesMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EnumValuesMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -23,7 +23,7 @@ import java.util.List;
  * Returns all values of a given enum class.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class EnumValuesMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/EpochTimeInDaysMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EpochTimeInDaysMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
  * Gets the current time since 1970 in days.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class EpochTimeInDaysMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/EscapeJsMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EscapeJsMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.resources.Resources;
 
 import javax.annotation.Nonnull;
@@ -27,7 +27,7 @@ import java.util.List;
  * in JavaScript.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class EscapeJsMacro extends BasicMacro {
 
     @Part

--- a/src/main/java/sirius/pasta/noodle/macros/FormatDateMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatDateMacro.java
@@ -15,7 +15,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDate;
@@ -31,7 +31,7 @@ import java.util.List;
  * {@link Value#asLocalDate(LocalDate)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class FormatDateMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/FormatDateTimeWithoutSecondsMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatDateTimeWithoutSecondsMacro.java
@@ -12,7 +12,7 @@ import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.temporal.TemporalAccessor;
@@ -26,7 +26,7 @@ import java.util.Date;
  * via {@link Value#asLocalDateTime(java.time.LocalDateTime)} and using {@link NLS#getCurrentLanguage()}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class FormatDateTimeWithoutSecondsMacro extends FormatDateMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/FormatIsoMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatIsoMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDate;
@@ -38,7 +38,7 @@ import java.util.List;
  * </table>
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class FormatIsoMacro extends BasicMacro {
 
     private static final DateTimeFormatter ISO_LOCAL_YEAR =

--- a/src/main/java/sirius/pasta/noodle/macros/FormatMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.nls.Formatter;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Permits to create a new {@link Formatter} via a <tt>{@literal @}format(pattern)</tt>.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class FormatMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/FormatSizeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatSizeMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>formatSize(long)</tt> which is a call to {@link NLS#formatSize(long)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class FormatSizeMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/FormatTimeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatTimeMacro.java
@@ -12,7 +12,7 @@ import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalTime;
@@ -27,7 +27,7 @@ import java.util.Date;
  * {@link Value#asLocalTime(LocalTime)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class FormatTimeMacro extends FormatDateMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/HelperMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/HelperMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.security.UserContext;
 
 import javax.annotation.Nonnull;
@@ -28,7 +28,7 @@ import java.util.List;
  * therefore be quite efficient anyway.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class HelperMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/I18nMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/I18nMacro.java
@@ -15,7 +15,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.List;
  * Represents <tt>i18n(String)</tt> which is essentially a call to {@link NLS#get(String)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class I18nMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/IsAfterMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsAfterMacro.java
@@ -11,7 +11,7 @@ package sirius.pasta.noodle.macros;
 import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDateTime;
@@ -21,7 +21,7 @@ import java.util.List;
  * Checks whether a given date is after another given date or now.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class IsAfterMacro extends DateComparingBaseMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/IsBeforeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsBeforeMacro.java
@@ -11,7 +11,7 @@ package sirius.pasta.noodle.macros;
 import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDateTime;
@@ -21,7 +21,7 @@ import java.util.List;
  * Checks whether a given date is before another given date or now.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class IsBeforeMacro extends DateComparingBaseMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/IsFilledMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsFilledMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>isFilled(Object)</tt> which is a call to {@link Strings#isFilled(Object)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class IsFilledMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/IsFrameworkEnabledMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsFrameworkEnabledMacro.java
@@ -15,7 +15,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.List;
  * <tt>true</tt> if one of the given frameworks is enabled.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class IsFrameworkEnabledMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/JoinMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/JoinMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>join(Iterable, String)</tt> which is a call to {@link Strings#join(Iterable, String)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class JoinMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/JsonMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/JsonMacro.java
@@ -15,7 +15,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.List;
  * Parses the given JSON string into a {@link JSONObject}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class JsonMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/LeftPadMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/LeftPadMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.List;
  * @see Strings#leftPad(String, String, int)
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class LeftPadMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/LimitMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/LimitMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -26,7 +26,7 @@ import java.util.List;
  * @see Strings#limit(Object, int, boolean)
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class LimitMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/LinkBuilderMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/LinkBuilderMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.util.LinkBuilder;
 
 import javax.annotation.Nonnull;
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * Permits to create a {@link LinkBuilder} by using <tt>{@literal @}linkBuilder</tt> within a Tagliatelle template.
  */
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 @Register
 public class LinkBuilderMacro extends BasicMacro {
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/Macro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/Macro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Named;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import java.util.List;
 
@@ -22,7 +22,7 @@ import java.util.List;
  * Represents a macro or constant function.
  * <p>
  * Note that {@link BasicMacro} is a base class which simplifies writing macros. Also note that if a macro is safe
- * to be called from custom code (provided by users of the system), {@link PublicApi}
+ * to be called from custom code (provided by users of the system), {@link NoodleSandbox}
  * should be added as annotation to the class.
  */
 @AutoRegister

--- a/src/main/java/sirius/pasta/noodle/macros/MonthNameMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/MonthNameMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>monthName(int)</tt> which is a call to {@link NLS#getMonthName(int)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class MonthNameMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/NowMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/NowMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDateTime;
@@ -23,7 +23,7 @@ import java.util.List;
  * Provides a shortcut for calling {@link LocalDateTime#now()}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class NowMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/PartMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/PartMacro.java
@@ -8,14 +8,13 @@
 
 package sirius.pasta.noodle.macros;
 
-import sirius.kernel.tokenizer.Position;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.Injector;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.List;
  * this is a constant call and will be optimized away entirely.
  */
 @Register
-@PublicApi
 public class PartMacro extends BasicMacro {
 
     @Override
@@ -82,5 +80,4 @@ public class PartMacro extends BasicMacro {
     public boolean isConstant(CompilationContext context, List<Node> args) {
         return true;
     }
-
 }

--- a/src/main/java/sirius/pasta/noodle/macros/PartMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/PartMacro.java
@@ -15,6 +15,7 @@ import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
  * this is a constant call and will be optimized away entirely.
  */
 @Register
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class PartMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/RightPadMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/RightPadMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.List;
  * @see Strings#rightPad(String, String, int)
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class RightPadMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/SmartTranslateMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/SmartTranslateMacro.java
@@ -15,7 +15,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.List;
  * Represents <tt>smartTranslate(String)</tt> which is essentially a call to {@link NLS#smartGet(String)}}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class SmartTranslateMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/ToListMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToListMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -24,7 +24,7 @@ import java.util.List;
  * expanded into the list instead.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class ToListMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/ToMachineStringMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToMachineStringMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>toMachineString(Object)</tt> which is a call to {@link NLS#toMachineString(Object)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class ToMachineStringMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/ToSpokenDateMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToSpokenDateMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.temporal.Temporal;
@@ -24,7 +24,7 @@ import java.util.List;
  * Represents <tt>toSpokenDate(Temporal)</tt> which is a call to {@link NLS#toSpokenDate(Temporal)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class ToSpokenDateMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/ToUserStringMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToUserStringMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.nls.NLS;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>toUserString(Object)</tt> which is a call to {@link NLS#toUserString(Object)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class ToUserStringMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/TodayMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/TodayMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDate;
@@ -23,7 +23,7 @@ import java.util.List;
  * Provides a shortcut for calling {@link LocalDate#now()}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class TodayMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/UrlEncodeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/UrlEncodeMacro.java
@@ -14,7 +14,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  * Represents <tt>urlEncode(String)</tt> which is a call to {@link Strings#urlEncode(String)}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class UrlEncodeMacro extends BasicMacro {
     @Override
     public Class<?> getType() {

--- a/src/main/java/sirius/pasta/noodle/macros/UserMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/UserMacro.java
@@ -13,7 +13,7 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
 
@@ -27,7 +27,7 @@ import java.util.List;
  * {@link sirius.pasta.noodle.OpCode#INTRINSIC_USER_CONTEXT_CURRENT_USER} and therefore be quite efficient anyway.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class UserMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/macros/XmlMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/XmlMacro.java
@@ -15,7 +15,7 @@ import sirius.kernel.xml.StructuredNode;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.List;
  * Parses the given XML string into a {@link StructuredNode}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class XmlMacro extends XmlProcessingMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/noodle/sandbox/NoodleSandbox.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/NoodleSandbox.java
@@ -21,5 +21,23 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
-public @interface PublicApi {
+public @interface NoodleSandbox {
+
+    /**
+     * Controls the accessibility of the annotated element.
+     * <p>
+     * <tt>GRANTED</tt> is probably the default case, however, if a whole class is granted, <tt>REJECTED</tt>
+     * can be used to overwrite this (as annotations on methods and fields win over ones on classes).
+     */
+    enum Accessibility {
+        GRANTED, REJECTED
+    }
+
+    /**
+     * Specifies the accessibility value.
+     *
+     * @return <tt>@{@link Accessibility#GRANTED}</tt> to grant access or @{@link Accessibility#REJECTED} to reject
+     * existing access rights.
+     */
+    Accessibility value();
 }

--- a/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
@@ -9,19 +9,22 @@
 package sirius.pasta.noodle.sandbox;
 
 import sirius.kernel.Sirius;
+import sirius.kernel.di.PartCollection;
+import sirius.kernel.di.std.Parts;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 
 import java.lang.reflect.Executable;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
  * Provides a security sandbox in case <tt>Noodle</tt> is compiling a script or template provided by a user.
  * <p>
  * User code may only access methods, macros or fields which have been whitelisted. This can either be
- * performed by placing a {@link PublicApi} annotation or by adding an entry in the system config in
+ * performed by placing a {@link NoodleSandbox} annotation or by adding an entry in the system config in
  * <tt>scripting.sandbox</tt>.
  * <p>
  * Note that the sandbox is applied at compile time and therefore has no runtime overhead at all. Also note that
@@ -31,8 +34,65 @@ import java.util.Set;
 @Register(classes = Sandbox.class)
 public class Sandbox {
 
-    private Set<String> denylist;
-    private Set<String> allowlist;
+    private Set<String> denyList;
+    private Set<String> allowList;
+
+    private SandboxMode mode;
+
+    @Parts(SandboxDetector.class)
+    private PartCollection<SandboxDetector> detectors;
+
+    /**
+     * Determines the global sandbox mode for the system.
+     * <p>
+     * This is read from <tt>scripting.sandbox.mode</tt> in the system configuration.
+     *
+     * @return the currently active sandbox mode
+     */
+    public SandboxMode getMode() {
+        if (mode == null) {
+            mode = Sirius.getSettings()
+                         .get("scripting.sandbox.mode")
+                         .getEnum(SandboxMode.class)
+                         .orElse(SandboxMode.DISABLED);
+        }
+
+        return mode;
+    }
+
+    /**
+     * Determines if the sandbox check should be enforced for the given template.
+     * <p>
+     * For this to happen, the {@link #getMode() mode} has to be anything except <tt>DISABLED</tt> and then a
+     * {@link SandboxDetector} has to mark the given resource as {@link SandboxDetector#shouldSandbox(String)}
+     * (return <tt>true</tt>).
+     *
+     * @param resourcePath the path of the resource to check
+     * @return <tt>true</tt> if the sandbox should be enabled, <tt>false</tt> otherwise
+     */
+    public SandboxMode determineEffectiveSandboxMode(String resourcePath) {
+        String effectiveResourcePath = resourcePath.startsWith("/") ? resourcePath : "/" + resourcePath;
+        
+        if (getMode() != SandboxMode.DISABLED && detectors.getParts()
+                                                          .stream()
+                                                          .anyMatch(detector -> detector.shouldSandbox(
+                                                                  effectiveResourcePath))) {
+            return getMode();
+        }
+
+        return SandboxMode.DISABLED;
+    }
+
+    /**
+     * Determines if the given annotation {@link sirius.pasta.noodle.sandbox.NoodleSandbox.Accessibility#GRANTED grants}
+     * access.
+     *
+     * @param annotation the annotation to check
+     * @return <tt>true</tt> if access is granted, <tt>false</tt> if access is rejected
+     */
+    public static boolean isAccessGranted(NoodleSandbox annotation) {
+        return annotation.value() == NoodleSandbox.Accessibility.GRANTED;
+    }
 
     /**
      * Determines if the given method can be invoked by user code.
@@ -41,62 +101,67 @@ public class Sandbox {
      * @return <tt>true</tt> if it can be invoked, <tt>false</tt> otherwise
      */
     public boolean canInvoke(Executable method) {
-        if (isAllowedViaAnnotation(method)) {
-            return true;
-        }
-
-        return isAllowed(method.getDeclaringClass().getName(), method.getName());
+        return isControlledViaAnnotation(method).orElseGet(() -> isAllowed(method.getDeclaringClass().getName(),
+                                                                           method.getName()));
     }
 
     private boolean isAllowed(String className, String methodName) {
-        if (denylist == null) {
+        if (denyList == null) {
             loadConfig();
         }
-        return !denylist.contains(className + "." + methodName) && (allowlist.contains(className + "." + methodName)
-                                                                    || allowlist.contains(className + ".*"));
+        return !denyList.contains(className + "." + methodName) && (allowList.contains(className + "." + methodName)
+                                                                    || allowList.contains(className + ".*"));
     }
 
     private void loadConfig() {
-        Set<String> newDenylist = new HashSet<>();
-        Set<String> newAllowlist = new HashSet<>();
+        Set<String> newDenyList = new HashSet<>();
+        Set<String> newAllowList = new HashSet<>();
 
-        for (Map.Entry<String, String> entry : Sirius.getSettings().getMap("scripting.sandbox").entrySet()) {
+        for (Map.Entry<String, String> entry : Sirius.getSettings().getMap("scripting.sandbox.rules").entrySet()) {
             if (Boolean.parseBoolean(entry.getValue())) {
-                newAllowlist.add(entry.getKey());
+                newAllowList.add(cleanupKey(entry.getKey()));
             } else {
-                newDenylist.add(entry.getKey());
+                newDenyList.add(cleanupKey(entry.getKey()));
             }
         }
 
-        this.denylist = newDenylist;
-        this.allowlist = newAllowlist;
+        this.denyList = newDenyList;
+        this.allowList = newAllowList;
     }
 
-    private boolean isAllowedViaAnnotation(Executable method) {
-        if (method.isAnnotationPresent(PublicApi.class)) {
-            return true;
-        }
-        if (method.getDeclaringClass().isAnnotationPresent(PublicApi.class)) {
-            return true;
+    private String cleanupKey(String key) {
+        if (key.startsWith("")) {
+            return key.substring(1, key.length() - 1);
         }
 
-        return checkFieldForGetter(method);
+        return key;
     }
 
-    private boolean checkFieldForGetter(Executable method) {
+    private Optional<Boolean> isControlledViaAnnotation(Executable method) {
+        return Optional.ofNullable(method.getAnnotation(NoodleSandbox.class))
+                       .or(() -> Optional.ofNullable(method.getDeclaringClass().getAnnotation(NoodleSandbox.class)))
+                       .map(Sandbox::isAccessGranted)
+                       .or(() -> checkFieldForGetter(method));
+    }
+
+    private Optional<Boolean> checkFieldForGetter(Executable method) {
         try {
             if (method.getName().startsWith("get") || method.getName().startsWith("set")) {
-                String fieldName = method.getName().substring(3, 3).toLowerCase() + method.getName().substring(4);
-                return method.getDeclaringClass().getDeclaredField(fieldName).isAnnotationPresent(PublicApi.class);
+                String fieldName = method.getName().substring(3);
+                return Optional.ofNullable(method.getDeclaringClass()
+                                                 .getDeclaredField(fieldName)
+                                                 .getAnnotation(NoodleSandbox.class)).map(Sandbox::isAccessGranted);
             }
             if (method.getName().startsWith("is")) {
-                String fieldName = method.getName().substring(2, 2).toLowerCase() + method.getName().substring(3);
-                return method.getDeclaringClass().getDeclaredField(fieldName).isAnnotationPresent(PublicApi.class);
+                String fieldName = method.getName().substring(2);
+                return Optional.ofNullable(method.getDeclaringClass()
+                                                 .getDeclaredField(fieldName)
+                                                 .getAnnotation(NoodleSandbox.class)).map(Sandbox::isAccessGranted);
             }
         } catch (NoSuchFieldException e) {
             Exceptions.ignore(e);
         }
 
-        return false;
+        return Optional.empty();
     }
 }

--- a/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
@@ -72,7 +72,7 @@ public class Sandbox {
      */
     public SandboxMode determineEffectiveSandboxMode(String resourcePath) {
         String effectiveResourcePath = resourcePath.startsWith("/") ? resourcePath : "/" + resourcePath;
-        
+
         if (getMode() != SandboxMode.DISABLED && detectors.getParts()
                                                           .stream()
                                                           .anyMatch(detector -> detector.shouldSandbox(

--- a/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
@@ -130,7 +130,7 @@ public class Sandbox {
     }
 
     private String cleanupKey(String key) {
-        if (key.startsWith("")) {
+        if (key.startsWith("\"")) {
             return key.substring(1, key.length() - 1);
         }
 

--- a/src/main/java/sirius/pasta/noodle/sandbox/SandboxDetector.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/SandboxDetector.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.noodle.sandbox;
+
+import sirius.kernel.di.std.AutoRegister;
+
+/**
+ * Checks if the {@link Sandbox} should be enabled for a given resource.
+ * <p>
+ * Sandbox checks are only feasible where user input is expected. Therefor an application can install such detectors
+ * and determine if a template is to be checked or not.
+ * <p>
+ * A detector has to be @{@link sirius.kernel.di.std.Register registered} to be visible to the framework.
+ * <p>
+ * Note that multiple detectors can be present at the same time. As soon as one returns <tt>true</tt>, the sandbox
+ * will be enabled.
+ */
+@AutoRegister
+public interface SandboxDetector {
+
+    /**
+     * Determines if the resource with the given path should be checked.
+     *
+     * @param resourcePath the path to the template (always starts with "/")
+     * @return <tt>true</tt> if the sandbox should be enabled, <tt>false</tt> otherwise
+     */
+    boolean shouldSandbox(String resourcePath);
+}

--- a/src/main/java/sirius/pasta/noodle/sandbox/SandboxMode.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/SandboxMode.java
@@ -1,0 +1,33 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.noodle.sandbox;
+
+/**
+ * Controls if and how the {@link Sandbox} is enabled.
+ * <p>
+ * The actual mode is determined by {@link Sandbox} itself and stored/computed in
+ * {@link sirius.pasta.noodle.compiler.SourceCodeInfo}.
+ */
+public enum SandboxMode {
+
+    /**
+     * Disables any sandbox check entirely.
+     */
+    DISABLED,
+
+    /**
+     * Performs the sandbox checks but only emits warnings during compilation.
+     */
+    WARN_ONLY,
+
+    /**
+     * Aborts compilation if a sandbox check fails.
+     */
+    ENABLED
+}

--- a/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
+++ b/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
@@ -25,6 +25,7 @@ import sirius.pasta.Pasta;
 import sirius.pasta.noodle.compiler.CompileError;
 import sirius.pasta.noodle.compiler.CompileException;
 import sirius.pasta.noodle.compiler.SourceCodeInfo;
+import sirius.pasta.noodle.sandbox.SandboxMode;
 import sirius.pasta.tagliatelle.compiler.TemplateCompilationContext;
 import sirius.pasta.tagliatelle.compiler.TemplateCompiler;
 import sirius.pasta.tagliatelle.rendering.GlobalRenderContext;
@@ -213,8 +214,11 @@ public class Tagliatelle {
 
     /**
      * Creates a new {@link TemplateCompilationContext} for the given inline code.
+     * <p>
+     * Note that this will enable the built-in {@link sirius.pasta.noodle.sandbox.Sandbox sandbox} if enabled for this
+     * system
      *
-     * @param name   the name of the source code / orign
+     * @param name   the name of the source code / origin
      * @param code   the actual template code to compile
      * @param parent if the compilation was started while compiling another template, its context is given here. This
      *               is mainly used to detect and abort cyclic dependencies at compile time.
@@ -225,6 +229,24 @@ public class Tagliatelle {
                                                                      @Nullable TemplateCompilationContext parent) {
         Template template = new Template(name, null);
         return new TemplateCompilationContext(template, SourceCodeInfo.forInlineCode(code), parent);
+    }
+
+    /**
+     * Creates a new {@link TemplateCompilationContext} for the given inline code.
+     *
+     * @param name        the name of the source code / origin
+     * @param code        the actual template code to compile
+     * @param sandboxMode the sandbox mode to apply
+     * @param parent      if the compilation was started while compiling another template, its context is given here. This
+     *                    is mainly used to detect and abort cyclic dependencies at compile time.
+     * @return a new compilation context for the given resource
+     */
+    public TemplateCompilationContext createInlineCompilationContext(@Nonnull String name,
+                                                                     @Nonnull String code,
+                                                                     @Nonnull SandboxMode sandboxMode,
+                                                                     @Nullable TemplateCompilationContext parent) {
+        Template template = new Template(name, null);
+        return new TemplateCompilationContext(template, SourceCodeInfo.forInlineCode(code, sandboxMode), parent);
     }
 
     /**

--- a/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
+++ b/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
@@ -228,7 +228,7 @@ public class Tagliatelle {
                                                                      @Nonnull String code,
                                                                      @Nullable TemplateCompilationContext parent) {
         Template template = new Template(name, null);
-        return new TemplateCompilationContext(template, SourceCodeInfo.forInlineCode(code), parent);
+        return new TemplateCompilationContext(template, SourceCodeInfo.forCustomCode(name, code, null), parent);
     }
 
     /**
@@ -246,7 +246,7 @@ public class Tagliatelle {
                                                                      @Nonnull SandboxMode sandboxMode,
                                                                      @Nullable TemplateCompilationContext parent) {
         Template template = new Template(name, null);
-        return new TemplateCompilationContext(template, SourceCodeInfo.forInlineCode(code, sandboxMode), parent);
+        return new TemplateCompilationContext(template, SourceCodeInfo.forCustomCode(name, code, sandboxMode), parent);
     }
 
     /**

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompilationContext.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompilationContext.java
@@ -8,12 +8,12 @@
 
 package sirius.pasta.tagliatelle.compiler;
 
-import sirius.kernel.tokenizer.Char;
-import sirius.kernel.tokenizer.ParseError;
-import sirius.kernel.tokenizer.Position;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.tokenizer.Char;
+import sirius.kernel.tokenizer.ParseError;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.Callable;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.CompileError;

--- a/src/main/java/sirius/pasta/tagliatelle/macros/GenerateIdMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/GenerateIdMacro.java
@@ -16,7 +16,7 @@ import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
 import sirius.pasta.noodle.macros.BasicMacro;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.pasta.tagliatelle.rendering.LocalRenderContext;
 import sirius.web.util.IdGeneratorContext;
 
@@ -27,7 +27,7 @@ import java.util.List;
  * Generates a new ID which is unique within this {@link LocalRenderContext}.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class GenerateIdMacro extends BasicMacro {
     @Override
     protected Class<?> getType() {

--- a/src/main/java/sirius/pasta/tagliatelle/macros/RenderBlockMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/RenderBlockMacro.java
@@ -14,7 +14,7 @@ import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
 import sirius.pasta.noodle.macros.BasicMacro;
-import sirius.pasta.noodle.sandbox.PublicApi;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.pasta.tagliatelle.rendering.LocalRenderContext;
 
 import javax.annotation.Nonnull;
@@ -24,7 +24,7 @@ import java.util.List;
  * Returns the contents of the given block as string.
  */
 @Register
-@PublicApi
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class RenderBlockMacro extends BasicMacro {
 
     @Override

--- a/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
@@ -58,8 +58,7 @@ public class PragmaTag extends TagHandler {
     public void apply(CompositeEmitter targetBlock) {
         Value value = getConstantAttribute(PARAM_VALUE);
         if (value.isFilled()) {
-            getCompilationContext().getTemplate()
-                                   .addPragma(getConstantAttribute(PARAM_NAME).asString(), value.asString());
+            getCompilationContext().getTemplate().addPragma(getConstantAttribute(PARAM_NAME).asString(), value.asString());
         } else if (getBlock("body") != null) {
             getCompilationContext().getTemplate()
                                    .addPragma(getConstantAttribute(PARAM_NAME).asString(), getBlock("body").toString());

--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -14,6 +14,7 @@ import sirius.kernel.health.ExceptionHint;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.nls.Formatter;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.security.UserContext;
 import sirius.web.templates.ContentHelper;
 
@@ -232,10 +233,12 @@ public class Message {
         this.html = messageExpanders.expand(html);
     }
 
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public MessageLevel getType() {
         return type;
     }
 
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getHtml() {
         return html;
     }

--- a/src/main/java/sirius/web/controller/MessageLevel.java
+++ b/src/main/java/sirius/web/controller/MessageLevel.java
@@ -1,5 +1,7 @@
 package sirius.web.controller;
 
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
+
 /**
  * Declares the severity of a message and provides a convenient way to determine a proper Bootstrap CSS class to render
  * the message.
@@ -39,6 +41,7 @@ public enum MessageLevel {
      *
      * @return the name of the css class used to render the message
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getCssClass() {
         return cssClass;
     }
@@ -48,6 +51,7 @@ public enum MessageLevel {
      *
      * @return the name of the color used for this message level
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getColor() {
         return color;
     }

--- a/src/main/java/sirius/web/http/UserAgent.java
+++ b/src/main/java/sirius/web/http/UserAgent.java
@@ -162,7 +162,7 @@ public class UserAgent {
     /**
      * Determines whether the user agent hints to an Android device.
      *
-     * @return whether the user agent hints to a Android device
+     * @return whether the user agent hints to an Android device
      */
     public boolean isAndroid() {
         return android;
@@ -180,16 +180,16 @@ public class UserAgent {
     /**
      * Determines whether the user agent hints to an internet explorer browser.
      *
-     * @return whether the user agent hints to an internet explorer browser
+     * @return whether the user agent hints to an Internet-Explorer browser
      */
     public boolean isInternetExplorer() {
         return internetExplorer;
     }
 
     /**
-     * Determines whether the user agent hints to an microsoft edge browser.
+     * Determines whether the user agent hints to a Microsoft Edge browser.
      *
-     * @return whether the user agent hints to an microsoft edge browser
+     * @return whether the user agent hints to a Microsoft Edge browser
      */
     public boolean isMsEdge() {
         return msEdge;

--- a/src/main/java/sirius/web/http/UserAgent.java
+++ b/src/main/java/sirius/web/http/UserAgent.java
@@ -9,6 +9,7 @@
 package sirius.web.http;
 
 import sirius.kernel.commons.Strings;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 
@@ -128,6 +129,7 @@ public class UserAgent {
      *
      * @return whether user agent hints to a mobile device
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isMobile() {
         return isPhone() || isTablet();
     }
@@ -137,6 +139,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints to a phone
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isPhone() {
         return phone;
     }
@@ -146,6 +149,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints to a tablet
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isTablet() {
         return tablet;
     }
@@ -155,6 +159,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints a desktop device
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isDesktop() {
         return !isMobile();
     }
@@ -164,6 +169,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints to an Android device
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isAndroid() {
         return android;
     }
@@ -173,6 +179,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints to an iOS device
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isIOS() {
         return iOS;
     }
@@ -182,6 +189,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints to an Internet-Explorer browser
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isInternetExplorer() {
         return internetExplorer;
     }
@@ -191,6 +199,7 @@ public class UserAgent {
      *
      * @return whether the user agent hints to a Microsoft Edge browser
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isMsEdge() {
         return msEdge;
     }
@@ -200,6 +209,7 @@ public class UserAgent {
      *
      * @return the user agent as String
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getUserAgentString() {
         return userAgentString;
     }
@@ -210,6 +220,7 @@ public class UserAgent {
      * @param expectedUserAgent the expected user agent
      * @return <tt>true</tt> if the user agent matches, <tt>false</tt> otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean is(@Nonnull String expectedUserAgent) {
         return Strings.areEqual(userAgentString, expectedUserAgent);
     }
@@ -220,6 +231,7 @@ public class UserAgent {
      * @param userAgentPart the user agent to check for
      * @return <tt>true</tt> if the usr agent contains the given value, <tt>false</tt> otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean contains(@Nonnull String userAgentPart) {
         return userAgentString != null && userAgentString.contains(userAgentPart);
     }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -50,6 +50,7 @@ import sirius.kernel.nls.NLS;
 import sirius.kernel.xml.BasicNamespaceContext;
 import sirius.kernel.xml.StructuredInput;
 import sirius.kernel.xml.XMLStructuredInput;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -562,6 +563,7 @@ public class WebContext implements SubContext {
      * @return a Value representing the provided data.
      */
     @Nonnull
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Value get(String key) {
         if (attribute != null && attribute.containsKey(key)) {
             return Value.of(attribute.get(key));
@@ -735,6 +737,7 @@ public class WebContext implements SubContext {
      * @param key used to specify which part of the post request should be returned.
      * @return the data provided for the given key or <tt>null</tt> if no data was supplied.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public HttpData getHttpData(String key) {
         if (postDecoder == null) {
             return null;
@@ -1014,6 +1017,7 @@ public class WebContext implements SubContext {
      *
      * @return the decoded uri of the underlying request
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getRequestedURI() {
         if (requestedURI == null && request != null) {
             decodeQueryString();
@@ -1026,6 +1030,7 @@ public class WebContext implements SubContext {
      *
      * @return the un-decoded uri of the underlying request
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getRawRequestedURI() {
         if (rawRequestedURI == null && request != null) {
             rawRequestedURI = stripQueryFromURI(request.uri());
@@ -1038,6 +1043,7 @@ public class WebContext implements SubContext {
      *
      * @return the base url which created this request, without the actual URI
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getBaseURL() {
         if (baseURL == null) {
             StringBuilder sb = new StringBuilder();
@@ -1059,6 +1065,7 @@ public class WebContext implements SubContext {
      *
      * @return the complete url (base url + uri) which created this request
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getRequestedURL() {
         return getBaseURL() + getRequestedURI();
     }
@@ -1069,6 +1076,7 @@ public class WebContext implements SubContext {
      * @return the remote address of the underlying TCP connection. This will take an X-Forwarded-For header into
      * account if the connection was opened from a known proxy ip.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public InetAddress getRemoteIP() {
         if (remoteIp == null) {
             remoteIp = WebServer.determineRemoteIP(channelHandlerContext, request);
@@ -1111,6 +1119,7 @@ public class WebContext implements SubContext {
      * @param key the name of the parameter to fetch
      * @return the first value or <tt>null</tt> if the parameter was not set or empty
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getParameter(String key) {
         return Values.of(getParameters(key)).at(0).getString();
     }
@@ -1124,6 +1133,7 @@ public class WebContext implements SubContext {
      * @param key the name of the parameter to fetch
      * @return all values in the query string
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public List<String> getParameters(String key) {
         if (queryString == null) {
             decodeQueryString();
@@ -1527,6 +1537,7 @@ public class WebContext implements SubContext {
      * @return the value of the given header or <tt>null</tt> if no such header is present
      */
     @Nullable
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getHeader(CharSequence header) {
         if (request == null) {
             return null;
@@ -1541,6 +1552,7 @@ public class WebContext implements SubContext {
      * @return the contents of the named header wrapped as <tt>Value</tt>
      */
     @Nonnull
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Value getHeaderValue(CharSequence header) {
         if (request == null) {
             return Value.EMPTY;
@@ -1583,6 +1595,7 @@ public class WebContext implements SubContext {
      *
      * @return a collection of all parameters sent by the client
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Collection<String> getParameterNames() {
         if (queryString == null) {
             decodeQueryString();
@@ -2107,6 +2120,7 @@ public class WebContext implements SubContext {
      *
      * @return user agent wrapper object
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public UserAgent getUserAgent() {
         if (userAgent == null) {
             userAgent = new UserAgent(getHeader(HttpHeaderNames.USER_AGENT));

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -24,6 +24,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
 import sirius.kernel.settings.Settings;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -120,6 +121,7 @@ public class ScopeInfo extends Composable {
      * @return the unique ID identifying the scope
      */
     @Nonnull
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getScopeId() {
         return scopeId;
     }
@@ -133,6 +135,7 @@ public class ScopeInfo extends Composable {
      * @return the type of the scope
      */
     @Nonnull
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getScopeType() {
         return scopeType;
     }
@@ -143,6 +146,7 @@ public class ScopeInfo extends Composable {
      * @return the representative (non-technical) name of the scope
      */
     @Nonnull
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getScopeName() {
         return scopeName;
     }
@@ -167,6 +171,7 @@ public class ScopeInfo extends Composable {
      * @return the language code used by this scope or <tt>null</tt> if there is no specific language used
      */
     @Nullable
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getLanguage() {
         return language;
     }
@@ -182,6 +187,7 @@ public class ScopeInfo extends Composable {
      * class did not match
      */
     @SuppressWarnings("unchecked")
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public <T> T getScopeObject(Class<T> clazz) {
         if (scopeSupplier == null) {
             return null;
@@ -194,6 +200,7 @@ public class ScopeInfo extends Composable {
     }
 
     @Override
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean is(@Nonnull Class<?> type) {
         Transformable userObject = getScopeObject(Transformable.class);
         if (userObject != null && userObject.is(type)) {
@@ -203,6 +210,7 @@ public class ScopeInfo extends Composable {
     }
 
     @Override
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public <A> Optional<A> tryAs(@Nonnull Class<A> adapterType) {
         Transformable userObject = getScopeObject(Transformable.class);
         if (userObject != null) {
@@ -224,6 +232,7 @@ public class ScopeInfo extends Composable {
      * @return a cached or newly created instance of the helper for this scope.
      */
     @SuppressWarnings("unchecked")
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public <T> T getHelper(Class<T> clazz) {
         Object result = helpersByType.get(clazz);
         if (result == null) {
@@ -470,6 +479,7 @@ public class ScopeInfo extends Composable {
      *
      * @return the config of this scope
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public UserSettings getSettings() {
         if (settings == null) {
             if (configSupplier != null) {

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.controller.ErrorMessageTransformer;
 import sirius.web.controller.Message;
 import sirius.web.http.UserMessagesCache;
@@ -93,6 +94,7 @@ public class UserContext implements SubContext {
      *
      * @return the current user context.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static UserContext get() {
         return CallContext.getCurrent().get(UserContext.class);
     }
@@ -103,6 +105,7 @@ public class UserContext implements SubContext {
      * @return the current user
      * @see #getUser()
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static UserInfo getCurrentUser() {
         return get().getUser();
     }
@@ -115,6 +118,7 @@ public class UserContext implements SubContext {
      * @return the config for the current user
      * @see UserInfo#getSettings()
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static UserSettings getSettings() {
         return get().getUser().getSettings();
     }
@@ -131,6 +135,7 @@ public class UserContext implements SubContext {
      * thrown.
      */
     @Nonnull
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static <H> H getHelper(@Nonnull Class<H> helperType) {
         return getCurrentScope().getHelper(helperType);
     }
@@ -141,6 +146,7 @@ public class UserContext implements SubContext {
      * @return the currently active scope
      * @see #getScope()
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static ScopeInfo getCurrentScope() {
         return get().getScope();
     }
@@ -154,6 +160,7 @@ public class UserContext implements SubContext {
      *
      * @param exception the exception to handle. If the given exception is <tt>null</tt>, nothing will happen.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static void handle(@Nullable Throwable exception) {
         if (exception != null) {
             message(Message.error(exception));
@@ -165,6 +172,7 @@ public class UserContext implements SubContext {
      *
      * @param message the message to add
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static void message(Message message) {
         get().addMessage(message);
     }
@@ -296,6 +304,7 @@ public class UserContext implements SubContext {
      *
      * @param message the message to be shown to the user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public void addMessage(Message message) {
         messages.add(message);
     }
@@ -305,6 +314,7 @@ public class UserContext implements SubContext {
      *
      * @return a list of messages to be shown to the user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public List<Message> getMessages() {
         userMessagesCache.restoreCachedUserMessages(CallContext.getCurrent().get(WebContext.class));
 
@@ -328,6 +338,7 @@ public class UserContext implements SubContext {
      *
      * @return a list of "real" messages which were created while processing the current request
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public List<Message> getUserSpecificMessages() {
         return Collections.unmodifiableList(messages);
     }
@@ -339,6 +350,7 @@ public class UserContext implements SubContext {
      * @param value the value which was supplied and rejected
      */
 
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public void addFieldError(String field, String value) {
         fieldErrors.put(field, value);
     }
@@ -349,6 +361,7 @@ public class UserContext implements SubContext {
      * @param field the field to check for errors
      * @return <tt>true</tt> if an error was added for the field, <tt>false</tt> otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean hasError(String field) {
         return fieldErrors.containsKey(field) || fieldErrorMessages.containsKey(field);
     }
@@ -362,6 +375,7 @@ public class UserContext implements SubContext {
      * @param field the field to check
      * @return "has-error" if an error was added for the given field, an empty string otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String signalFieldError(String field) {
         return hasError(field) ? "has-error" : "";
     }
@@ -373,6 +387,7 @@ public class UserContext implements SubContext {
      * @param value the entity value (used if no error occurred)
      * @return the originally submitted value (if an error occurred), the given value otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getFieldValue(String field, Object value) {
         if (fieldErrors.containsKey(field)) {
             return fieldErrors.get(field);
@@ -387,6 +402,7 @@ public class UserContext implements SubContext {
      * @return the originally submitted value (if an error occurred) or the parameter (using field as name)
      * from the current {@link WebContext} otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getFieldValue(String field) {
         if (fieldErrors.containsKey(field)) {
             return fieldErrors.get(field);
@@ -400,6 +416,7 @@ public class UserContext implements SubContext {
      * @param field the name of the field which values should be extracted
      * @return a list of values submitted for the given field
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Collection<String> getFieldValues(String field) {
         return CallContext.getCurrent().get(WebContext.class).getParameters(field);
     }
@@ -410,6 +427,7 @@ public class UserContext implements SubContext {
      * @param field        name of the form field
      * @param errorMessage value to be added
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public static void setErrorMessage(String field, String errorMessage) {
         get().addFieldErrorMessage(field, errorMessage);
     }
@@ -420,6 +438,7 @@ public class UserContext implements SubContext {
      * @param field        name of the form field
      * @param errorMessage value to be added
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public void addFieldErrorMessage(String field, String errorMessage) {
         fieldErrorMessages.put(field, errorMessage);
     }
@@ -429,6 +448,7 @@ public class UserContext implements SubContext {
      *
      * @return all field errors
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Map<String, String> getFieldErrors() {
         return Collections.unmodifiableMap(fieldErrors);
     }
@@ -439,6 +459,7 @@ public class UserContext implements SubContext {
      * @param field name of the form field
      * @return error message if existent else an empty string
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getFieldErrorMessage(String field) {
         if (fieldErrorMessages.containsKey(field)) {
             return fieldErrorMessages.get(field);
@@ -455,6 +476,7 @@ public class UserContext implements SubContext {
      *
      * @return the currently active user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public UserInfo getUser() {
         if (currentUser == null) {
             if (fetchingCurrentUser) {
@@ -500,6 +522,7 @@ public class UserContext implements SubContext {
      *
      * @return the currently active user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isUserPresent() {
         return currentUser != null;
     }
@@ -540,6 +563,7 @@ public class UserContext implements SubContext {
      *
      * @return the currently active scope
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public ScopeInfo getScope() {
         if (currentScope == null) {
             if (fetchingCurrentScope) {

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -13,6 +13,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.transformers.Composable;
 import sirius.kernel.di.transformers.Transformable;
 import sirius.kernel.health.Exceptions;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.controller.Controller;
 
 import javax.annotation.CheckReturnValue;
@@ -256,6 +257,7 @@ public class UserInfo extends Composable {
      *
      * @return the unique ID of the user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getUserId() {
         return userId;
     }
@@ -265,6 +267,7 @@ public class UserInfo extends Composable {
      *
      * @return the name of the user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getUserName() {
         return username;
     }
@@ -284,6 +287,7 @@ public class UserInfo extends Composable {
      * @return the unique ID the tenant the user belongs to
      */
     @Nullable
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getTenantId() {
         return tenantId;
     }
@@ -294,6 +298,7 @@ public class UserInfo extends Composable {
      * @return the name of the tenant the user belongs to
      */
     @Nullable
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getTenantName() {
         return tenantName;
     }
@@ -314,6 +319,7 @@ public class UserInfo extends Composable {
      *
      * @return the two-letter language code of the user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getLanguage() {
         return language;
     }
@@ -324,6 +330,7 @@ public class UserInfo extends Composable {
      * @param permissions the permissions to check
      * @return <tt>true</tt> if the user has all the requested permissions, <tt>false</tt> otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean hasPermissions(String... permissions) {
         for (String permission : permissions) {
             if (!hasPermission(permission)) {
@@ -348,6 +355,7 @@ public class UserInfo extends Composable {
      * @param permission the permission to check
      * @return <tt>true</tt> if the user has the permission, <tt>false</tt> otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean hasPermission(String permission) {
         return Permissions.hasPermission(permission, hasEveryPermission ? s -> true : permissions::contains);
     }
@@ -359,6 +367,7 @@ public class UserInfo extends Composable {
      *
      * @param permission the permission to check
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public void assertPermission(String permission) {
         if (!hasPermission(permission)) {
             throw Exceptions.createHandled()
@@ -374,6 +383,7 @@ public class UserInfo extends Composable {
      *
      * @return <tt>true</tt> if the user has the permission {@link #PERMISSION_LOGGED_IN}, <tt>false</tt> otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean isLoggedIn() {
         return hasPermission(PERMISSION_LOGGED_IN);
     }
@@ -384,6 +394,7 @@ public class UserInfo extends Composable {
      *
      * @return the name of the user
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getProtocolUsername() {
         if (nameAppendixSupplier != null) {
             String appendix = nameAppendixSupplier.get();
@@ -404,6 +415,7 @@ public class UserInfo extends Composable {
      */
     @SuppressWarnings("unchecked")
     @Nullable
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public <T> T getUserObject(Class<T> clazz) {
         if (userSupplier == null) {
             return null;
@@ -416,6 +428,7 @@ public class UserInfo extends Composable {
     }
 
     @Override
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean is(@Nonnull Class<?> type) {
         Transformable userObject = getUserObject(Transformable.class);
         if (userObject != null) {
@@ -426,6 +439,7 @@ public class UserInfo extends Composable {
     }
 
     @Override
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public <A> Optional<A> tryAs(@Nonnull Class<A> adapterType) {
         return Optional.ofNullable(getUserObject(Transformable.class))
                        .flatMap(userObject -> userObject.tryAs(adapterType))
@@ -439,6 +453,7 @@ public class UserInfo extends Composable {
      *
      * @return all permissions granted to the user.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Set<String> getPermissions() {
         return Collections.unmodifiableSet(permissions);
     }
@@ -450,6 +465,7 @@ public class UserInfo extends Composable {
      *
      * @return the config object which contains all settings of the current scope, current tenant and user.
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public UserSettings getSettings() {
         if (settingsSupplier == null) {
             return UserContext.getCurrentScope().getSettings();

--- a/src/main/java/sirius/web/security/UserSettings.java
+++ b/src/main/java/sirius/web/security/UserSettings.java
@@ -10,6 +10,7 @@ package sirius.web.security;
 
 import com.typesafe.config.Config;
 import sirius.kernel.settings.ExtendedSettings;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 /**
  * Extends the {@link ExtendedSettings} wrapper by a boilerplate method to quickly check for a permission given in the
@@ -35,6 +36,7 @@ public class UserSettings extends ExtendedSettings {
      * @return <tt>true</tt> if the current user has the permission given in the requested setting, <tt>false</tt>
      * otherwise
      */
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public boolean hasPermissionOfSetting(String key) {
         return UserContext.getCurrentUser().hasPermission(getString(key));
     }

--- a/src/main/java/sirius/web/templates/TagliatelleContentHandler.java
+++ b/src/main/java/sirius/web/templates/TagliatelleContentHandler.java
@@ -12,6 +12,8 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.pasta.noodle.compiler.CompileException;
+import sirius.pasta.noodle.sandbox.Sandbox;
+import sirius.pasta.noodle.sandbox.SandboxMode;
 import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.pasta.tagliatelle.compiler.TemplateCompiler;
@@ -36,6 +38,9 @@ public class TagliatelleContentHandler implements ContentHandler {
     @Part
     private Tagliatelle tagliatelle;
 
+    @Part
+    private Sandbox sandbox;
+
     protected Template getTemplate(Generator generator) throws CompileException {
         if (Strings.isFilled(generator.getTemplateCode())) {
             TemplateCompiler compiler =
@@ -43,12 +48,20 @@ public class TagliatelleContentHandler implements ContentHandler {
                                                                                     generator.getTemplateName() :
                                                                                     "inline",
                                                                                     generator.getTemplateCode(),
+                                                                                    determineSandboxMode(generator.getTemplateName()),
                                                                                     null));
             compiler.compile();
             return compiler.getContext().getTemplate();
         } else {
             return tagliatelle.resolve(generator.getTemplateName()).orElse(null);
         }
+    }
+
+    private SandboxMode determineSandboxMode(String templateName) {
+        if (Strings.isEmpty(templateName)) {
+            return sandbox.getMode();
+        }
+        return sandbox.determineEffectiveSandboxMode(templateName);
     }
 
     @Override

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -468,11 +468,14 @@ assets {
 }
 
 tagliatelle {
+    # Provides names for tag prefixes to be rendered in /system/tags..
     taglib {
-        w = "Wondergem"
         t = "Tycho"
-        h = "Help"
         mail = "Mails"
+
+        # Note that these are legacy taglibs...
+        h = "Help"
+        w = "Wondergem"
     }
 }
 

--- a/src/main/resources/component-web.conf
+++ b/src/main/resources/component-web.conf
@@ -398,12 +398,60 @@ content {
 }
 
 # Defines rules for the Sandbox of Noodle. Only methods named here can be invoked, unless they are marked with
-# false, which effectively blacklists them. Note that if a method wears @PublicApi as annotation, it may also
-# be called by user code.
+# false, which effectively blacklists them. Note that if a method wears @NoodleAccessible as annotation, it may also
+# be called by user code (if the access is marked as granted).
 scripting {
     sandbox {
-        "sirius.kernel.commons.Tuple.*": true
-        "sirius.kernel.commons.Value.*": true
+        # The security sandbox is disabled by default for performance reasons. Also, no SandboxDetector is available
+        # anyway.
+        mode = DISABLED
+
+        # Provides a set of default rules for Java and Sirius classes.
+        rules {
+            "java.lang.String.*" = true
+            "java.lang.Object.*" = true
+            "java.lang.Enum.*" = true
+            "java.util.List.*" = true
+            "java.util.Collection.*" = true
+            "java.util.Set.*" = true
+            "sirius.kernel.commons.Tuple.*" = true
+            "sirius.kernel.commons.Value.*" = true
+            "sirius.kernel.commons.Amount.*" = true
+            "sirius.kernel.commons.Strings.*" = true
+            "sirius.kernel.settings.Settings.get" = true
+            "sirius.kernel.async.CallContext.getCurrent" = true
+            "sirius.kernel.async.CallContext.get" = true
+            "sirius.kernel.async.CallContext.getLanguage" = true
+            "sirius.kernel.async.CallContext.getFallbackLanguage" = true
+            "sirius.kernel.nls.NLS.getCurrentLanguage" = true
+            "sirius.kernel.nls.NLS.getDefaultLanguage" = true
+            "sirius.kernel.nls.NLS.getFallbackLanguage" = true
+            "sirius.kernel.nls.NLS.getSystemLanguage" = true
+            "sirius.kernel.nls.NLS.get" = true
+            "sirius.kernel.nls.NLS.getIfExists" = true
+            "sirius.kernel.nls.NLS.safeGet" = true
+            "sirius.kernel.nls.NLS.smartGet" = true
+            "sirius.kernel.nls.NLS.fmtr" = true
+            "sirius.kernel.nls.NLS.getDayOfWeek" = true
+            "sirius.kernel.nls.NLS.getDayOfWeekShort" = true
+            "sirius.kernel.nls.NLS.getMonthName" = true
+            "sirius.kernel.nls.NLS.getMonthNameShort" = true
+            "sirius.kernel.nls.NLS.toMachineString" = true
+            "sirius.kernel.nls.NLS.toUserString" = true
+            "sirius.kernel.nls.NLS.toSpokenDate" = true
+            "sirius.kernel.nls.NLS.formatSpokenDate" = true
+            "sirius.kernel.nls.NLS.parseMachineString" = true
+            "sirius.kernel.nls.NLS.parseUserString" = true
+            "sirius.kernel.nls.NLS.convertDuration" = true
+            "sirius.kernel.nls.NLS.smartRound" = true
+            "sirius.kernel.nls.NLS.formatSize" = true
+            "sirius.kernel.nls.Formatter.set" = true
+            "sirius.kernel.nls.Formatter.setDirect" = true
+            "sirius.kernel.nls.Formatter.setDirectUnencoded" = true
+            "sirius.kernel.nls.Formatter.ignoreMissingParameters" = true
+            "sirius.kernel.nls.Formatter.format" = true
+            "sirius.kernel.nls.Formatter.smartFormat" = true
+        }
     }
 }
 


### PR DESCRIPTION
We now have a system wide setting if the sandbox is enabled at all.
Additionally one or more SandboxDetectors can determine if a template
is to be sandboxed or not.

Additionally, instead of just enabling or disabling the sandbox, we now
also support a "WARN_ONLY" mode, which enables the sandbox but
only reports warnings.

Finally the rules and the way we evaluate them (along with annotations)
have been made a bit more flexible (and some standard have been
added).