### PR TITLE
Dialog: Uses fixed positioning for the background

### DIFF
--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -122,6 +122,10 @@
   position: absolute;
 }
 
+.sci-position-fixed {
+  position: fixed;
+}
+
 .sci-tag {
   padding: 4px 8px;
   border-radius: 4px;

--- a/src/main/resources/default/assets/common/scripts/dialog.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/dialog.js.pasta
@@ -1,5 +1,5 @@
 (function (dialog) {
-    const template = '<div id="sci-dialog-background" class="sci-d-none sci-position-absolute sci-align-items-center sci-justify-content-center sci-p-2 sci-text sci-font sci-enable-font">' +
+    const template = '<div id="sci-dialog-background" class="sci-d-none sci-position-fixed sci-align-items-center sci-justify-content-center sci-p-2 sci-text sci-font sci-enable-font">' +
         '   <div id="sci-dialog" class="sci-d-flex sci-font sci-bg-white sci-p-2 sci-shadow sci-card sci-flex-column sci-overflow-hidden">' +
         '      <div id="sci-dialog-header" class="sci-pt-1 sci-pb-2 sci-d-flex sci-justify-content-space-between sci-border-grey sci-flex-shrink-0 sci-overflow-hidden">' +
         '          <div id="sci-dialog-title" class="sci-text-size-h2 sci-text-ellipsis sci-text-grey-dark"></div>' +


### PR DESCRIPTION
This has to be used rather than absolute positioning as it be offset by a scrolling parent container.

**Before:**

<img width="763" alt="image" src="https://github.com/scireum/sirius-web/assets/2427877/d14bb5ef-7a8f-4af0-97b0-c0682d092c5e">

**After:**

<img width="766" alt="image" src="https://github.com/scireum/sirius-web/assets/2427877/c097a8f3-ada4-4f5c-885a-dfde4b4f088b">

Fixes: [OX-9378](https://scireum.myjetbrains.com/youtrack/issue/OX-9378)