### PR TITLE
Fixes a possible NPE navigating to /help

### DIFF
--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -70,7 +70,8 @@ public class HelpDispatcher implements WebDispatcher {
 
     @Override
     public DispatchDecision dispatch(WebContext ctx) throws Exception {
-        if (!ctx.getRequestedURI().startsWith(HELP_PREFIX) || !HttpMethod.GET.equals(ctx.getRequest().method())) {
+        if (!(ctx.getRequestedURI().startsWith(HELP_PREFIX + "/") || ctx.getRequestedURI().endsWith(HELP_PREFIX))
+            || !HttpMethod.GET.equals(ctx.getRequest().method())) {
             return DispatchDecision.CONTINUE;
         }
 

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -70,7 +70,7 @@ public class HelpDispatcher implements WebDispatcher {
 
     @Override
     public DispatchDecision dispatch(WebContext ctx) throws Exception {
-        if (!(ctx.getRequestedURI().startsWith(HELP_PREFIX + "/") || ctx.getRequestedURI().endsWith(HELP_PREFIX))
+        if (!(ctx.getRequestedURI().startsWith(HELP_PREFIX + "/") || HELP_PREFIX.equals(ctx.getRequestedURI()))
             || !HttpMethod.GET.equals(ctx.getRequest().method())) {
             return DispatchDecision.CONTINUE;
         }


### PR DESCRIPTION
- `/help` -> OK
- `/help/` -> OK
- `/help/...` -> OK
- `/help2`-> FAIL

```stacktrace
sirius.kernel.health.HandledException: An unexpected exception occurred: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null (java.lang.NullPointerException)
	at sirius.kernel.health.Exceptions$ErrorHandler.handle(Exceptions.java:246)
	at sirius.kernel.health.Exceptions.handle(Exceptions.java:411)
	at sirius.web.http.DispatcherPipeline.handleInternalServerError(DispatcherPipeline.java:106)
	at sirius.web.http.DispatcherPipeline.dispatch(DispatcherPipeline.java:97)
	at sirius.web.http.DispatcherPipeline.lambda$dispatch$1(DispatcherPipeline.java:65)
	at sirius.kernel.async.ExecutionBuilder$TaskWrapper.run(ExecutionBuilder.java:122)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
	at java.base/java.util.regex.Matcher.getTextLength(Unknown Source)
	at java.base/java.util.regex.Matcher.reset(Unknown Source)
	at java.base/java.util.regex.Matcher.<init>(Unknown Source)
	at java.base/java.util.regex.Pattern.matcher(Unknown Source)
	at sirius.web.dispatch.HelpDispatcher.setupLanguage(HelpDispatcher.java:149)
	at sirius.web.dispatch.HelpDispatcher.dispatch(HelpDispatcher.java:94)
	at sirius.web.http.DispatcherPipeline.dispatch(DispatcherPipeline.java:80)
```