### PR TITLE
Do not cache help pages, caches help assets longer

### DIFF
--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -140,12 +140,17 @@ public class AssetsDispatcher implements WebDispatcher {
             return;
         }
 
-        if (!constantAsset || uri.startsWith("/assets/no-cache/")) {
+        if (uri.startsWith("/assets/no-cache/")) {
             response.notCached();
             return;
         }
 
-        response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
+        if (constantAsset) {
+            response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
+            return;
+        }
+
+        response.cachedForSeconds(Response.obtainClientDurationInSeconds());
     }
 
     private String computeEffectiveURI(WebContext webContext) {

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -140,17 +140,12 @@ public class AssetsDispatcher implements WebDispatcher {
             return;
         }
 
-        if (uri.startsWith("/assets/no-cache/")) {
+        if (!constantAsset || uri.startsWith("/assets/no-cache/")) {
             response.notCached();
             return;
         }
 
-        if (constantAsset) {
-            response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
-            return;
-        }
-
-        response.cachedForSeconds(Response.obtainClientDurationInSeconds());
+        response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
     }
 
     private String computeEffectiveURI(WebContext webContext) {

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -34,6 +34,7 @@ import sirius.web.resources.Resources;
 import sirius.web.security.UserContext;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -53,6 +54,9 @@ public class HelpDispatcher implements WebDispatcher {
 
     @ConfigValue("help.languages")
     private List<String> helpSystemLanguageDirectories;
+
+    @ConfigValue("http.response.defaultStaticAssetTTL")
+    private static Duration defaultStaticAssetTTL;
 
     @Part
     private Resources resources;
@@ -114,7 +118,9 @@ public class HelpDispatcher implements WebDispatcher {
             return DispatchDecision.CONTINUE;
         }
 
-        ctx.respondWith().resource(asset.getUrl().openConnection());
+        ctx.respondWith()
+           .cachedForSeconds((int) defaultStaticAssetTTL.getSeconds())
+           .resource(asset.getUrl().openConnection());
         return DispatchDecision.DONE;
     }
 

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -27,6 +27,7 @@ import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.web.controller.Message;
 import sirius.web.event.TemplateInvocationHandler;
+import sirius.web.http.Response;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
 import sirius.web.resources.Resource;
@@ -127,7 +128,13 @@ public class HelpDispatcher implements WebDispatcher {
     private DispatchDecision serveTopic(WebContext ctx, String uri) {
         Template template = resolveTemplate(uri);
         if (template != null) {
-            ctx.respondWith().cached().template(HttpResponseStatus.OK, template);
+            Response response = ctx.respondWith();
+            if (template.isConstant()) {
+                response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
+            } else {
+                response.notCached();
+            }
+            response.template(HttpResponseStatus.OK, template);
             return DispatchDecision.DONE;
         }
 

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -27,7 +27,6 @@ import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.web.controller.Message;
 import sirius.web.event.TemplateInvocationHandler;
-import sirius.web.http.Response;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
 import sirius.web.resources.Resource;
@@ -128,13 +127,7 @@ public class HelpDispatcher implements WebDispatcher {
     private DispatchDecision serveTopic(WebContext ctx, String uri) {
         Template template = resolveTemplate(uri);
         if (template != null) {
-            Response response = ctx.respondWith();
-            if (template.isConstant()) {
-                response.cachedForSeconds((int) defaultStaticAssetTTL.getSeconds());
-            } else {
-                response.notCached();
-            }
-            response.template(HttpResponseStatus.OK, template);
+            ctx.respondWith().notCached().template(HttpResponseStatus.OK, template);
             return DispatchDecision.DONE;
         }
 


### PR DESCRIPTION
They most probably contain user specific info (like the user and tenant when switching to a user or tenant) and should therefore not be cached at all.

Fixes: [SIRI-912](https://scireum.myjetbrains.com/youtrack/issue/SIRI-912)