### PR TITLE
Tycho: Correctly shows error state on token autocomplete fields

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/forms.scss
+++ b/src/main/resources/default/assets/tycho/styles/forms.scss
@@ -112,6 +112,9 @@
   }
 }
 
+.has-error .form-control.token-autocomplete-container {
+  border-color: $sirius-red;
+}
 
 .form-control.token-autocomplete-container.token-autocomplete-singleselect {
   .token-autocomplete-input:after {


### PR DESCRIPTION
The default style specified above has a rather unspecific selector and therefore was overwritten by the rule that set the default gray border color of the field.

![image](https://github.com/scireum/sirius-web/assets/2427877/c5eefc34-cbcc-4e8e-97ef-6ac10d101784)


Fixes: [SIRI-876](https://scireum.myjetbrains.com/youtrack/issue/SIRI-876)