### PR TITLE
Continuity: Allows to jump back multiple history states when entry contains depth counter

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -317,6 +317,8 @@ window.sirius.Continuity = (function () {
             const entryName = entryKey.split(this.entryScopeSeparator)[0];
             if (this.options.entryTypes[entryName] && !this.options.entryTypes[entryName].excludeFromParameter) {
                 const paramStateEntry = Object.assign({}, state[entryKey]);
+                // Omit the entry depth from the parameter state as it only makes sense on the current page with the current history stack.
+                // When opening the URL in a new tab the entry depth would be wrong.
                 delete paramStateEntry['entryDepth'];
                 paramState[entryKey] = paramStateEntry;
 

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -254,10 +254,11 @@ window.sirius.Continuity = (function () {
      * @param {string} type the type of the state entry to remove
      * @param {boolean} [forceNewState] allows to force the creation of a new state without the entry type
      */
-    Continuity.prototype.popStateEntry = function (type, forceNewState) {
+    Continuity.prototype.popStateEntry = function (type, forceNewState, numberOfStepsBack) {
         this.log('[CONTINUITY] [ACTION] Popping state for type "%s"', type);
         if (this.lastState && !forceNewState) {
-            history.back();
+            const entryDepth = this.currentState[type].entryDepth || 1;
+            history.go(-entryDepth);
         } else {
             this.lastState = Object.assign({}, this.currentState);
             delete this.currentState[type];
@@ -315,7 +316,10 @@ window.sirius.Continuity = (function () {
         for (var entryKey in state) {
             const entryName = entryKey.split(this.entryScopeSeparator)[0];
             if (this.options.entryTypes[entryName] && !this.options.entryTypes[entryName].excludeFromParameter) {
-                paramState[entryKey] = state[entryKey];
+                const paramStateEntry = Object.assign({}, state[entryKey]);
+                delete paramStateEntry['entryDepth'];
+                paramState[entryKey] = paramStateEntry;
+
             }
         }
 


### PR DESCRIPTION
This allows for some more complex scenarios where a single history entry also has multiple history sub-entries and popping the entry should undo all of the sub states at once.

Depth counting is currently done manually where necessary.

The depth is always omitted from the deeplink URL as opening a deeplink won't include all previous history states (that were open when creating the deeplink), so jumping back multiple states at once would lead somewhere completely wrong.

Example:
Search that writes a new state each time a filter is changed, rendered within an overlay. Popping (closing) the overlay should not simply undo a single search state change but undo them all at once so the overlay is actually closed.

Fixes: [OX-9814](https://scireum.myjetbrains.com/youtrack/issue/OX-9814)