### PR TITLE
Empty Check: Top Margin

### DIFF
--- a/src/main/resources/default/taglib/t/emptyCheck.html.pasta
+++ b/src/main/resources/default/taglib/t/emptyCheck.html.pasta
@@ -15,7 +15,7 @@
 <i:if test="(data.is(Page.class) && data.as(Page.class).getItems().isEmpty()) || (data.is(java.util.Collection.class) && data.as(java.util.Collection.class).isEmpty())">
     <div class="card mb-4">
         <div class="card-body">
-            <div class="mt-4 row">
+            <div class="row">
                 <div class="col-12 col-lg-10 col-xl-8 offset-lg-1 offset-xl-2">
                     <div class="d-flex flex-column align-items-center">
                         <i:if test="data.is(Page.class) && data.as(Page.class).isFiltered()">
@@ -23,7 +23,7 @@
                             <i:if test="isFilled(body)">
                                 <i:raw>@body</i:raw>
                                 <i:else>
-                                    <span class="h5 mb-4">@i18n("emptyCheck.html.filteredEmpty")</span>
+                                    <span class="h5 mt-4 mb-4">@i18n("emptyCheck.html.filteredEmpty")</span>
                                     <i:render name="filtered-empty-extensions" />
                                 </i:else>
                             </i:if>
@@ -32,7 +32,7 @@
                                 <i:if test="isFilled(body)">
                                     <i:raw>@body</i:raw>
                                     <i:else>
-                                        <span class="h5 mb-4">@i18n("emptyCheck.html.empty")</span>
+                                        <span class="h5 mt-4 mb-4">@i18n("emptyCheck.html.empty")</span>
                                         <i:render name="empty-extensions" />
                                     </i:else>
                                 </i:if>


### PR DESCRIPTION
In case of an "empty" block the card used to show excessive top margin. This PR moves the top-margin setting to the default heading.

### Screenies

See space above video.

| Without | With |
|-|-|
| ![Screenshot 2023-06-28 at 20 59 00](https://github.com/scireum/sirius-web/assets/36069303/dcaf9f60-d4ef-4ccf-a21e-122f7bb1b0d1) | ![Screenshot 2023-06-28 at 20 58 00](https://github.com/scireum/sirius-web/assets/36069303/902b9a78-7c4b-4063-8bb5-5801b1fa4699) |