### PR TITLE
Fixes t:dropdownDeleteItem

### DIFF
--- a/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
@@ -2,9 +2,10 @@
 <i:arg type="Page" name="page" default=""/>
 <i:arg type="String" name="permission" default=""/>
 <i:arg type="String" name="framework" default=""/>
-<i:arg type="String" name="class"  default="" description="Lists additional CSS classes to apply to the item."/>
+<i:arg type="String" name="class" default="" description="Lists additional CSS classes to apply to the item."/>
 <i:arg type="boolean" name="adminOnly" default="false"/>
-<i:arg type="boolean" name="withConfirm" default="true" description="Specifies if a confirmation modal should pop up when clicked on the item"/>
+<i:arg type="boolean" name="withConfirm" default="true"
+       description="Specifies if a confirmation modal should pop up when clicked on the item"/>
 <i:arg type="String" name="labelKey" default="NLS.delete"/>
 
 <i:pragma name="description" value="Renders a delete link to be used in a dropdown menu (e.g. card actions)."/>

--- a/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
@@ -9,7 +9,9 @@
 
 <i:pragma name="description" value="Renders a delete link to be used in a dropdown menu (e.g. card actions)."/>
 
-<t:dropdownItem class="danger @(withConfirm ? 'confirm-link-js' : '') @class"
+<i:local name="dropdownClass" value="@apply('danger %s %s', class, withConfirm ? 'confirm-link-js' : '')"/>
+
+<t:dropdownItem class="@dropdownClass"
                 permission="@permission"
                 framework="@framework"
                 icon="fa-solid fa-trash fa-fw"


### PR DESCRIPTION
Taglib parameters only support either string literals (`class="foo bar"`) or noodle expressions (`class="@Class"`), but not both together. We need to use `@apply` to concatenate everything together.