### PR TITLE
Fixes Amount in JSONStructuredOutput

### DIFF
--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -227,14 +227,14 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
             addObjectName(name);
             if (data == null) {
                 writer.write("null");
-            } else if (data instanceof Boolean || data instanceof Number) {
-                writer.write(data.toString());
             } else if (data instanceof Amount amount) {
                 if (amount.isFilled()) {
                     writer.write(amount.toMachineString());
                 } else {
                     writer.write("null");
                 }
+            } else if (data instanceof Boolean || data instanceof Number) {
+                writer.write(data.toString());
             } else {
                 writeString(transformToStringRepresentation(data));
             }


### PR DESCRIPTION
- as Amounts are Numbers, the proper output path wasn't used before
- now toMachineString gets used for Amount, resulting in '.' as decimal separator

