### PR TITLE
Continuity: Only appends history params when any are present

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -342,8 +342,13 @@ window.sirius.Continuity = (function () {
             return undefined;
         }
 
+        let url = this.path;
+
         const effectiveSearchParams = searchParams || this.searchParams;
-        let url = this.path + '?' + effectiveSearchParams;
+
+        if (effectiveSearchParams.entries.length > 0) {
+            url + '?' + effectiveSearchParams;
+        }
         if (window.location.hash) {
             // We want to keep the fragment component of the URL intact.
             url += window.location.hash;

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -347,7 +347,7 @@ window.sirius.Continuity = (function () {
         const effectiveSearchParams = searchParams || this.searchParams;
 
         if (effectiveSearchParams.entries.length > 0) {
-            url + '?' + effectiveSearchParams;
+            url = url + '?' + effectiveSearchParams;
         }
         if (window.location.hash) {
             // We want to keep the fragment component of the URL intact.


### PR DESCRIPTION
Otherwise continuity affects the URL by appending a useless '?'.

Old behavior:
- visiting `/system/dashboard`
- URL automatically changes to `/system/dashboard?`

New behavior:
- visiting `/system/dashboard`
- URL stays `/system/dashboard`

Fixes: [SIRI-638](https://scireum.myjetbrains.com/youtrack/issue/SIRI-638)