### PR TITLE
Passes unparsed / malformed function calls through

### DIFF
--- a/src/main/java/sirius/web/sass/Generator.java
+++ b/src/main/java/sirius/web/sass/Generator.java
@@ -537,9 +537,12 @@ public class Generator {
                                                                       .replaceAll("[^a-z0-9]", ""),
                                                                   Generator.class,
                                                                   FunctionCall.class).invoke(null, this, call);
-        } catch (NoSuchMethodException | IllegalArgumentException ignored) {
+        } catch (NoSuchMethodException ignored) {
             return new Value(call.toString());
         } catch (InvocationTargetException e) {
+            if (e.getTargetException() instanceof IllegalArgumentException) {
+                return new Value(call.toString());
+            }
             warn("Cannot execute function: " + call + " - " + e.getCause().getMessage());
         } catch (Exception e) {
             warn("Cannot execute function: " + call + " - " + e.getMessage());

--- a/src/main/java/sirius/web/sass/Generator.java
+++ b/src/main/java/sirius/web/sass/Generator.java
@@ -537,7 +537,7 @@ public class Generator {
                                                                       .replaceAll("[^a-z0-9]", ""),
                                                                   Generator.class,
                                                                   FunctionCall.class).invoke(null, this, call);
-        } catch (NoSuchMethodException ignored) {
+        } catch (NoSuchMethodException | IllegalArgumentException ignored) {
             return new Value(call.toString());
         } catch (InvocationTargetException e) {
             warn("Cannot execute function: " + call + " - " + e.getCause().getMessage());

--- a/src/test/java/sirius/web/sass/SassTest.java
+++ b/src/test/java/sirius/web/sass/SassTest.java
@@ -27,6 +27,12 @@ public class SassTest {
         compare("variables.scss", "variables.css");
     }
 
+
+    @Test
+    public void testFunctions() {
+        compare("functions.scss", "functions.css");
+    }
+
     @Test
     public void testEscape() {
         compare("escape.scss", "escape.css");

--- a/src/test/resources/sass/functions.css
+++ b/src/test/resources/sass/functions.css
@@ -1,0 +1,4 @@
+.test {
+    value: 1.0;
+    filters: opacity(40%);
+}

--- a/src/test/resources/sass/functions.scss
+++ b/src/test/resources/sass/functions.scss
@@ -1,0 +1,7 @@
+.test {
+  // Apply function...
+  value: opacity(#FF00FF);
+
+  // Leave CSS function in place...
+  filters: opacity(40%);
+}


### PR DESCRIPTION
This is required, as some functions are defined in both CSS and SCSS but with different parameters (and semantics).

One example is "opacity" which can also be a CSS value for "filter".