### PR TITLE
removes the box shadow of upload file when in card

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/forms.scss
+++ b/src/main/resources/default/assets/tycho/styles/forms.scss
@@ -129,6 +129,10 @@
   }
 }
 
+.card .dropzone.sirius-imageupload {
+  box-shadow: none !important;
+}
+
 .dropzone.sirius-fileupload {
   border: none;
   background: transparent;


### PR DESCRIPTION
Removes the box-shadow of an upload-file when it's positioned in a card.

![image](https://user-images.githubusercontent.com/119577649/223637374-a12a494b-f540-41fa-bd29-4408f769a71f.png)
