### PR TITLE
Continuity: Correctly checks whether search params of URL are filled

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -344,9 +344,9 @@ window.sirius.Continuity = (function () {
 
         let url = this.path;
 
-        const effectiveSearchParams = searchParams || this.searchParams;
+        const effectiveSearchParams = (searchParams || this.searchParams).toString();
 
-        if (effectiveSearchParams.entries.length > 0) {
+        if (effectiveSearchParams.length > 0) {
             url = url + '?' + effectiveSearchParams;
         }
         if (window.location.hash) {


### PR DESCRIPTION
The previous check would fail as `entries` is a function that returns an iterator. An alternative solution to this would be to call `.entries().next()` but we have to call the `toString` anyways when the search params are not empty.

Fixes: OX-9500