### PR TITLE
Prevents duplicate arguments

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/VariableScoper.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/VariableScoper.java
@@ -20,7 +20,7 @@ import java.util.Set;
 /**
  * Responsible for keeping track which variables are currently visible.
  * <p>
- * This also assigns each variable an unique index as the interperter later on only stores them in a simple list.
+ * This also assigns each variable a unique index as the interpreter later on only stores them in a simple list.
  */
 public class VariableScoper {
 
@@ -128,7 +128,7 @@ public class VariableScoper {
     /**
      * Pushes a new scope on the stack.
      * <p>
-     * Use {@link Scope#pop()} to remove it once he scope / block is closed.
+     * Use {@link Scope#pop()} to remove it once the scope / block is closed.
      *
      * @return the newly created scope
      */

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
@@ -99,6 +99,10 @@ public class ArgTag extends TagHandler {
                                           typeName);
         }
 
+        if (getCompilationContext().getVariableScoper().resolve(name).isPresent()) {
+            getCompilationContext().warning(getStartOfTag(), "An argument with the name '%s' is already defined.", name);
+        }
+
         getCompilationContext().getVariableScoper().defineVariable(getStartOfTag(), name, type);
         getCompilationContext().getTemplate()
                                .addArgument(new TemplateArgument(type,

--- a/src/main/resources/default/taglib/t/datefield.html.pasta
+++ b/src/main/resources/default/taglib/t/datefield.html.pasta
@@ -10,7 +10,6 @@
 <i:arg name="help" type="String" default="@i18n(helpKey)"/>
 <i:arg name="addonText" type="String" default=""/>
 <i:arg name="readonly" type="boolean" default="false"/>
-<i:arg name="id" type="String" default=""/>
 <i:arg name="placeholder" type="String" default=""/>
 <i:arg name="tabIndex" type="String" default=""/>
 <i:arg name="noPastDates" type="boolean" default="false" />

--- a/src/main/resources/default/taglib/t/textfield.html.pasta
+++ b/src/main/resources/default/taglib/t/textfield.html.pasta
@@ -13,7 +13,6 @@
 <i:arg name="addonText" type="String" default=""/>
 <i:arg name="readonly" type="boolean" default="false"/>
 <i:arg name="type" type="String" default="text"/>
-<i:arg name="id" type="String" default=""/>
 <i:arg name="placeholder" type="String" default=""/>
 <i:arg name="tabIndex" type="String" default=""/>
 

--- a/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
+++ b/src/test/java/sirius/pasta/tagliatelle/CompilerSpec.groovy
@@ -326,6 +326,16 @@ class CompilerSpec extends BaseSpecification {
         errors.get(0).getMessage().contains("The attribute 'deprecatedArg' is deprecated: Do not use")
     }
 
+    def "duplicate arguments are detected"() {
+        when:
+        TemplateCompilationContext compilationContext = compile("/templates/duplicateArgument.html.pasta")
+        List<ParseError> errors = compilationContext.getErrors()
+        then:
+        errors.size() == 1
+        errors.get(0).getSeverity() == ParseError.Severity.WARNING
+        errors.get(0).getMessage().contains("An argument with the name 'test' is already defined")
+    }
+
     def "deprecation is detected"() {
         when:
         TemplateCompilationContext compilationContext = compile("/templates/deprecatedCaller.html.pasta")

--- a/src/test/resources/templates/duplicateArgument.html.pasta
+++ b/src/test/resources/templates/duplicateArgument.html.pasta
@@ -1,2 +1,3 @@
+<i:pragma name="unchecked" value="true" />
 <i:arg type="String" name="test"/>
 <i:arg type="String" name="test"/>

--- a/src/test/resources/templates/duplicateArgument.html.pasta
+++ b/src/test/resources/templates/duplicateArgument.html.pasta
@@ -1,0 +1,2 @@
+<i:arg type="String" name="test"/>
+<i:arg type="String" name="test"/>


### PR DESCRIPTION
Defining two arguments with the same name are pretty pointless (rather a mistake) and therefore emit a warning

Fixes: SIRI-879