### PR TITLE
Adjusts Styling of Tycho Sidebar

### DIFF
--- a/src/main/resources/default/taglib/t/sidebar.html.pasta
+++ b/src/main/resources/default/taglib/t/sidebar.html.pasta
@@ -1,7 +1,7 @@
 <i:arg type="String" name="class" default="" description="Permits adding additional classes to the sidebar."/>
 
 <div class="row flex-grow-0 flex-lg-grow-1">
-    <div class="col-12 col-lg-4 col-xl-3 sidebar-js d-none d-lg-block @class">
+    <div class="col-12 col-lg-4 col-xl-3 sidebar-js mb-4 mb-lg-0 d-none d-lg-block @class">
         <div class="card h-100 shadow-sm">
             <div class="card-body">
                 <div class="d-flex flex-column">
@@ -15,7 +15,7 @@
             </div>
         </div>
     </div>
-    <div class="col-12 col-lg-8 col-xl-9 d-flex mb-4">
+    <div class="col-12 col-lg-8 col-xl-9">
         <div class="flex-grow-1">
             <i:render name="body"/>
         </div>


### PR DESCRIPTION
on pages with content the missing mb-4 on small screens crashes the layout
<img width="1108" alt="Bildschirm­foto 2023-03-15 um 11 49 20" src="https://user-images.githubusercontent.com/55080004/225287171-ebcb12d0-6f71-47ee-94a4-813ceb9ad736.png">
before vs now
- fixes: SIRI-761