### PR TITLE
Removes the X-Custom-TTL header

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -147,7 +147,6 @@ public class AssetsDispatcher implements WebDispatcher {
 
         if (constantAsset) {
             response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
-            response.withDefaultCustomProxyTTL();
             return;
         }
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -118,11 +118,6 @@ public class Response {
     private static final String NO_CACHE = HttpHeaderValues.NO_CACHE + ", max-age=0";
 
     /**
-     * Represents the key used to define the custom reverse proxy cache TTL.
-     */
-    private static final String CUSTOM_PROXY_CACHE_TTL_HEADER = "X-Custom-TTL";
-
-    /**
      * Stores the associated request.
      */
     protected WebContext webContext;
@@ -147,11 +142,6 @@ public class Response {
      * by the content creator.
      */
     protected Integer cacheSeconds = null;
-
-    /**
-     * Stores the custom value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
-     */
-    protected String customProxyTTL;
 
     /**
      * Stores if this response should be considered "private" by intermediate caches and proxies.
@@ -189,9 +179,6 @@ public class Response {
 
     @ConfigValue("http.response.defaultClientCacheTTL")
     private static Duration defaultCacheDuration;
-
-    @ConfigValue("http.response.defaultCustomProxyTTL")
-    private static String defaultCustomProxyTTL;
 
     protected static AsyncHttpClient asyncClient;
 
@@ -703,27 +690,6 @@ public class Response {
     }
 
     /**
-     * Sets the value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
-     *
-     * @param ttl the value to set
-     * @return <tt>this</tt> to fluently create the response
-     */
-    public Response withCustomProxyTTL(String ttl) {
-        this.customProxyTTL = ttl;
-        return this;
-    }
-
-    /**
-     * Sets the default value for the {@link #CUSTOM_PROXY_CACHE_TTL_HEADER} header.
-     *
-     * @return <tt>this</tt> to fluently create the response
-     */
-    public Response withDefaultCustomProxyTTL() {
-        this.customProxyTTL = defaultCustomProxyTTL;
-        return this;
-    }
-
-    /**
      * Returns the value of a header with the specified name. If there are
      * more than one values for the specified name, the first value is returned.
      *
@@ -964,9 +930,6 @@ public class Response {
             addHeaderIfNotExists(HttpHeaderNames.LAST_MODIFIED,
                                  Outcall.RFC2616_INSTANT.format(Instant.ofEpochMilli(lastModifiedMillis)
                                                                        .atZone(ZoneId.systemDefault())));
-        }
-        if (Strings.isFilled(customProxyTTL)) {
-            addHeaderIfNotExists(CUSTOM_PROXY_CACHE_TTL_HEADER, customProxyTTL);
         }
     }
 

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -268,11 +268,6 @@ http {
 
         # Contains the default cache duration for static assets.
         defaultStaticAssetTTL = 6h
-
-        # Contains the default value for the X-Custom-TTL HTTP header.
-        # This header can be used by custom reverse proxy servers when the default cache control is not sufficient.
-        # The value will be given as string, so proxies such as varnish can use this value without conversion.
-        defaultCustomProxyTTL = 30d
     }
 }
 

--- a/src/test/java/sirius/web/dispatch/AssetsDispatcherSpec.groovy
+++ b/src/test/java/sirius/web/dispatch/AssetsDispatcherSpec.groovy
@@ -31,17 +31,6 @@ class AssetsDispatcherSpec extends BaseSpecification {
         '/assets/dynamic/X/test/test.js'  | 'public, max-age=615168000'
     }
 
-    def "proper custom proxy caching set for all cache-control URIs"() {
-        expect:
-        URLConnection c = new URL("http://localhost:9999" + uri).openConnection()
-        c.getHeaderField("X-Custom-TTL") == header
-        where:
-        uri                               | header
-        '/assets/test/test.css'           | '30d'
-        '/assets/no-cache/test/test.css'  | null
-        '/assets/dynamic/X/test/test.css' | null
-    }
-
     def "Custom base64ResourceFunction works"() {
         when:
         SiriusSassGenerator gen = new SiriusSassGenerator()


### PR DESCRIPTION
as proxy configuration is getting overly complex and demands "hacks" in order to alter the Date and Expires headers since we would deliver a file already expired as we cache longer than its age.

In fact, we see no need for a reverse-proxy to cache an asset longer than what we already set in its "Expire" and "Cache-Control" headers.

Fixes: [SIRI-728](https://scireum.myjetbrains.com/youtrack/issue/SIRI-728)