### PR TITLE
Dialogs: Always enables our own font stack when rendering a dialog

### DIFF
--- a/src/main/resources/default/assets/common/scripts/dialog.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/dialog.js.pasta
@@ -1,5 +1,5 @@
 (function (dialog) {
-    const template = '<div id="sci-dialog-background" class="sci-d-none sci-position-absolute sci-align-items-center sci-justify-content-center sci-p-2 sci-text sci-font">' +
+    const template = '<div id="sci-dialog-background" class="sci-d-none sci-position-absolute sci-align-items-center sci-justify-content-center sci-p-2 sci-text sci-font sci-enable-font">' +
         '   <div id="sci-dialog" class="sci-d-flex sci-font sci-bg-white sci-p-2 sci-shadow sci-card sci-flex-column sci-overflow-hidden">' +
         '      <div id="sci-dialog-header" class="sci-pt-1 sci-pb-2 sci-d-flex sci-justify-content-space-between sci-border-grey sci-flex-shrink-0 sci-overflow-hidden">' +
         '          <div id="sci-dialog-title" class="sci-text-size-h2 sci-text-ellipsis sci-text-grey-dark"></div>' +


### PR DESCRIPTION
This is our own component so we wont break anything when we enable our font classes here. This prevents having to mark each content rendered in the dialog with "sci-enable-font" which is highly likely to be forgotten at some point.

Fixes: [OX-9378](https://scireum.myjetbrains.com/youtrack/issue/OX-9378)