### PR TITLE
Helper for Synthetic Administrators

### DIFF
--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Represents an user.
+ * Represents a user.
  * <p>
  * A user is authenticated using a {@link UserManager}. To obtain or modify the current user, use {@link
  * UserContext#getCurrentUser()} or {@link UserContext#setCurrentUser(UserInfo)}.
@@ -69,9 +69,9 @@ public class UserInfo extends Composable {
         }
 
         /**
-         * Creates a new builder and initializes it with an id for the user.
+         * Creates a new builder and initializes it with an identifier for the user.
          *
-         * @param id the id of the user to build.
+         * @param id the identifier of the user to build.
          * @return the builder itself for fluent method calls
          */
         @CheckReturnValue

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -46,6 +46,16 @@ public class UserInfo extends Composable {
      */
     public static final UserInfo NOBODY = Builder.createUser("ANONYMOUS").withUsername("(no user)").build();
 
+    /**
+     * Defines the identifier used to represent the synthetic "Administrator" user.
+     */
+    public static final String SYNTHETIC_ADMIN_USER_ID = "ADMIN";
+
+    /**
+     * Defines the name used for the synthetic "Administrator" user.
+     */
+    public static final String SYNTHETIC_ADMIN_USER_NAME = "Administrator";
+
     protected String tenantId;
     protected String tenantName;
     protected String userId;
@@ -80,6 +90,20 @@ public class UserInfo extends Composable {
             builder.user = new UserInfo();
             builder.user.userId = id;
             return builder;
+        }
+
+        /**
+         * Creates a new builder and configures it for a synthetic "Administrator" user with every possible permission.
+         *
+         * @param tenantId   the identifier of the tenant the user belongs to
+         * @param tenantName the name of the tenant the user belongs to
+         * @return the builder itself for fluent method calls
+         */
+        public static Builder createSyntheticAdminUser(String tenantId, String tenantName) {
+            return createUser(SYNTHETIC_ADMIN_USER_ID).withUsername(SYNTHETIC_ADMIN_USER_NAME)
+                                                      .withTenantId(tenantId)
+                                                      .withTenantName(tenantName)
+                                                      .withEveryPermission(true);
         }
 
         /**


### PR DESCRIPTION
Adds a method that permits to create synthetic administrator users. The functionality has been taken from [`Tenants.java`](https://github.com/scireum/sirius-biz/blob/fee262b935e9bb28539ea3eff81e23a50d7af425/src/main/java/sirius/biz/tenants/Tenants.java#L564) and adapted for re-use.