### PR TITLE
Design System: Adds a small pill component class

### DIFF
--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -159,6 +159,23 @@
   white-space: nowrap;
 }
 
+.sci-pill {
+  padding: 0.25rem 0.5rem;
+  border-radius: 1rem;
+
+  font-size: 0.9rem;
+  line-height: 1;
+  font-weight: 300;
+
+  color: $sirius-white;
+  background-color: $sirius-gray;
+
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sci-muted-link {
   text-decoration: none;
   cursor: pointer;


### PR DESCRIPTION
This matches the pill used for filter counts displayed in the Navigator Pro of OXOMI.

![image](https://github.com/scireum/sirius-web/assets/2427877/91cc1f95-9e32-4d47-a951-03a08af53462)

Fixes: [OX-9981](https://scireum.myjetbrains.com/youtrack/issue/OX-9981)