### PR TITLE
IE 11: Fixes excessively large dialog header height

### DIFF
--- a/src/main/resources/default/assets/common/scripts/dialog.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/dialog.js.pasta
@@ -1,9 +1,9 @@
 (function (dialog) {
     const template = '<div id="sci-dialog-background" class="sci-d-none sci-position-fixed sci-align-items-center sci-justify-content-center sci-p-2 sci-text sci-font sci-enable-font">' +
         '   <div id="sci-dialog" class="sci-d-flex sci-font sci-bg-white sci-p-2 sci-shadow sci-card sci-flex-column sci-overflow-hidden">' +
-        '      <div id="sci-dialog-header" class="sci-pt-1 sci-pb-2 sci-d-flex sci-justify-content-space-between sci-border-grey sci-flex-shrink-0 sci-overflow-hidden">' +
+        '      <div id="sci-dialog-header" class="sci-pt-1 sci-pb-2 sci-d-flex sci-justify-content-space-between sci-align-items-center sci-border-grey sci-flex-shrink-0 sci-overflow-hidden">' +
         '          <div id="sci-dialog-title" class="sci-text-size-h2 sci-text-ellipsis sci-text-grey-dark"></div>' +
-        '          <div class="sci-cursor-pointer sci-d-flex sci-dialog-button-close-js" style="width: 1.5rem;">@escapeJS(inlineSVG("/assets/images/icons/navigation/close-thin.svg"))</div>' +
+        '          <div class="sci-cursor-pointer sci-d-flex sci-dialog-button-close-js" style="width: 1.5rem; height: 1.5rem;">@escapeJS(inlineSVG("/assets/images/icons/navigation/close-thin.svg"))</div>' +
         '      </div>' +
         '      <div id="sci-dialog-content" class="sci-text sci-flex-grow-1 sci-d-flex sci-flex-column"></div>' +
         '      <div id="sci-dialog-footer" class="sci-pt-2 sci-d-flex sci-border-grey sci-flex-shrink-0 sci-d-none sci-overflow-hidden"></div>' +


### PR DESCRIPTION
For some reason IE 11 would render the close button icon with an excessive height when no specific height is given. Because of this we now specify a height (the icon is square anyway).

**Before:**

![image](https://github.com/scireum/sirius-web/assets/2427877/337bb976-7c43-4093-805c-89e43e292dd9)


**After:**

![image](https://github.com/scireum/sirius-web/assets/2427877/2bf9f239-8693-4415-8abe-0328beab0b10)
