### PR TITLE
Tycho boolean select now properly supports ID parameter

### DIFF
--- a/src/main/resources/default/taglib/t/booleanSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/booleanSelect.html.pasta
@@ -1,4 +1,4 @@
-<i:arg name="id" type="String" default="@generateId('singleselect-%s')"/>
+<i:arg name="id" type="String" default="@generateId('booleanselect-%s')"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="labelClass" type="String" default="" description="Lists additional CSS classes to apply to the label."/>
 <i:arg name="name" type="String"/>

--- a/src/main/resources/default/taglib/t/booleanSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/booleanSelect.html.pasta
@@ -5,16 +5,16 @@
 <i:arg name="value" type="boolean"/>
 <i:arg name="labelKey" type="String" default=""/>
 <i:arg name="label" type="String" default="@i18n(labelKey)"/>
-<i:arg name="trueLabelKey" type="String" default="booleanfield.html.trueLabel" />
-<i:arg name="trueLabel" type="String" default="@i18n(trueLabelKey)" />
-<i:arg name="falseLabelKey" type="String" default="booleanfield.html.falseLabel" />
-<i:arg name="falseLabel" type="String" default="@i18n(falseLabelKey)" />
+<i:arg name="trueLabelKey" type="String" default="booleanfield.html.trueLabel"/>
+<i:arg name="trueLabel" type="String" default="@i18n(trueLabelKey)"/>
+<i:arg name="falseLabelKey" type="String" default="booleanfield.html.falseLabel"/>
+<i:arg name="falseLabel" type="String" default="@i18n(falseLabelKey)"/>
 <i:arg name="helpKey" type="String" default=""/>
 <i:arg name="help" type="String" default="@i18n(helpKey)"/>
 <i:arg name="readonly" type="boolean" default="false"/>
 <i:arg name="optional" type="boolean" default="false"/>
 
-<i:pragma name="description" value="Renders a dropdown for boolean values within a Tycho template" />
+<i:pragma name="description" value="Renders a dropdown for boolean values within a Tycho template"/>
 
 <i:if test="readonly">
     <t:textfield id="@id"

--- a/src/main/resources/default/taglib/t/booleanSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/booleanSelect.html.pasta
@@ -1,4 +1,4 @@
-<i:arg name="id" type="String" default=""/>
+<i:arg name="id" type="String" default="@generateId('singleselect-%s')"/>
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="labelClass" type="String" default="" description="Lists additional CSS classes to apply to the label."/>
 <i:arg name="name" type="String"/>
@@ -17,14 +17,16 @@
 <i:pragma name="description" value="Renders a dropdown for boolean values within a Tycho template" />
 
 <i:if test="readonly">
-    <t:textfield class="@class"
+    <t:textfield id="@id"
+                 class="@class"
                  labelClass="@labelClass"
                  value="value ? trueLabel : falseLabel"
                  label="@label"
                  help="@help"
                  readonly="true"/>
     <i:else>
-        <t:singleSelect class="@class"
+        <t:singleSelect id="@id"
+                        class="@class"
                         labelClass="@labelClass"
                         name="@name"
                         label="@label"


### PR DESCRIPTION
Fixes: [OX-8902](https://scireum.myjetbrains.com/youtrack/issue/OX-8902)

BREAKING:
The default auto-generated ID selector for booleanSelect-fields changes from e.g. `singleselect-1` to `booleanselect-1`. Either adjusts existing JS code relying on the old selector to use the new one, or assign the old selector manually as ID in the template code.