### PR TITLE
Supports If-Modified-Since HTTP header delivering assets

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -222,7 +222,9 @@ public class AssetsDispatcher implements WebDispatcher {
             }
         }
 
-        response.named(uri.substring(uri.lastIndexOf('/') + 1)).file(file);
+        if (!handleUnmodified(file, response)) {
+            response.named(uri.substring(uri.lastIndexOf('/') + 1)).file(file);
+        }
         return DispatchDecision.DONE;
     }
 

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -105,18 +105,18 @@ public class AssetsDispatcher implements WebDispatcher {
     private DispatchDecision tryStaticResource(WebContext ctx, String uri, Response response)
             throws URISyntaxException, IOException {
         Optional<Resource> res = resources.resolve(uri).filter(resource -> !resource.getPath().endsWith(PASTA_SUFFIX));
-        if (res.isPresent()) {
-            ctx.enableTiming(ASSETS_PREFIX);
-            URL url = res.get().getUrl();
-            if ("file".equals(url.getProtocol())) {
-                response.file(new File(url.toURI()));
-            } else {
-                response.resource(url.openConnection());
-            }
-            return DispatchDecision.DONE;
+        if (res.isEmpty()) {
+            return DispatchDecision.CONTINUE;
         }
 
-        return DispatchDecision.CONTINUE;
+        ctx.enableTiming(ASSETS_PREFIX);
+        URL url = res.get().getUrl();
+        if ("file".equals(url.getProtocol())) {
+            response.file(new File(url.toURI()));
+        } else {
+            response.resource(url.openConnection());
+        }
+        return DispatchDecision.DONE;
     }
 
     private Tuple<String, Integer> getEffectiveURI(WebContext ctx) {

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -147,7 +147,7 @@ public class AssetsDispatcher implements WebDispatcher {
         try {
             Optional<Template> template = tagliatelle.resolve(uri + PASTA_SUFFIX);
             if (template.isPresent()) {
-                if (!handleUnmodified(template.get(), response)) {
+                if (!handleUnmodifiedTemplate(template.get(), response)) {
                     response.template(HttpResponseStatus.OK, template.get());
                 }
 
@@ -170,7 +170,7 @@ public class AssetsDispatcher implements WebDispatcher {
                                                               + i18nMatcher.group("extension")
                                                               + PASTA_SUFFIX);
             if (template.isPresent()) {
-                if (!handleUnmodified(template.get(), response)) {
+                if (!handleUnmodifiedTemplate(template.get(), response)) {
                     response.template(HttpResponseStatus.OK, template.get());
                 }
 
@@ -181,7 +181,7 @@ public class AssetsDispatcher implements WebDispatcher {
         return DispatchDecision.CONTINUE;
     }
 
-    private boolean handleUnmodified(Template template, Response response) {
+    private boolean handleUnmodifiedTemplate(Template template, Response response) {
         if (!template.isConstant()) {
             return false;
         }

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -116,12 +116,12 @@ public class AssetsDispatcher implements WebDispatcher {
         URL url = optionalResource.get().getUrl();
         if ("file".equals(url.getProtocol())) {
             File file = new File(url.toURI());
-            if (!handleUnmodified(file, response)) {
+            if (!response.handleIfModifiedSince(file.lastModified())) {
                 response.file(file);
             }
         } else {
             URLConnection urlConnection = url.openConnection();
-            if (!handleUnmodified(urlConnection, response)) {
+            if (!response.handleIfModifiedSince(urlConnection.getLastModified())) {
                 response.resource(urlConnection);
             }
         }
@@ -189,14 +189,6 @@ public class AssetsDispatcher implements WebDispatcher {
         return response.handleIfModifiedSince(template.getCompilationTimestamp());
     }
 
-    private boolean handleUnmodified(URLConnection urlConnection, Response response) {
-        return response.handleIfModifiedSince(urlConnection.getLastModified());
-    }
-
-    private boolean handleUnmodified(File file, Response response) {
-        return response.handleIfModifiedSince(file.lastModified());
-    }
-
     private DispatchDecision trySASS(WebContext webContext, String uri, Response response) {
         if (!uri.endsWith(".css")) {
             return DispatchDecision.CONTINUE;
@@ -226,7 +218,7 @@ public class AssetsDispatcher implements WebDispatcher {
             }
         }
 
-        if (!handleUnmodified(file, response)) {
+        if (!response.handleIfModifiedSince(file.lastModified())) {
             response.named(uri.substring(uri.lastIndexOf('/') + 1)).file(file);
         }
         return DispatchDecision.DONE;

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -568,11 +568,10 @@ public class Response {
      * @return <tt>true</tt> if the request was answered via a 304, <tt>false</tt> otherwise
      */
     public boolean handleIfModifiedSince(long lastModifiedInMillis) {
-        long ifModifiedSinceDateSeconds = WebServer.parseDateHeader(getHeader(HttpHeaderNames.IF_MODIFIED_SINCE))
-                                                   .map(date -> date.atZone(ZoneId.systemDefault())
-                                                                    .toInstant()
-                                                                    .getEpochSecond())
-                                                   .orElse(0L);
+        long ifModifiedSinceDateSeconds =
+                WebServer.parseDateHeader(webContext.getHeader(HttpHeaderNames.IF_MODIFIED_SINCE))
+                         .map(date -> date.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond())
+                         .orElse(0L);
         if (ifModifiedSinceDateSeconds > 0
             && lastModifiedInMillis > 0
             && ifModifiedSinceDateSeconds >= lastModifiedInMillis / 1000) {


### PR DESCRIPTION
If the asset has been modified before the [If-Modified-Since](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since) requested date, we return a 304 NOT_MODIFIED return code with am empty body.

This logic was implemented for tagliatelle templates, but not for static assets or compiled CSS files, although a bug has been fixed here and the portion of code never really worked. See 1st. commit for details.

Fixes: [SIRI-729](https://scireum.myjetbrains.com/youtrack/issue/SIRI-729)