### PR TITLE
Prevents empty writes to the localStorage (and minor fixes).

### DIFF
--- a/src/main/java/sirius/pasta/tagliatelle/macros/StaticAssetUriMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/StaticAssetUriMacro.java
@@ -8,14 +8,15 @@
 
 package sirius.pasta.tagliatelle.macros;
 
-import sirius.kernel.tokenizer.Position;
 import sirius.kernel.Sirius;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.info.Product;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
 import sirius.pasta.noodle.macros.BasicMacro;
+import sirius.pasta.noodle.sandbox.NoodleSandbox;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.List;
  * a <tt>no-cache</tt> URI.
  */
 @Register
+@NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
 public class StaticAssetUriMacro extends BasicMacro {
 
     @Override
@@ -69,5 +71,4 @@ public class StaticAssetUriMacro extends BasicMacro {
     public boolean isConstant(CompilationContext context, List<Node> args) {
         return true;
     }
-
 }

--- a/src/main/java/sirius/web/controller/PreserveErrorMessageTransformer.java
+++ b/src/main/java/sirius/web/controller/PreserveErrorMessageTransformer.java
@@ -20,6 +20,9 @@ import sirius.kernel.health.HandledException;
 @Register
 public class PreserveErrorMessageTransformer implements ErrorMessageTransformer {
 
+    /**
+     * Marks an error message as "to be preserved" - so that more or less a &lt;pre&gt; tag is wrapped around it.
+     */
     public static final ExceptionHint PRESERVE = new ExceptionHint("preserve");
 
     @Override

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -483,7 +483,11 @@ sirius.writeLocalStore = function (name, value) {
     }
     try {
         if (sirius.isDefined(window.localStorage)) {
-            window.localStorage.setItem(name, value);
+            if (sirius.isEmpty(value)) {
+                window.localStorage.removeItem(name);
+            } else {
+                window.localStorage.setItem(name, value);
+            }
         }
     } catch (e) {
         console.log('Cannot write local store', {name: name, value: value, error: e});


### PR DESCRIPTION
Empty writes to the localStorage aren't beneficial anyway. Also, many GDPR scanners now get
nervous when the localStorage is touched. Therefore, we prevent
"unused" writes if possible.

Also, fixes a JavaDoc and permits to access staticAssetUri() in sandboxed environments...