### PR TITLE
Prevents overlay content from being able to overlap the close button

### DIFF
--- a/src/main/resources/default/assets/common/styles/overlay.scss
+++ b/src/main/resources/default/assets/common/styles/overlay.scss
@@ -36,6 +36,7 @@
       height: 32px;
       right: 2px;
       top: 2px;
+      z-index: 1;
 
       .sci-overlay-button {
         display: block;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2427877/225131103-6581b7d4-db36-459e-aa58-20d675b87fdb.png)

After:
![image](https://user-images.githubusercontent.com/2427877/225131029-74a05eb4-828f-430a-b69b-8164545cd4f0.png)


Fixes: [OX-9715](https://scireum.myjetbrains.com/youtrack/issue/OX-9715)