### PR TITLE
Sirius JS: Allows to suppress enter listener when shift is pressed

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -148,7 +148,7 @@ sirius.findParentOfType = function (_node, type) {
  *
  * @param _node the node to attach the listener on
  * @param listener the listener to attach
- * @param [suppressOnShift] if true, the listener is only invoked if shift is not simulataniously pressed
+ * @param [suppressOnShift] if true, the listener is only invoked if shift is not simultaneously pressed
  */
 sirius.addEnterListener = function (_node, listener, suppressOnShift) {
     _node.addEventListener('keydown', function (event) {
@@ -250,7 +250,7 @@ sirius.throttle = function (fn, threshold) {
 /**@
  * Adds an event listener that triggers exactly once per element when it becomes visible or is about to become visible.
  * <p>
- * The event will trigger once an element comes within a certain distance to the viewport. By default the vertical and
+ * The event will trigger once an element comes within a certain distance to the viewport. By default, the vertical and
  * horizontal distances are equal to the element's height and width respectively. This distance can be increased by
  * specifying a value greater than 1 as the distanceFactor.
  *

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -148,9 +148,13 @@ sirius.findParentOfType = function (_node, type) {
  *
  * @param _node the node to attach the listener on
  * @param listener the listener to attach
+ * @param [suppressOnShift] if true, the listener is only invoked if shift is not simulataniously pressed
  */
-sirius.addEnterListener = function (_node, listener) {
+sirius.addEnterListener = function (_node, listener, suppressOnShift) {
     _node.addEventListener('keydown', function (event) {
+        if (suppressOnShift && event.shiftKey) {
+            return;
+        }
         if (event.key === 'Enter') {
             event.preventDefault();
             listener(event);


### PR DESCRIPTION
This is useful for allowing to insert new lines via Shift + Enter in text areas.