### PR TITLE
JSONStructuredOutput: unifies handling of ClosedChannelExceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>dev-35.0.1</sirius.kernel>
+        <sirius.kernel>dev-35.2.1</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -44,8 +44,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
         try {
             this.callback = callback;
             writer = new OutputStreamWriter(out, encoding);
-        } catch (UnsupportedEncodingException e) {
-            throw Exceptions.handle(e);
+        } catch (UnsupportedEncodingException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -64,10 +64,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     protected void endArray(String name) {
         try {
             writer.write("]");
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -75,10 +75,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     protected void endObject(String name) {
         try {
             writer.write("}");
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -92,10 +92,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             } else {
                 writer.write("[");
             }
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -114,10 +114,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
                     property(attr.getName(), attr.getValue());
                 }
             }
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -196,10 +196,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
                 writer.write("(");
             }
             beginObject("result");
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
 
         return this;
@@ -242,10 +242,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             } else {
                 writeString(transformToStringRepresentation(data));
             }
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -255,8 +255,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             addRequiredComma();
             addObjectName(name);
             writer.write(Strings.isFilled(formattedAmount) ? formattedAmount : "null");
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 
@@ -271,10 +271,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
         if (!isCurrentObjectEmpty()) {
             try {
                 writer.write(",");
-            } catch (ClosedChannelException e) {
-                throw handleClosedChannel(e);
-            } catch (IOException e) {
-                throw Exceptions.handle(e);
+            } catch (ClosedChannelException exception) {
+                throw handleClosedChannel(exception);
+            } catch (IOException exception) {
+                throw Exceptions.handle(exception);
             }
         }
     }
@@ -288,7 +288,7 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     /**
      * Finalizes the output and closes the stream.
      * <p>
-     * In constrast to {@link #endResult()} this does not require an open result object.
+     * In contrast to {@link #endResult()} this does not require an open result object.
      */
     public void finalizeOutput() {
         try {
@@ -297,10 +297,10 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
                 writer.write(")");
             }
             writer.close();
-        } catch (ClosedChannelException e) {
-            throw handleClosedChannel(e);
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (ClosedChannelException exception) {
+            throw handleClosedChannel(exception);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         }
     }
 }

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -13,7 +13,6 @@ import com.alibaba.fastjson.JSONObject;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
-import sirius.kernel.health.HandledException;
 import sirius.kernel.xml.AbstractStructuredOutput;
 import sirius.kernel.xml.Attribute;
 import sirius.kernel.xml.StructuredOutput;
@@ -70,13 +69,6 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
         } catch (IOException e) {
             throw Exceptions.handle(e);
         }
-    }
-
-    private HandledException handleClosedChannel(ClosedChannelException e) {
-        return Exceptions.createHandled()
-                         .error(e)
-                         .withSystemErrorMessage("An IO exception occurred (closed channel): %s")
-                         .handle();
     }
 
     @Override

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
-import java.nio.channels.ClosedChannelException;
 
 /**
  * Encoder to generate JSON via the {@link sirius.kernel.xml.StructuredOutput} interface.
@@ -64,10 +63,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     protected void endArray(String name) {
         try {
             writer.write("]");
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 
@@ -75,10 +72,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     protected void endObject(String name) {
         try {
             writer.write("}");
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 
@@ -92,10 +87,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             } else {
                 writer.write("[");
             }
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 
@@ -114,10 +107,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
                     property(attr.getName(), attr.getValue());
                 }
             }
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 
@@ -196,10 +187,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
                 writer.write("(");
             }
             beginObject("result");
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
 
         return this;
@@ -242,10 +231,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             } else {
                 writeString(transformToStringRepresentation(data));
             }
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 
@@ -256,7 +243,7 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             addObjectName(name);
             writer.write(Strings.isFilled(formattedAmount) ? formattedAmount : "null");
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 
@@ -271,10 +258,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
         if (!isCurrentObjectEmpty()) {
             try {
                 writer.write(",");
-            } catch (ClosedChannelException exception) {
-                throw handleClosedChannel(exception);
             } catch (IOException exception) {
-                throw Exceptions.handle(exception);
+                throw handleOutputException(exception);
             }
         }
     }
@@ -297,10 +282,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
                 writer.write(")");
             }
             writer.close();
-        } catch (ClosedChannelException exception) {
-            throw handleClosedChannel(exception);
         } catch (IOException exception) {
-            throw Exceptions.handle(exception);
+            throw handleOutputException(exception);
         }
     }
 }


### PR DESCRIPTION
Extracts handler-method to abstract superclass in sirius-kernel
- https://github.com/scireum/sirius-kernel/pull/448

Note: `ClosedChannelException` extends `IOException`, so we don't need separate catch clauses here.

Fixes: [SIRI-766](https://scireum.myjetbrains.com/youtrack/issue/SIRI-766)