### PR TITLE
make tycho more responsive on small windows and fix ugly windows view

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/page.scss
+++ b/src/main/resources/default/assets/tycho/styles/page.scss
@@ -10,39 +10,30 @@ body {
   background-color: $backgroundGray;
 }
 
-#wrapper-menu {
-  margin-bottom: 1rem;
-}
-
-
 #wrapper-body {
   min-width: 0;
 }
 
-@media (min-width: 960px) {
+#wrapper {
+  display: grid;
+  grid-template-rows: 63px 1fr 40px;
+}
 
-  #wrapper {
-    display: grid;
-    grid-template-rows: 80px 1fr 40px;
-  }
+#wrapper-menu {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1020;
+  margin-bottom: 0;
+}
 
-  #wrapper-menu {
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
-    z-index: 1020;
-    margin-bottom: 0;
-  }
-
-  #wrapper-footer {
-    position: fixed;
-    bottom: 0;
-    right: 0;
-    left: 0;
-    /*z-index 999, to display the footer in front of cards/links (bootstrap), but behind autocompleteSingleSelect*/
-    z-index: 999;
-  }
-
+#wrapper-footer {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  /*z-index 999, to display the footer in front of cards/links (bootstrap), but behind autocompleteSingleSelect*/
+  z-index: 999;
 }
 
 nav.navbar {
@@ -61,7 +52,6 @@ nav.navbar {
 #page-header h1 {
   font-size: 1.5rem;
 }
-
 
 .breadcrumb {
   background-color: transparent;
@@ -93,7 +83,6 @@ nav.navbar {
 }
 
 #main-container {
-  padding-top: 1rem;
   display: flex;
   flex-flow: column;
   justify-content: stretch;

--- a/src/main/resources/default/assets/tycho/styles/page.scss
+++ b/src/main/resources/default/assets/tycho/styles/page.scss
@@ -107,5 +107,7 @@ nav.navbar {
     font-size: 2rem;
     font-weight: lighter;
     margin-bottom: 0px;
+    overflow-x: clip;
+    overflow-y: inherit;
   }
 }

--- a/src/main/resources/default/taglib/t/page.html.pasta
+++ b/src/main/resources/default/taglib/t/page.html.pasta
@@ -61,12 +61,12 @@
             <i:else>
                 <i:render name="header"/>
 
-                <div id="page-header">
+                <div id="page-header" class="mt-1 mt-md-3">
                     <div class="container-fluid">
                         <div id="page-nav">
-                            <div class="d-flex flex-column flex-lg-row">
+                            <div class="d-flex flex-row">
                                 <i:render name="breadcrumbBar">
-                                    <div class="overflow-hidden mr-auto mb-2 mb-lg-0">
+                                    <div class="overflow-hidden mr-auto">
                                         <i:invoke template="/templates/tycho/page-breadcrumbs.html.pasta">
                                             <i:render name="breadcrumbs"/>
                                         </i:invoke>
@@ -79,7 +79,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="main-container" class="container-fluid mb-2 pb-lg-5">
+                <div id="main-container" class="container-fluid mb-2 mt-1 mt-md-3 pb-lg-5">
                     <i:render name="page-header"/>
 
                     <i:render name="messages">

--- a/src/main/resources/default/taglib/t/pageHeader.html.pasta
+++ b/src/main/resources/default/taglib/t/pageHeader.html.pasta
@@ -20,7 +20,7 @@
                 <i class="fa fa-bars"></i>
             </a>
             <i:if test="isFilled(title)">
-                <h1 class="legend mr-auto overflow-hidden text-nowrap text-truncate">@title</h1>
+                <h1 class="legend mr-auto text-ellipsis text-nowrap">@title</h1>
                 <i:else>
                     <i:local name="markupTitle" value="@renderToString('title')"/>
                     <i:if test="isFilled(markupTitle)">

--- a/src/main/resources/default/templates/system/console.html.pasta
+++ b/src/main/resources/default/templates/system/console.html.pasta
@@ -56,8 +56,6 @@
 
             #wrapper {
                 height: 100vh;
-                display: grid;
-                grid-template-rows: 80px 1fr 40px;
             }
 
             #wrapper-body {
@@ -67,6 +65,7 @@
 
             #wrapper-body > #main-container {
                 max-height: 100%;
+                padding-top: 1rem;
             }
 
             #wrapper-body > #page-header {
@@ -76,12 +75,7 @@
             #term {
                 overflow-x: hidden;
                 overflow-y: auto;
-                padding: 0;
                 min-height: 100%;
-            }
-
-            .breadcrumb {
-                display: none;
             }
 
             .terminal, .terminal .terminal-output, .terminal .terminal-output div, .terminal .terminal-output div div,


### PR DESCRIPTION
(details see commits)
<img width="696" alt="Bildschirm­foto 2023-03-02 um 08 19 35" src="https://user-images.githubusercontent.com/55080004/222358308-22ce7186-d3df-4872-beb1-a73c4b6bd4c5.png">

before change (on windows):
![image](https://user-images.githubusercontent.com/55080004/222359088-7ac1fcf2-533a-4d7a-96b5-bee60fe1b7df.png)


after change (on windows):
![image](https://user-images.githubusercontent.com/55080004/222358711-f8e0a727-c64f-4a25-992d-9585f1080da9.png)
