### PR TITLE
API Docs: shows method and content type in toc instead of generic icon

### DIFF
--- a/src/main/resources/default/templates/system/api.html.pasta
+++ b/src/main/resources/default/templates/system/api.html.pasta
@@ -25,8 +25,9 @@
         <i:block name="sidebar">
             <t:navbox labelKey="template.html.tableOfContent.heading">
                 <i:for type="sirius.web.services.PublicServiceInfo" var="service" items="api.getServices()">
-                    <t:navboxLink url="@apply('#%s', service.getUri())"
-                                  icon="fa fa-file-alt">
+                    <t:navboxLink url="@apply('#%s', service.getUri())">
+                        <i:invoke template="/templates/system/service-format-tag.html.pasta"
+                                  service="@service"/>
                         @service.getLabel()
                     </t:navboxLink>
                 </i:for>
@@ -64,25 +65,11 @@
                         </p>
                     </i:if>
 
-                    <div>
-                        <div class="p-2" style="border-radius: 4px; background-color: #EEEEEE">
-                            <t:fullTag color="@service.determineHttpMethodColor(service.getHttpMethod())"
-                                       class="align-text-top">
-                                @service.getHttpMethod().name()
-                            </t:fullTag>
+                    <div class="p-2" style="border-radius: 4px; background-color: #EEEEEE">
+                        <i:invoke template="/templates/system/service-format-tag.html.pasta"
+                                  service="@service"/>
 
-                            <i:if test="service.getFormat() == sirius.web.services.Format.JSON">
-                                <t:fullTag color="blue-light" class="align-text-top">JSON</t:fullTag>
-                            </i:if>
-                            <i:if test="service.getFormat() == sirius.web.services.Format.XML">
-                                <t:fullTag color="green-light" class="align-text-top">XML</t:fullTag>
-                            </i:if>
-                            <i:if test="service.getFormat() == sirius.web.services.Format.RAW">
-                                <t:fullTag color="violet-light" class="align-text-top">RAW</t:fullTag>
-                            </i:if>
-
-                            <span class="text-monospace whitespace-pre-wrap">@service.getUri()</span>
-                        </div>
+                        <span class="text-monospace whitespace-pre-wrap">@service.getUri()</span>
                     </div>
 
                     <i:if test="!service.getParameters().isEmpty()">

--- a/src/main/resources/default/templates/system/service-format-tag.html.pasta
+++ b/src/main/resources/default/templates/system/service-format-tag.html.pasta
@@ -1,0 +1,16 @@
+<i:arg type="sirius.web.services.PublicServiceInfo" name="service"/>
+
+<t:fullTag color="@service.determineHttpMethodColor(service.getHttpMethod())"
+           class="align-text-top">
+    @service.getHttpMethod().name()
+</t:fullTag>
+
+<i:if test="service.getFormat() == sirius.web.services.Format.JSON">
+    <t:fullTag color="blue-light" class="align-text-top">JSON</t:fullTag>
+</i:if>
+<i:if test="service.getFormat() == sirius.web.services.Format.XML">
+    <t:fullTag color="green-light" class="align-text-top">XML</t:fullTag>
+</i:if>
+<i:if test="service.getFormat() == sirius.web.services.Format.RAW">
+    <t:fullTag color="violet-light" class="align-text-top">RAW</t:fullTag>
+</i:if>


### PR DESCRIPTION
Provides a better overview of the service capabilities in the table of contents. Also eliminates name conflicts if documentation exists for the same service with different content types (e.g. json vs xml as in the 2nd screenshot).

Before:
![Bildschirmfoto 2023-07-27 um 12 11 19](https://github.com/scireum/sirius-web/assets/42942954/9da4fc3a-95a1-4908-9d4a-cbcb83d2089b)
![Bildschirmfoto 2023-07-27 um 12 10 54](https://github.com/scireum/sirius-web/assets/42942954/18038fcd-2b86-44f9-a4bb-9984ac1e8eef)


After:
![Bildschirmfoto 2023-07-27 um 12 17 43](https://github.com/scireum/sirius-web/assets/42942954/08656849-aa1a-4c9e-a628-386af627f4ab)

![Bildschirmfoto 2023-07-27 um 12 16 53](https://github.com/scireum/sirius-web/assets/42942954/879efadc-979a-48aa-9b60-c8b506f95fe4)
