### PR TITLE
Adds the possibility to create dependencies between two SingleSelects

### DIFF
--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -12,6 +12,7 @@
 <i:arg name="optional" type="boolean" default="false"/>
 <i:arg name="allowCustomEntries" type="boolean" default="false"/>
 <i:arg name="suggestionUri" type="String" default=""/>
+<i:arg name="dependencyField" type="String" default=""/>
 
 <i:pragma name="description">
     Renders a select field for a single value using the given parameters. Note that additional flags can be set via CSS
@@ -51,6 +52,9 @@
 </div>
 <script>
     sirius.ready(function () {
+        const _dependencyField = document.getElementById('@dependencyField');
+        const _dependencyFieldSelect = document.getElementById('@dependencyField' + '-select');
+
         const autocomplete = new TokenAutocomplete(
             Object.assign({
                 selector: '#@id',
@@ -63,8 +67,16 @@
                 noMatchesText: '@i18n("template.html.selects.noMatches")',
                 noMatchesCustomEntriesDescription: '@i18n("template.html.selects.useCustomEntry")',
                 placeholderText: '@placeholder',
-                suggestionsUri: '@suggestionUri'
+                suggestionsUri: '@suggestionUri',
+                suggestionsUriBuilder: function (query) {
+                    return this.suggestionsUri + (_dependencyFieldSelect ? "/" + _dependencyFieldSelect.value : '') + '?query=' + query;
+                }
             }, <i:render name="autocompleteOptions"/>));
+        if (_dependencyField) {
+            _dependencyField.addEventListener("tokens-changed", function() {
+                autocomplete.autocomplete.loadSuggestions();
+            });
+        }
 
         <i:render name="script"/>
     });

--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -68,22 +68,22 @@
                 placeholderText: '@placeholder',
                 suggestionsUri: '@suggestionUri',
                 suggestionsUriBuilder: function (query) {
-                    let baseUri = this.suggestionsUri + '?query=' + query;
+                    let baseUri = this.suggestionsUri + '?query=' + encodeURIComponent(query);
                     if (_dependencyField) {
-                        return baseUri + '&dependentValue=' + _dependencyField.tokenAutocomplete.val().join();
+                        return baseUri + '&dependentValue=' + encodeURIComponent(_dependencyField.tokenAutocomplete.val().join());
                     }
                     return baseUri;
                 }
             }, <i:render name="autocompleteOptions"/>));
 
-            // Remove selected value if dependency field is cleared
-            if (_dependencyField) {
-                _dependencyField.addEventListener('tokens-changed', function (event) {
-                    if(_dependencyField.tokenAutocomplete.val().length === 0) {
-                        autocomplete.select.clear();
-                    }
-                });
-            }
+        // Remove selected value if dependency field is cleared
+        if (_dependencyField) {
+            _dependencyField.addEventListener('tokens-changed', function (event) {
+                if (_dependencyField.tokenAutocomplete.val().length === 0) {
+                    autocomplete.select.clear();
+                }
+            });
+        }
         <i:render name="script"/>
     });
 </script>

--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -76,6 +76,14 @@
                 }
             }, <i:render name="autocompleteOptions"/>));
 
+            // Remove selected value if dependency field is cleared
+            if (_dependencyField) {
+                _dependencyField.addEventListener('tokens-changed', function (event) {
+                    if(_dependencyField.tokenAutocomplete.val().length === 0) {
+                        autocomplete.select.clear();
+                    }
+                });
+            }
         <i:render name="script"/>
     });
 </script>

--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -12,7 +12,7 @@
 <i:arg name="optional" type="boolean" default="false"/>
 <i:arg name="allowCustomEntries" type="boolean" default="false"/>
 <i:arg name="suggestionUri" type="String" default=""/>
-<i:arg name="dependencyField" type="String" default=""/>
+<i:arg name="dependencyFieldId" type="String" default=""/>
 
 <i:pragma name="description">
     Renders a select field for a single value using the given parameters. Note that additional flags can be set via CSS
@@ -52,8 +52,7 @@
 </div>
 <script>
     sirius.ready(function () {
-        const _dependencyField = document.getElementById('@dependencyField');
-        const _dependencyFieldSelect = document.getElementById('@dependencyField' + '-select');
+        const _dependencyField = document.getElementById('@dependencyFieldId');
 
         const autocomplete = new TokenAutocomplete(
             Object.assign({
@@ -69,14 +68,13 @@
                 placeholderText: '@placeholder',
                 suggestionsUri: '@suggestionUri',
                 suggestionsUriBuilder: function (query) {
-                    return this.suggestionsUri + (_dependencyFieldSelect ? "/" + _dependencyFieldSelect.value : '') + '?query=' + query;
+                    let baseUri = this.suggestionsUri + '?query=' + query;
+                    if (_dependencyField) {
+                        return baseUri + '&dependentValue=' + _dependencyField.tokenAutocomplete.val().join();
+                    }
+                    return baseUri;
                 }
             }, <i:render name="autocompleteOptions"/>));
-        if (_dependencyField) {
-            _dependencyField.addEventListener("tokens-changed", function() {
-                autocomplete.autocomplete.loadSuggestions();
-            });
-        }
 
         <i:render name="script"/>
     });


### PR DESCRIPTION
If the selection options of a SingleSelect are dependent on the selection of another SingleSelect, this can now be specified via a dependencyField and the dependent fields can be determined via autocomplete.

![image](https://github.com/scireum/sirius-web/assets/119577649/ed4bb936-a9b7-4e33-b775-2b71b0756799)

Whenever we select a classification system, only the classes that belong to it will be specified as an option.