### PR TITLE
JS: Adds helper for checking if a DOM node is probably visible

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -31,6 +31,22 @@ sirius.isEmptyNode = function (node) {
 }
 
 /**@
+ * Checks if a given DOM node is visible.
+ * <p>
+ * Note: This is not a perfect way to check for visibility, but it's a good approximation in controlled circumstances.
+ *
+ * @param {Node} node the DOM node to check for visibility
+ * @returns {boolean} true if the node is most probably visible
+ */
+sirius.isVisibleNode = function (_node) {
+    if (!sirius.isDefined(_node) || !sirius.isElement(_node)) {
+        return false;
+    }
+    const style = window.getComputedStyle(_node);
+    return style && style.display !== 'none' && style.visibility !== 'hidden' && style.visibility !== 'collapse';
+}
+
+/**@
  * Checks if the given value is empty or null.
  * <p>
  * Note: Regarding DOM elements the method only checks if the given value is a DOM element and therefore is defined.

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -31,9 +31,10 @@ sirius.isEmptyNode = function (node) {
 }
 
 /**@
- * Checks if a given DOM node is visible.
+ * Checks if a given DOM node could be visible to the user (as in it is not actively hidden).
  * <p>
  * Note: This is not a perfect way to check for visibility, but it's a good approximation in controlled circumstances.
+ * Also, it does not check if the node is actually currently in the viewport.
  *
  * @param {Node} node the DOM node to check for visibility
  * @returns {boolean} true if the node is most probably visible


### PR DESCRIPTION
This is not a definitive way (as there are many more ways to manipulate a node to not show up, like size, opacity, ...) but its a useful way to determine whether a node is shown or hidden via our most used measures:

- manual display none
- sci-d-none

Fixes: [OX-10422](https://scireum.myjetbrains.com/youtrack/issue/OX-10422)