### PR TITLE
enhance css to not break layout on long buttons with more than one word

### DIFF
--- a/src/main/resources/default/taglib/t/searchHeader.html.pasta
+++ b/src/main/resources/default/taglib/t/searchHeader.html.pasta
@@ -11,7 +11,7 @@
 <div class="card shadow-sm mb-4">
     <div class="card-body">
         <div class="row">
-            <div class="col-8 col-xl-9 @class">
+            <div class="col flex-grow-1 @class">
                 <i:if test="!suppressSearch">
                     <i:local name="linkAndQueryString" value="@Strings.split(baseUrl,'?')"/>
                     <form action="@linkAndQueryString.getFirst()" method="get" id="search">
@@ -38,7 +38,7 @@
                     </form>
                 </i:if>
             </div>
-            <div class="col-4 col-xl-3 d-flex flex-row justify-content-end">
+            <div class="col flex-grow-0 d-flex flex-row justify-content-end text-nowrap">
                 <i:render name="body"/>
                 <a class="ml-2 btn btn-outline-secondary" href="@page.linkToCurrentPage(baseUrl)">
                     <i class="fa-solid fa-arrows-rotate"></i>


### PR DESCRIPTION

<img width="1396" alt="Bildschirm­foto 2023-03-21 um 17 34 22" src="https://user-images.githubusercontent.com/55080004/226678152-c836a735-9b4a-4570-ac32-43e29a554159.png">

before vs after change

<img width="1391" alt="Bildschirm­foto 2023-03-21 um 17 32 23" src="https://user-images.githubusercontent.com/55080004/226677512-10f0a7f5-405b-4eb0-a421-e5ed4469dcde.png">
- fixes: SIRI-769