### PR TITLE
Metrics: Expands color palette for charts a bit

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/charts.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/charts.js.pasta
@@ -2,7 +2,9 @@ const SIRIUS_CHART_COLOR_WHEEL = [
     "#5cbae6",
     "#fac364",
     "#b6d957",
-    "#d998cb"
+    "#d998cb",
+    "#f2d249",
+    "#98aafb"
 ];
 const SIRIUS_INLINE_CHART_TYPES = [
     'bar', 'line', 'soft-bar', 'area'


### PR DESCRIPTION
As far as I am aware the added colors should originate from the same color spectrum as the already specified colors. This reduces the risk of colors being reused in charts.

Fixes: SIRI-657