### PR TITLE
SE-13063: Only prevent multiple clicks if it would lead to a form submission

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -1,6 +1,6 @@
 sirius.ready(function () {
     document.querySelectorAll('.single-click-link-js').forEach(function (_node) {
-        if (sirius.findParentOfType(_node, 'FORM')) {
+        if (sirius.findParentOfType(_node, 'FORM') != null) {
             _node.addEventListener('click', function (event) {
                 if (_node.classList.contains('single-click-pending-js')) {
                     event.preventDefault();

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -1,14 +1,16 @@
 sirius.ready(function () {
     document.querySelectorAll('.single-click-link-js').forEach(function (_node) {
-        _node.addEventListener('click', function (event) {
-            if (_node.classList.contains('single-click-pending-js')) {
-                event.preventDefault();
-                event.stopPropagation();
-                event.cancelBubble = true;
-                return true;
-            }
-            _node.classList.add('single-click-pending-js');
-        }, true);
+        if (sirius.findParentOfType(_node, 'FORM')) {
+            _node.addEventListener('click', function (event) {
+                if (_node.classList.contains('single-click-pending-js')) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.cancelBubble = true;
+                    return true;
+                }
+                _node.classList.add('single-click-pending-js');
+            }, true);
+        }
     });
 
     document.querySelectorAll('.submit-link-js').forEach(function (_node) {


### PR DESCRIPTION
In cases where the submit button does not reside inside a form and thus the page is probably not going to be reloaded automatically, it is more likely that multiple submissions are okay and that t:formBar was simply invoked without a 'singleClick' parameter.

This is an alternative solution to https://github.com/scireum/sirius-biz/pull/1845

Fixes: SE-13063