### PR TITLE
Beautifies the response documentation by adding whitespaces for the DefaultErrorResponsesJson

### DIFF
--- a/src/main/java/sirius/web/services/DefaultErrorResponsesJson.java
+++ b/src/main/java/sirius/web/services/DefaultErrorResponsesJson.java
@@ -22,9 +22,9 @@ public class DefaultErrorResponsesJson implements SharedResponses {
             content = @Content(mediaType = "application/json",examples = @ExampleObject(//language=JSON
             """
                     {
-                        "success":false,
-                        "error":true,
-                        "message":"The parameter {missingParameter} must be filled."
+                        "success": false,
+                        "error": true,
+                        "message": "The parameter {missingParameter} must be filled."
                     }
                     """)))
     @ApiResponse(responseCode = "401",


### PR DESCRIPTION
Fixes: [OX-9704](https://scireum.myjetbrains.com/youtrack/issue/OX-9704/Fehler-in-KBA-INT63-Berechnung-bei-API-Token-ist-falsch)