### PR TITLE
Fixes a Chrome only issue where click-spaming on a button lead to multiple execution of the attached click-handlers although the button had the pending class attached

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -7,7 +7,7 @@ sirius.ready(function () {
                 return true;
             }
             _node.classList.add('single-click-pending-js');
-        });
+        }, true);
     });
 
     document.querySelectorAll('.submit-link-js').forEach(function (_node) {

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -3,6 +3,7 @@ sirius.ready(function () {
         _node.addEventListener('click', function (e) {
             if (_node.classList.contains('single-click-pending-js')) {
                 e.preventDefault();
+                e.stopPropagation();
                 e.cancelBubble = true;
                 return true;
             }

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -63,4 +63,3 @@ function getFormData(_node) {
     }
     return object;
 }
-

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -1,10 +1,10 @@
 sirius.ready(function () {
     document.querySelectorAll('.single-click-link-js').forEach(function (_node) {
-        _node.addEventListener('click', function (e) {
+        _node.addEventListener('click', function (event) {
             if (_node.classList.contains('single-click-pending-js')) {
-                e.preventDefault();
-                e.stopPropagation();
-                e.cancelBubble = true;
+                event.preventDefault();
+                event.stopPropagation();
+                event.cancelBubble = true;
                 return true;
             }
             _node.classList.add('single-click-pending-js');


### PR DESCRIPTION
The issue was solved by setting the useCapture option to true which controls whether events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener