### PR TITLE
Extends the autoReloadImage function by a fallback image...

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -442,9 +442,10 @@ sirius.embedSvgImages = function (_container, selector) {
  *
  * @param _image the DOM element of the image to reload
  * @param imageSource the source of the image to load
+ * @param fallbackImageSource the fallback image source to use if the image cannot be loaded
  * @param callback an optional callback to execute once the image is loaded
  */
-sirius.autoReloadImage = function (_image, imageSource, callback) {
+sirius.autoReloadImage = function (_image, imageSource, fallbackImageSource, callback) {
     let maxRetryCount = 3;
     let retryCount = 1;
     let waitTime = 1000;
@@ -468,6 +469,8 @@ sirius.autoReloadImage = function (_image, imageSource, callback) {
             setTimeout(function () {
                 _image.src = imageSource;
             }, waitTime);
+        } else if (sirius.isFilled(fallbackImageSource) && retryCount === maxRetryCount + 1) {
+            _image.src = fallbackImageSource;
         }
     };
 


### PR DESCRIPTION
...which allows one to specify a fallback image which should be shown in the case that the image could not be displayed after the max retry count has been reached

Fixes: OX-10093