### PR TITLE
Data Explorer: Tooltips (SIRI-803)

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/charts.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/charts.js.pasta
@@ -220,7 +220,11 @@ function _lineChart(selector, labels, datasets, stacked) {
         maintainAspectRatio: false,
         bezierCurve: true,
         plugins: {
-            legend: {display: datasets.length > 1}
+            legend: {display: datasets.length > 1},
+            tooltip: {
+                mode: "x",
+                position: "nearest"
+            }
         },
         scales: {
             y: {
@@ -241,13 +245,11 @@ function _lineChart(selector, labels, datasets, stacked) {
             axis: 'x',
             intersect: false
         }
-        customConfig.plugins.tooltip = {
-            callbacks: {
-                footer: function (tooltipItems) {
-                    return '___i18n("Charts.total"): ' + tooltipItems.reduce(function (acc, item) {
-                        return acc + item.parsed.y;
-                    }, 0);
-                }
+        customConfig.plugins.tooltip.callbacks = {
+            footer: function (tooltipItems) {
+                return '___i18n("Charts.total"): ' + tooltipItems.reduce(function (acc, item) {
+                    return acc + item.parsed.y;
+                }, 0);
             }
         }
     }


### PR DESCRIPTION
> https://scireum.myjetbrains.com/youtrack/issue/SIRI-803

Internal and external users report issues concerning the tooltip in data explorer graphs. In order to clarify, the tooltip now shows values for all graphs for the current month (current value and value from the chosen reference point).

### Screenie Before

https://github.com/scireum/sirius-web/assets/36069303/f2dd9da1-5eab-4790-b55a-f18a090bf7d3

### Screenie After

https://github.com/scireum/sirius-web/assets/36069303/d2453760-8ec0-4880-afae-d956dcaac802

