### PR TITLE
Tycho: Prevents duplicate back navigation on page reload

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/history.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/history.js.pasta
@@ -24,8 +24,8 @@ function storeTychoHistory(urls) {
 
         window.sessionStorage.setItem("tycho-history", JSON.stringify(urls));
         window.sessionStorage.setItem('tycho-history-browser-length', window.history.length);
-    } catch (e) {
-        console.log(e);
+    } catch (exception) {
+        console.log(exception);
     }
 }
 
@@ -71,25 +71,24 @@ function appendHistoryUrl(url) {
             urls.splice(lastIndexOf + 1);
         }
         storeTychoHistory(urls);
-        return;
-    }
-
-    if (urls.length !== 0 && urls[urls.length - 1] === url && lastKnownBrowserHistoryLength < window.history.length) {
-        // If the user navigates back from this state, we need to skip the entries with the same url
-        window.sessionStorage.setItem('tycho-history-skip-url', url);
-        // We also want to skip it, if this state is called..
-        url = '-';
     } else {
-        window.sessionStorage.removeItem('tycho-history-skip-url');
-    }
+        if (urls.length !== 0 && urls[urls.length - 1] === url && lastKnownBrowserHistoryLength < window.history.length) {
+            // If the user navigates back from this state, we need to skip the entries with the same url
+            window.sessionStorage.setItem('tycho-history-skip-url', url);
+            // We also want to skip it, if this state is called...
+            url = '-';
+        } else {
+            window.sessionStorage.removeItem('tycho-history-skip-url');
+        }
 
-    if (url !== '-') {
-        urls.push(url);
-        storeTychoHistory(urls);
-    }
+        if (url !== '-') {
+            urls.push(url);
+            storeTychoHistory(urls);
+        }
 
-    // Store the url to load in the current state
-    window.history.replaceState({url: url}, document.title, window.location.href);
+        // Store the url to load in the current state
+        window.history.replaceState({url: url}, document.title, window.location.href);
+    }
 }
 
 function hasHistoryUrls() {
@@ -112,8 +111,7 @@ sirius.ready(function () {
     }
 });
 
-// On page load, if we have a state with a different url, load it
-if (window.history.state) {
+function handleHistoryStateOnLoad() {
     const url = window.history.state.url;
     if (url === '-') {
         window.sessionStorage.removeItem('tycho-history-skip-url');
@@ -124,4 +122,9 @@ if (window.history.state) {
     } else if (url !== currentUri()) {
         window.location.href = url;
     }
+}
+
+if (window.history.state) {
+    // On page load, if we have a state with a different url, load it
+    handleHistoryStateOnLoad();
 }

--- a/src/main/resources/default/assets/tycho/scripts/history.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/history.js.pasta
@@ -1,4 +1,3 @@
-
 function currentUri() {
     return location.pathname + location.search;
 }
@@ -30,7 +29,18 @@ function storeTychoHistory(urls) {
     }
 }
 
+const tychoHistory = {
+    /*
+     * This flag is used to prevent the execution of the appendHistoryUrl logic when we previously issued a back navigation.
+     */
+    backNavigationQueued: false
+}
+
 function appendHistoryUrl(url) {
+    if (tychoHistory.backNavigationQueued) {
+        tychoHistory.backNavigationQueued = false;
+        return;
+    }
     // No explicit URL is given, use the current one...
     if (url === '') {
         url = currentUri();
@@ -70,7 +80,7 @@ function appendHistoryUrl(url) {
         // We also want to skip it, if this state is called..
         url = '-';
     } else {
-        window.sessionStorage.removeItem('tycho-history-skip-url')
+        window.sessionStorage.removeItem('tycho-history-skip-url');
     }
 
     if (url !== '-') {
@@ -100,13 +110,16 @@ sirius.ready(function () {
             _node.parentNode.classList.remove('d-none');
         });
     }
-})
+});
 
 // On page load, if we have a state with a different url, load it
 if (window.history.state) {
     const url = window.history.state.url;
     if (url === '-') {
         window.sessionStorage.removeItem('tycho-history-skip-url');
+        // Ensure we don't execute the appendHistoryUrl logic when we issue a back navigation.
+        // Some browsers (e.g. Chrome) will still execute code in the current execution context, others (e.g. Firefox) won't.
+        tychoHistory.backNavigationQueued = true;
         window.history.back();
     } else if (url !== currentUri()) {
         window.location.href = url;


### PR DESCRIPTION
Bug scenario:

1. Opening `/system/jobs` in a new tab
2. Selecting a job from the list that has required parameters
3. Trying to start the job without any parameters
4. Reloading the page
5. ⚡ Chrome would jump back to the jobs list instead of staying on the job page

Previously working behaviour in FireFox:

![Bildschirm­foto 2023-03-10 um 14 21 39](https://user-images.githubusercontent.com/2427877/224339556-25aaed8f-d1d3-4a08-886a-bb455bf5daaa.png)

Previously broken behaviour in Chrome:

![Bildschirm­foto 2023-03-10 um 14 21 48](https://user-images.githubusercontent.com/2427877/224339609-16bd5ce5-546e-4ae2-8831-d17dca28c217.png)

Fixes: [SIRI-716](https://scireum.myjetbrains.com/youtrack/issue/SIRI-716)