### PR TITLE
Continuity: Sub-Scopes & Removal of Handlers and Entries

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -120,6 +120,16 @@ window.sirius.Continuity = (function () {
     };
 
     /**@
+     * Allows to unregister a previously registered state entry handler for the given type.
+     *
+     * @param entryType the type/key of the state entry to remove the handler for.
+     */
+    Continuity.prototype.unregisterStateEntryHandler = function (entryType) {
+        this.log('[CONTINUITY] [INTERNAL] Unregistered state handler for type "%s".', entryType);
+        delete this.stateEntryHandlers[entryType];
+    }
+
+    /**@
      * Handles the change to the given state by calling the responsible state entry handles and updating some internal fields.
      * For state entries contained in the new history state the `restore` callback is triggered, for omitted state entries the `destroy` callback is triggered.
      *
@@ -146,7 +156,10 @@ window.sirius.Continuity = (function () {
         Object.keys(this.stateEntryHandlers).forEach(function (entryKey) {
             if (!state[entryKey]) {
                 me.log('[CONTINUITY] [INTERNAL] State handler of type "%s" called to destroy!', entryKey);
-                me.stateEntryHandlers[entryKey].destroy.call(me);
+                let handler = me.stateEntryHandlers[entryKey];
+                if (handler) {
+                    handler.destroy.call(me);
+                }
             }
         });
     };

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -190,7 +190,13 @@ window.sirius.Continuity = (function () {
         this.log('[CONTINUITY] [ACTION] Pushing new state for type "%s": %o', type, entry);
 
         this.lastState = Object.assign({}, this.currentState);
-        this.currentState[type] = entry;
+        if (typeof entry !== 'undefined' && entry !== null) {
+            // If the entry is defined we set it in the state
+            this.currentState[type] = entry;
+        } else {
+            // If the entry is undefined or null we remove it from the state
+            delete this.currentState[type];
+        }
         this.searchParams.set(this.options.stateParameterName, this.buildStateUrlParam(this.currentState));
 
         // Creates a new history instance, and saves state on it
@@ -207,7 +213,13 @@ window.sirius.Continuity = (function () {
     Continuity.prototype.replaceStateEntry = function (type, entry) {
         this.log('[CONTINUITY] [ACTION] Replacing state for type "%s": %o', type, entry);
 
-        this.currentState[type] = entry;
+        if (typeof entry !== 'undefined' && entry !== null) {
+            // If the entry is defined we set it in the state
+            this.currentState[type] = entry;
+        } else {
+            // If the entry is undefined or null we remove it from the state
+            delete this.currentState[type];
+        }
         this.searchParams.set(this.options.stateParameterName, this.buildStateUrlParam(this.currentState));
 
         // Creates a new history instance, and saves state on it

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -18,6 +18,11 @@ window.sirius.Continuity = (function () {
         this.lastState = null;
         this.currentState = null;
 
+        // This separator can be used in the added state entries to expand the generic entry name (used when configuring entryTypes via options)
+        // by a more specific sub-scope. This is useful when multiple elements with the same entryType are placed on the same page but should not influence each others history state.
+        // An entry handler can then be registered by each for `entryType|subScope` to handle the state changes of the specific element.
+        this.entryScopeSeparator = '|';
+
         this.path = window.location.pathname;
         this.searchParams = new URLSearchParams(window.location.search);
 
@@ -295,7 +300,8 @@ window.sirius.Continuity = (function () {
     Continuity.prototype.buildStateUrlParam = function (state) {
         const paramState = {};
         for (var entryKey in state) {
-            if (this.options.entryTypes[entryKey] && !this.options.entryTypes[entryKey].excludeFromParameter) {
+            const entryName = entryKey.split(this.entryScopeSeparator)[0];
+            if (this.options.entryTypes[entryName] && !this.options.entryTypes[entryName].excludeFromParameter) {
                 paramState[entryKey] = state[entryKey];
             }
         }


### PR DESCRIPTION
### Description

Allows to remove a entry from the current history state by calling `continuity.replaceStateEntry('entryType', null)` or `continuity.pushStateEntry('entryType', null)`


Allows to unregister a state entry handler previously registered via `continuity.registerStateEntryHandler('entryType', ...)` by calling `continuity.unregisterStateEntryHandler('entryType')`

Allows to use so called sub-scopes for entryTypes by using `continuity.registerStateEntryHandler('entryType|subScope', ...)` and `continuity.pushStateEntry('entryType|subScope', ...)` which allows to have unique state entries and handlers that share the same `entryType` configuration.

Example for where this may be useful:
Single page with multiple similar elements (e.g. multiple paginator-lists) could be registered as an entry type `paginator` while configuring Continuity and later on each paginator could register its own handler like `paginator|xyz` and push its own states with `paginator|xyz` which can cleanly be added to the deeplink URL and restored on page load.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-9500](https://scireum.myjetbrains.com/youtrack/issue/OX-9500)

### Checklist

- [x] The code change has been tested and works locally
- [x] No commented-out code is introduced in this PR
- [x] No new Sonarlint issues were added (except for TODOs and Deprecations)
- [x] The code was formatted via IntelliJ and follows general best practices (see [CodeStyle / JavaDoc](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc))
- [x] Testing: N/A
- [x] Documentation: JSDoc was added for new methods and field
