### PR TITLE
Revamps asset caching

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -71,7 +71,8 @@ public class AssetsDispatcher implements WebDispatcher {
     private String cacheDir;
 
     @ConfigValue("http.response.defaultStaticAssetTTL")
-    private Duration defaultStaticAssetTTL;
+    private static Duration defaultStaticAssetTTL;
+
     private File cacheDirFile;
 
     @Part
@@ -143,7 +144,7 @@ public class AssetsDispatcher implements WebDispatcher {
             return 0;
         }
 
-        return constantAsset ? (int) defaultStaticAssetTTL.getSeconds() : Response.fetchDefaultClientTTL();
+        return constantAsset ? (int) defaultStaticAssetTTL.getSeconds() : Response.obtainClientDurationInSeconds();
     }
 
     private String computeEffectiveCustomProxyTTL(String uri, boolean constantAsset) {

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -88,20 +88,20 @@ public class AssetsDispatcher implements WebDispatcher {
             return DispatchDecision.CONTINUE;
         }
 
-        Tuple<String, Integer> uriAndCacheFlag = getEffectiveURI(webContext);
+        String effectiveUrl = computeEffectiveURI(webContext);
 
-        Response response = webContext.respondWith().cachedForSeconds(uriAndCacheFlag.getSecond());
-        DispatchDecision staticResourceDecision = tryStaticResource(webContext, uriAndCacheFlag.getFirst(), response);
+        Response response = webContext.respondWith();
+        DispatchDecision staticResourceDecision = tryStaticResource(webContext, effectiveUrl, response);
         if (staticResourceDecision == DispatchDecision.DONE) {
             return DispatchDecision.DONE;
         }
 
-        DispatchDecision sassDecision = trySASS(webContext, uriAndCacheFlag.getFirst(), response);
+        DispatchDecision sassDecision = trySASS(webContext, effectiveUrl, response);
         if (sassDecision == DispatchDecision.DONE) {
             return DispatchDecision.DONE;
         }
 
-        return tryTagliatelle(webContext, uriAndCacheFlag.getFirst(), response);
+        return tryTagliatelle(webContext, effectiveUrl, response);
     }
 
     private DispatchDecision tryStaticResource(WebContext webContext, String uri, Response response)
@@ -128,19 +128,19 @@ public class AssetsDispatcher implements WebDispatcher {
         return DispatchDecision.DONE;
     }
 
-    private Tuple<String, Integer> getEffectiveURI(WebContext webContext) {
+    private String computeEffectiveURI(WebContext webContext) {
         String uri = webContext.getRequestedURI();
         if (uri.startsWith("/assets/dynamic/")) {
             uri = uri.substring(16);
             Tuple<String, String> pair = Strings.split(uri, "/");
-            return Tuple.create(ASSETS_PREFIX + pair.getSecond(), Response.HTTP_CACHE_INFINITE);
+            return ASSETS_PREFIX + pair.getSecond();
         }
 
         if (uri.startsWith("/assets/no-cache/")) {
-            return Tuple.create(ASSETS_PREFIX + uri.substring(17), 0);
+            return ASSETS_PREFIX + uri.substring(17);
         }
 
-        return Tuple.create(uri, Response.fetchDefaultClientTTL());
+        return uri;
     }
 
     private DispatchDecision tryTagliatelle(WebContext webContext, String uri, Response response) {

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -140,7 +140,7 @@ public class AssetsDispatcher implements WebDispatcher {
             return Tuple.create(ASSETS_PREFIX + uri.substring(17), 0);
         }
 
-        return Tuple.create(uri, Response.HTTP_CACHE);
+        return Tuple.create(uri, Response.fetchDefaultClientTTL());
     }
 
     private DispatchDecision tryTagliatelle(WebContext webContext, String uri, Response response) {

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -635,6 +635,15 @@ public class Response {
     }
 
     /**
+     * Returns the default custom proxy cache duration for responses which can be cached.
+     *
+     * @return the default custom proxy cache duration in seconds
+     */
+    public static String fetchDefaultCustomProxyTTL() {
+        return Sirius.getSettings().getString("http.response.defaultCustomProxyTTL");
+    }
+
+    /**
      * Marks this response as not-cacheable.
      *
      * @return <tt>this</tt> to fluently create the response

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -77,7 +77,7 @@ import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 
 /**
- * Represents a response which is used to reply to a HTTP request.
+ * Represents a response which is used to reply to an HTTP request.
  * <p>
  * Responses are created by calling {@link sirius.web.http.WebContext#respondWith()}.
  *
@@ -430,7 +430,7 @@ public class Response {
     }
 
     /**
-     * Disables keep-alive protocol (even if it would have been otherwise supported).
+     * Disables keep-alive protocol (even if it had been otherwise supported).
      *
      * @return the response itself for fluent method calls
      */
@@ -1026,7 +1026,7 @@ public class Response {
     /**
      * Sends an 401 UNAUTHORIZED response with a WWW-Authenticate header for the given realm.
      * <p>
-     * This will generally force the client to perform a HTTP Basic authentication.
+     * This will generally force the client to perform an HTTP Basic authentication.
      *
      * @param realm the realm to report to the client. This will be used to select an appropriate username
      *              and password
@@ -1560,7 +1560,7 @@ public class Response {
     }
 
     /**
-     * Creates a XML output which can be used to generate well-formed XML.
+     * Creates an XML output which can be used to generate well-formed XML.
      * <p>
      * By default, caching will be disabled. If the generated XML is small enough, it will be transmitted in
      * one go. Otherwise, a chunked response will be sent.
@@ -1572,7 +1572,7 @@ public class Response {
     }
 
     /**
-     * Creates a XML output which can be used to generate well-formed XML.
+     * Creates an XML output which can be used to generate well-formed XML.
      * <p>
      * By default, caching will be disabled. If the generated XML is small enough, it will be transmitted in
      * one go. Otherwise, a chunked response will be sent.

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -106,59 +106,59 @@ public class Response {
     private static final Set<String> CENSORED_LOWERCASE_PARAMETER_NAMES =
             Set.of("password", "passphrase", "secret", "secretKey");
 
-    /*
-     * Contains the content type used for html
+    /**
+     * Contains the content type used for html.
      */
     private static final String CONTENT_TYPE_HTML = "text/html; charset=UTF-8";
 
-    /*
+    /**
      * Represents a value to be used for CACHE_CONTROL which prevents any caching...
      */
     private static final String NO_CACHE = HttpHeaderValues.NO_CACHE + ", max-age=0";
 
-    /*
-     * Stores the associated request
+    /**
+     * Stores the associated request.
      */
     protected WebContext webContext;
 
-    /*
-     * Stores the underlying channel
+    /**
+     * Stores the underlying channel.
      */
     protected ChannelHandlerContext channelHandlerContext;
 
-    /*
-     * Stores the outgoing headers to be sent
+    /**
+     * Stores the outgoing headers to be sent.
      */
     private HttpHeaders headers;
 
-    /*
+    /**
      * Stores the effective response code.
      */
     private volatile int responseCode;
 
-    /*
+    /**
      * Stores the max expiration of this response. A null value indicates to use the defaults suggested
      * by the content creator.
      */
     protected Integer cacheSeconds = null;
 
-    /*
-     * Stores if this response should be considered "private" by intermediate caches and proxies
+    /**
+     * Stores if this response should be considered "private" by intermediate caches and proxies.
      */
     protected boolean isPrivate = false;
 
-    /*
-     * Determines if the response should be marked as download
+    /**
+     * Determines if the response should be marked as download.
      */
     protected boolean download = false;
 
-    /*
-     * Contains the name of the downloadable file
+    /**
+     * Contains the name of the downloadable file.
      */
     protected String name;
 
-    /*
-     * Determines if the response supports keepalive
+    /**
+     * Determines if the response supports keepalive.
      */
     private boolean responseKeepalive = true;
 
@@ -167,8 +167,8 @@ public class Response {
      */
     protected final int defaultCacheSeconds;
 
-    /*
-     * Determines if the response is chunked
+    /**
+     * Determines if the response is chunked.
      */
     protected boolean responseChunked = false;
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -117,6 +117,11 @@ public class Response {
     private static final String NO_CACHE = HttpHeaderValues.NO_CACHE + ", max-age=0";
 
     /**
+     * Represents the key used to define the custom reverse proxy cache TTL.
+     */
+    private static final String CUSTOM_PROXY_CACHE_TTL_HEADER = "X-Custom-TTL";
+
+    /**
      * Stores the associated request.
      */
     protected WebContext webContext;
@@ -141,6 +146,11 @@ public class Response {
      * by the content creator.
      */
     protected Integer cacheSeconds = null;
+
+    /**
+     * Stores the custom value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
+     */
+    protected String cacheCustomProxy;
 
     /**
      * Stores if this response should be considered "private" by intermediate caches and proxies.
@@ -701,6 +711,17 @@ public class Response {
     }
 
     /**
+     * Sets the value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
+     *
+     * @param ttl the value to set
+     * @return <tt>this</tt> to fluently create the response
+     */
+    public Response customProxyCached(String ttl) {
+        this.cacheCustomProxy = ttl;
+        return this;
+    }
+
+    /**
      * Returns the value of a header with the specified name. If there are
      * more than one values for the specified name, the first value is returned.
      *
@@ -941,6 +962,9 @@ public class Response {
             addHeaderIfNotExists(HttpHeaderNames.LAST_MODIFIED,
                                  Outcall.RFC2616_INSTANT.format(Instant.ofEpochMilli(lastModifiedMillis)
                                                                        .atZone(ZoneId.systemDefault())));
+        }
+        if (Strings.isFilled(cacheCustomProxy)) {
+            addHeaderIfNotExists(CUSTOM_PROXY_CACHE_TTL_HEADER, cacheCustomProxy);
         }
     }
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -151,7 +151,7 @@ public class Response {
     /**
      * Stores the custom value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
      */
-    protected String cacheCustomProxy;
+    protected String customProxyTTL;
 
     /**
      * Stores if this response should be considered "private" by intermediate caches and proxies.
@@ -708,8 +708,18 @@ public class Response {
      * @param ttl the value to set
      * @return <tt>this</tt> to fluently create the response
      */
-    public Response customProxyCached(String ttl) {
-        this.cacheCustomProxy = ttl;
+    public Response withCustomProxyTTL(String ttl) {
+        this.customProxyTTL = ttl;
+        return this;
+    }
+
+    /**
+     * Sets the default value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
+     *
+     * @return <tt>this</tt> to fluently create the response
+     */
+    public Response withDefaultCustomProxyTTL() {
+        this.customProxyTTL = defaultCustomProxyTTL;
         return this;
     }
 
@@ -955,8 +965,8 @@ public class Response {
                                  Outcall.RFC2616_INSTANT.format(Instant.ofEpochMilli(lastModifiedMillis)
                                                                        .atZone(ZoneId.systemDefault())));
         }
-        if (Strings.isFilled(cacheCustomProxy)) {
-            addHeaderIfNotExists(CUSTOM_PROXY_CACHE_TTL_HEADER, cacheCustomProxy);
+        if (Strings.isFilled(customProxyTTL)) {
+            addHeaderIfNotExists(CUSTOM_PROXY_CACHE_TTL_HEADER, customProxyTTL);
         }
     }
 

--- a/src/main/java/sirius/web/http/SendFile.java
+++ b/src/main/java/sirius/web/http/SendFile.java
@@ -64,7 +64,7 @@ class SendFile {
             randomAccessFile = new RandomAccessFile(file, "r");
             response.setDateAndCacheHeaders(file.lastModified(),
                                             response.cacheSeconds == null ?
-                                            response.defaultCacheSeconds :
+                                            Response.obtainClientDurationInSeconds() :
                                             response.cacheSeconds,
                                             response.isPrivate);
 

--- a/src/main/java/sirius/web/http/SendFile.java
+++ b/src/main/java/sirius/web/http/SendFile.java
@@ -63,7 +63,9 @@ class SendFile {
 
             randomAccessFile = new RandomAccessFile(file, "r");
             response.setDateAndCacheHeaders(file.lastModified(),
-                                            response.cacheSeconds == null ? Response.HTTP_CACHE : response.cacheSeconds,
+                                            response.cacheSeconds == null ?
+                                            response.defaultCacheSeconds :
+                                            response.cacheSeconds,
                                             response.isPrivate);
 
             if (!parseRangesAndUpdateHeaders()) {

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -191,7 +191,9 @@ public class TunnelHandler implements AsyncHandler<String> {
         overrideContentTypeIfNecessary();
 
         response.setDateAndCacheHeaders(lastModifiedMillis,
-                                        response.cacheSeconds == null ? Response.HTTP_CACHE : response.cacheSeconds,
+                                        response.cacheSeconds == null ?
+                                        response.defaultCacheSeconds :
+                                        response.cacheSeconds,
                                         response.isPrivate);
 
         if (response.name != null) {

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -192,7 +192,7 @@ public class TunnelHandler implements AsyncHandler<String> {
 
         response.setDateAndCacheHeaders(lastModifiedMillis,
                                         response.cacheSeconds == null ?
-                                        response.defaultCacheSeconds :
+                                        Response.obtainClientDurationInSeconds() :
                                         response.cacheSeconds,
                                         response.isPrivate);
 

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -269,7 +269,7 @@ http {
         # Contains the default cache duration for static assets.
         defaultStaticAssetTTL = 6h
 
-        # Contains the default value for the x-custom-ttl HTTP header.
+        # Contains the default value for the X-Custom-TTL HTTP header.
         # This header can be used by custom reverse proxy servers when the default cache control is not sufficient.
         # The value will be given as string, so proxies such as varnish can use this value without conversion.
         defaultCustomProxyTTL = 30d

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -265,6 +265,9 @@ http {
     response {
         # Contains the default client cache duration.
         defaultClientCacheTTL = 1h
+
+        # Contains the default cache duration for static assets.
+        defaultStaticAssetTTL = 6h
     }
 }
 

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -268,6 +268,11 @@ http {
 
         # Contains the default cache duration for static assets.
         defaultStaticAssetTTL = 6h
+
+        # Contains the default value for the x-custom-ttl HTTP header.
+        # This header can be used by custom reverse proxy servers when the default cache control is not sufficient.
+        # The value will be given as string, so proxies such as varnish can use this value without conversion.
+        defaultCustomProxyTTL = 30d
     }
 }
 

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -261,6 +261,11 @@ http {
             requiredRoles = "permission-system-health-api"
         }
     }
+
+    response {
+        # Contains the default client cache duration.
+        defaultClientCacheTTL = 1h
+    }
 }
 
 # Configures the help system

--- a/src/test/java/sirius/web/dispatch/AssetsDispatcherSpec.groovy
+++ b/src/test/java/sirius/web/dispatch/AssetsDispatcherSpec.groovy
@@ -9,26 +9,37 @@
 package sirius.web.dispatch
 
 import io.netty.handler.codec.http.HttpHeaderNames
-import sirius.web.sass.Output
 import sirius.kernel.BaseSpecification
+import sirius.web.sass.Output
 
 class AssetsDispatcherSpec extends BaseSpecification {
 
-    def "proper caching set for all kind of assets and cache-control URIs"(String uri, String header) {
+    def "proper caching set for all kind of assets and cache-control URIs"() {
         expect:
         URLConnection c = new URL("http://localhost:9999" + uri).openConnection()
         c.getHeaderField(HttpHeaderNames.CACHE_CONTROL.toString()) == header
         where:
         uri                               | header
-        '/assets/test/test.css'           | 'public, max-age=3600'
-        '/assets/test/test.txt'           | 'public, max-age=3600'
-        '/assets/test/test.js'            | 'public, max-age=3600'
+        '/assets/test/test.css'           | 'public, max-age=21600'
+        '/assets/test/test.txt'           | 'public, max-age=21600'
+        '/assets/test/test.js'            | 'public, max-age=21600'
         '/assets/no-cache/test/test.css'  | 'no-cache, max-age=0'
         '/assets/no-cache/test/test.txt'  | 'no-cache, max-age=0'
         '/assets/no-cache/test/test.js'   | 'no-cache, max-age=0'
         '/assets/dynamic/X/test/test.css' | 'public, max-age=615168000'
         '/assets/dynamic/X/test/test.txt' | 'public, max-age=615168000'
         '/assets/dynamic/X/test/test.js'  | 'public, max-age=615168000'
+    }
+
+    def "proper custom proxy caching set for all cache-control URIs"() {
+        expect:
+        URLConnection c = new URL("http://localhost:9999" + uri).openConnection()
+        c.getHeaderField("X-Custom-TTL") == header
+        where:
+        uri                               | header
+        '/assets/test/test.css'           | '30d'
+        '/assets/no-cache/test/test.css'  | null
+        '/assets/dynamic/X/test/test.css' | null
     }
 
     def "Custom base64ResourceFunction works"() {
@@ -40,7 +51,8 @@ class AssetsDispatcherSpec extends BaseSpecification {
         StringWriter writer = new StringWriter()
         gen.generate(new Output(writer, true))
         then:
-        writer.toString() == "test { background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QsODw4S4KU/XgAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAdElEQVRYw+3Q3Q1AMAAA4ar+qHhghq7SBQ3CPsQO5a1JS0wh+nA3wZdr5hBEfUlRZbBgwYIFCxYsWLBgwYIFCxYsWLBgwYIFCxYsWLBgfZSqDRRtWv1eC2vx2zFGV7S5pX2U+n3M2SWX1ZCNv6a+aHNL/bQvbxUXkThEKBQAAAAASUVORK5CYII=); }\n "
+        writer
+                .toString() == "test { background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QsODw4S4KU/XgAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAdElEQVRYw+3Q3Q1AMAAA4ar+qHhghq7SBQ3CPsQO5a1JS0wh+nA3wZdr5hBEfUlRZbBgwYIFCxYsWLBgwYIFCxYsWLBgwYIFCxYsWLBgfZSqDRRtWv1eC2vx2zFGV7S5pX2U+n3M2SWX1ZCNv6a+aHNL/bQvbxUXkThEKBQAAAAASUVORK5CYII=); }\n "
     }
 
 }


### PR DESCRIPTION
# Makes the default client cache duration configurable
Key: `http.response.defaultClientCacheTTL`
This is basically what lands in Cache-Control's max-age HTTP header.
**BREAKING**: The `Response.HTTP_CACHE` is gone. Use `Response.obtainClientDurationInSeconds()` instead.

# Increases the cache of constant assets to 6h
Configurable with the key: `http.response.defaultStaticAssetTTL`

# Introduces the `X-Custom-TTL` HTTP response header
This header can be used by reverse proxies, e.g [Varnish](varnish-cache.org), to set a different TTL (time-to-leave) value than the one provided with the standard HTTP headers, such as `Cache-Control`.

# Sets the X-Custom-TTL HTTP response header of constant assets to 30d
Configurable with the key: `http.response.defaultCustomProxyTTL`

Fixes: [SIRI-728](https://scireum.myjetbrains.com/youtrack/issue/SIRI-728)