### PR TITLE
Continuity: Only calls state handler restore when entry is actually changed

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -521,3 +521,44 @@ sirius.isDragleaveEventLeavingWindow = function (event) {
     }
     return false;
 }
+
+/**@
+ * Compares the two given objects for equality, allowing for nested objects.
+ *
+ * @param object1 the first object to compare
+ * @param object2 the second object to compare
+ * @returns {boolean} true if the objects are equal, false otherwise
+ */
+sirius.areObjectsDeeplyEqual = function (object1, object2) {
+    const keys1 = Object.keys(object1);
+    const keys2 = Object.keys(object2);
+
+    if (keys1.length !== keys2.length) {
+        return false;
+    }
+
+    // var is used here instead of const to keep the code compatible with IE11.
+    for (var key of keys1) {
+        const value1 = object1[key];
+        const value2 = object2[key];
+        const areObjects = sirius.isObject(value1) && sirius.isObject(value2);
+        if (areObjects && !sirius.areObjectsDeeplyEqual(value1, value2)) {
+            return false;
+        }
+        if (!areObjects && value1 !== value2) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**@
+ * Checks if the given value is an object.
+ *
+ * @param object the value to check
+ * @returns {boolean} true if the value is an object, false otherwise
+ */
+sirius.isObject = function (object) {
+    return object != null && typeof object === 'object';
+}

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -149,7 +149,7 @@ window.sirius.Continuity = (function () {
             if (handler) {
                 const entry = state[entryKey];
                 me.log('[CONTINUITY] [INTERNAL] State handler of type "%s" called for entry: %o', entryKey, entry);
-                if (!deepEqual(stateBeforeChange[entryKey], entry)) {
+                if (!sirius.areObjectsDeeplyEqual(stateBeforeChange[entryKey], entry)) {
                     // We only call the handler if the specific entry has actually changed.
                     handler.restore.call(me, entry);
                 } else {
@@ -428,34 +428,6 @@ window.sirius.Continuity = (function () {
             event.detail = this;
             document.dispatchEvent(event);
         }
-    }
-
-    function deepEqual(object1, object2) {
-        const keys1 = Object.keys(object1);
-        const keys2 = Object.keys(object2);
-
-        if (keys1.length !== keys2.length) {
-            return false;
-        }
-
-        // var is used here instead of const to keep the code compatible with IE11.
-        for (var key of keys1) {
-            const value1 = object1[key];
-            const value2 = object2[key];
-            const areObjects = isObject(value1) && isObject(value2);
-            if (areObjects && !deepEqual(value1, value2)) {
-                return false;
-            }
-            if (!areObjects && value1 !== value2) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    function isObject(object) {
-        return object != null && typeof object === 'object';
     }
 
     return Continuity;

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -137,8 +137,9 @@ window.sirius.Continuity = (function () {
      * @param {boolean} dontSetLastState whether the internal last state should be replaced by the current history state (before the new one became active)
      */
     Continuity.prototype.handleStateChange = function (state, dontSetLastState) {
+        let stateBeforeChange = Object.assign({}, this.currentState);
         if (!dontSetLastState) {
-            this.lastState = Object.assign({}, this.currentState);
+            this.lastState = stateBeforeChange;
         }
         this.currentState = state;
 
@@ -148,7 +149,12 @@ window.sirius.Continuity = (function () {
             if (handler) {
                 const entry = state[entryKey];
                 me.log('[CONTINUITY] [INTERNAL] State handler of type "%s" called for entry: %o', entryKey, entry);
-                handler.restore.call(me, entry);
+                if (!deepEqual(stateBeforeChange[entryKey], entry)) {
+                    // We only call the handler if the specific entry has actually changed.
+                    handler.restore.call(me, entry);
+                } else {
+                    me.log('[CONTINUITY] [INTERNAL] State handler of type "%s" called for unchanged entry: %o', entryKey, entry);
+                }
             } else {
                 me.log('[CONTINUITY] [INTERNAL] State handler of type "%s" not found!', entryKey);
             }
@@ -422,6 +428,34 @@ window.sirius.Continuity = (function () {
             event.detail = this;
             document.dispatchEvent(event);
         }
+    }
+
+    function deepEqual(object1, object2) {
+        const keys1 = Object.keys(object1);
+        const keys2 = Object.keys(object2);
+
+        if (keys1.length !== keys2.length) {
+            return false;
+        }
+
+        // var is used here instead of const to keep the code compatible with IE11.
+        for (var key of keys1) {
+            const value1 = object1[key];
+            const value2 = object2[key];
+            const areObjects = isObject(value1) && isObject(value2);
+            if (areObjects && !deepEqual(value1, value2)) {
+                return false;
+            }
+            if (!areObjects && value1 !== value2) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    function isObject(object) {
+        return object != null && typeof object === 'object';
     }
 
     return Continuity;


### PR DESCRIPTION
Optimized the 'handleStateChange' function to ensure that the state handler is only called when there is a real change in the state. For this a deep comparison function 'deepEqual' was also added to make sure the changes in the nested properties of objects are correctly detected. This should improve the "optical stability" of the page as state handlers aren't executing code that recreate the currently visible state (e.g. by executing the same search again).

Fixes: [OX-10141](https://scireum.myjetbrains.com/youtrack/issue/OX-10141)