### PR TITLE
SIRI-727: Adds class and style properties to w:textarea

### DIFF
--- a/src/main/resources/default/taglib/w/textarea.html.pasta
+++ b/src/main/resources/default/taglib/w/textarea.html.pasta
@@ -11,6 +11,8 @@
 <i:arg name="required" type="boolean" default="false" />
 <i:arg name="readonly" type="boolean" default="false" />
 <i:arg name="adminOnly" type="boolean" default="false" />
+<i:arg name="class" type="String" default=""/>
+<i:arg name="style" type="String" default=""/>
 
 <i:pragma name="description" value="Renders a text area within a Wondergem template" />
 
@@ -22,7 +24,12 @@
         </span>
         </label>
     </i:if>
-    <textarea @id="@id" name="@name" rows="@rows" class="form-control input-block-level" @readonly="readonly">@UserContext.get().getFieldValue(name, value)</textarea>
+    <textarea @id="@id"
+              name="@name"
+              rows="@rows"
+              class="form-control input-block-level @class"
+              style="@style"
+              @readonly="readonly">@UserContext.get().getFieldValue(name, value)</textarea>
 
     <i:if test="isFilled(help)">
         <span class="help-block"><i:raw>@help</i:raw></span>


### PR DESCRIPTION
This is useful when we don't want to allow resizing the text area. Also, it makes the tag much more flexible and be in line with other tags that allow classes or even styles.

Note, that while we can declare the parameters on multiple lines, we mustn't add spaces to the value of the tag as the spaces or line breaks will propagate the to the displayed value otherwise! 