### PR TITLE
Allows whitelisting interface methods

### DIFF
--- a/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample.java
+++ b/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample.java
@@ -8,8 +8,11 @@
 
 package sirius.pasta.noodle.sandbox;
 
+import sirius.kernel.di.std.Named;
 
-public class SandboxExample {
+import javax.annotation.Nonnull;
+
+public class SandboxExample implements Named {
 
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String grantedMethod() {
@@ -22,5 +25,11 @@ public class SandboxExample {
 
     public String noAnnotation2() {
         return "rejected";
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "granted";
     }
 }

--- a/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample2.java
+++ b/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample2.java
@@ -8,6 +8,8 @@
 
 package sirius.pasta.noodle.sandbox;
 
+import javax.annotation.Nonnull;
+
 public class SandboxExample2 extends SandboxExample {
 
     @Override
@@ -23,6 +25,12 @@ public class SandboxExample2 extends SandboxExample {
     @Override
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String noAnnotation2() {
+        return "granted";
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
         return "granted";
     }
 }

--- a/src/test/java/sirius/pasta/noodle/sandbox/SandboxSpec.groovy
+++ b/src/test/java/sirius/pasta/noodle/sandbox/SandboxSpec.groovy
@@ -79,6 +79,12 @@ class SandboxSpec extends BaseSpecification {
         sandbox.canInvoke(WebContext.class.getMethod("toString"))
         and:
         sandbox.canInvoke(ScopeInfo.class.getMethod("is", Class))
+        and:
+        sandbox.canInvoke(SandboxExample.class.getMethod("getName"))
+        and:
+        sandbox.canInvoke(SandboxExample2.class.getMethod("getName"))
+        and:
+        sandbox.canInvoke(SandboxExample3.class.getMethod("getName"))
     }
 
     def "macros with GRANTED annotation are allowed"() {


### PR DESCRIPTION
The approach however is simplified and doesn't support methods of interfaces that override the method of an extended interface (which isn't common case anyway). An example would be if Macro would override Named#getName.