### PR TITLE
Design System: Correct Border Rules & Dsiabled Style for Buttons

### DIFF
--- a/src/main/resources/assets/design-system/button.scss
+++ b/src/main/resources/assets/design-system/button.scss
@@ -2,6 +2,8 @@
   cursor: pointer;
   text-decoration: none;
   text-align: center;
+  border-width: 0;
+  border-style: none;
   border-radius: 0.25rem;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/main/resources/assets/design-system/button.scss
+++ b/src/main/resources/assets/design-system/button.scss
@@ -37,6 +37,11 @@
     background-color: lighten($sirius-primary, 25%) !important;
     color: $sirius-white !important;
   }
+
+  &:disabled, &.sci-btn-disabled {
+    background-color: lighten($sirius-primary, 25%) !important;
+    cursor: default;
+  }
 }
 
 .sci-btn-secondary {
@@ -48,6 +53,11 @@
   &:hover {
     background-color: lighten($sirius-gray-dark, 25%) !important;
     color: $sirius-white !important;
+  }
+
+  &:disabled, &.sci-btn-disabled {
+    background-color: lighten($sirius-gray-dark, 25%) !important;
+    cursor: default;
   }
 }
 
@@ -74,6 +84,12 @@
     background-color: $sirius-primary !important;
     color: $sirius-white !important;
   }
+
+  &:disabled, &.sci-btn-disabled {
+    border-color: lighten($sirius-primary, 25%) !important;
+    color: lighten($sirius-primary, 25%) !important;
+    cursor: default;
+  }
 }
 
 .sci-btn-secondary-outline {
@@ -86,6 +102,12 @@
   &:hover {
     background-color: $sirius-gray-dark !important;
     color: $sirius-white !important;
+  }
+
+  &:disabled, &.sci-btn-disabled {
+    border-color: lighten($sirius-gray-dark, 25%) !important;
+    color: lighten($sirius-gray-dark, 25%) !important;
+    cursor: default;
   }
 }
 


### PR DESCRIPTION
This allows us to also apply our button classes to button elements. Previously this looked hideous as the default styles of the button elements introduced a border that we did not override. So the classes were only suitable for anchor, div or span elements.

**Before:**

![image](https://github.com/scireum/sirius-web/assets/2427877/6ebb4b28-cf69-4e48-ac25-b5df4c9d48b6)

**After:**

![image](https://github.com/scireum/sirius-web/assets/2427877/0eec8251-55a5-47e6-97fa-f7de70825510)

**Disabled Style:**

![image](https://github.com/scireum/sirius-web/assets/2427877/62c2ed72-768c-4c29-ba25-f5469e597f21)


Fixes: [OX-10460](https://scireum.myjetbrains.com/youtrack/issue/OX-10460)