### PR TITLE
Automatically grows the contents next to the sidebar to 100% height.

### DIFF
--- a/src/main/resources/default/taglib/t/sidebar.html.pasta
+++ b/src/main/resources/default/taglib/t/sidebar.html.pasta
@@ -16,7 +16,7 @@
         </div>
     </div>
     <div class="col-12 col-lg-8 col-xl-9">
-        <div class="d-flex flex-column flex-grow-1 h-100">
+        <div class="d-flex flex-column h-100">
             <i:render name="body"/>
         </div>
     </div>

--- a/src/main/resources/default/taglib/t/sidebar.html.pasta
+++ b/src/main/resources/default/taglib/t/sidebar.html.pasta
@@ -15,10 +15,9 @@
             </div>
         </div>
     </div>
-    <div class="col-12 col-lg-8 col-xl-9 d-flex">
-        <div class="flex-grow-1">
+    <div class="col-12 col-lg-8 col-xl-9">
+        <div class="d-flex flex-column flex-grow-1 h-100">
             <i:render name="body"/>
         </div>
     </div>
 </div>
-


### PR DESCRIPTION
BEFORE:
![grafik](https://github.com/scireum/sirius-web/assets/875799/7aff292e-678a-4096-ac74-68504d90334e)

AFTER:
![grafik](https://github.com/scireum/sirius-web/assets/875799/84548ac3-21b7-40a3-bfaf-dc76b3cf89f5)
