### PR TITLE
IE 11: Correctly applies fallback logic for silent form submit

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -322,12 +322,12 @@ sirius.camelize = function (str) {
  *
  * @param form the form to submit
  */
-sirius.requestSubmitForm = function (form) {
-    if (form != null) {
-        if (form.requestSubmit) {
-            form.requestSubmit();
+sirius.requestSubmitForm = function (_form) {
+    if (_form != null) {
+        if (_form.requestSubmit) {
+            _form.requestSubmit();
         } else {
-            form.submit();
+            _form.submit();
         }
     }
 }

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -318,7 +318,7 @@ sirius.camelize = function (str) {
  * Submits the given form using
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit HTMLFormElement.requestSubmit}
  * to trigger its submit event as well as constraint validation.
- * Falls back to silently submitting the form via {@link HTMLFormElement.submit} in unsupported browsers.
+ * Falls back to silently submitting the form via a hidden submit button in unsupported browsers.
  *
  * @param form the form to submit
  */
@@ -327,7 +327,17 @@ sirius.requestSubmitForm = function (_form) {
         if (_form.requestSubmit) {
             _form.requestSubmit();
         } else {
-            _form.submit();
+            // Workaround for browsers (like IE 11) that don't support requestSubmit.
+            // Calling submit directly would skip the onsubmit event and constraint validation.
+            // This means there is no way to prevent the page from reloading when submitting the form.
+            const _submitButton = document.createElement('button');
+            _submitButton.type = 'submit';
+            _submitButton.style.display = 'none';
+            _form.appendChild(_submitButton);
+
+            _submitButton.click();
+
+            _form.removeChild(_submitButton);
         }
     }
 }


### PR DESCRIPTION
Changed the fallback mechanism for silent form submission.
Originally, the functionality directly called `HTMLFormElement.submit` in cases when the `HTMLFormElement.requestSubmit` was not supported by the browser.
However, this bypassed triggering the 'onsubmit' event and constraint validation, and there was no way to prevent the page from reloading.
Now, a hidden submit button is created dynamically to handle the submission instead, ensuring 'onsubmit' event, validation, and prevention of page reload. This change enhances compatibility with older browsers like IE 11.

Fixes: [OX-10197](https://scireum.myjetbrains.com/youtrack/issue/OX-10197)