### PR TITLE
Sirius JS: Actually make helper work with plain DOM elements

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -825,10 +825,10 @@ sirius.copyToClipboard = function (textToCopy, _element) {
     selection.addRange(range);
     _fakeElement.setSelectionRange(0, textToCopy.length);
 
-    if (document.execCommand('copy') && typeof _element !== 'undefined' && typeof _element.addClass === 'function') {
-        _element.addClass('sci-copied');
+    if (document.execCommand('copy') && sirius.isDefined(_element) && _element instanceof HTMLElement) {
+        _element.classList.add('sci-copied');
         setTimeout(function () {
-            _element.removeClass('sci-copied');
+            _element.classList.remove('sci-copied');
         }, 1000);
     }
     document.body.removeChild(_fakeElement);


### PR DESCRIPTION
The previous implementation checked for a function that is only present on JQuery DOM objects.

Fixes: [SIRI-880](https://scireum.myjetbrains.com/youtrack/issue/SIRI-880)