### PR TITLE
Do not reveal product in http.server header

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -312,8 +312,7 @@ public class Response {
 
     private void setupHeaders(DefaultHttpResponse response) {
         // Add Server: nodeName as header
-        response.headers()
-                .set(HttpHeaderNames.SERVER, CallContext.getNodeName() + " (scireum SIRIUS - powered by Netty)");
+        response.headers().set(HttpHeaderNames.SERVER, CallContext.getNodeName());
 
         // Add a P3P-Header. This is used to disable the 3rd-Party auth handling of InternetExplorer
         // which is pretty broken and not used (google and facebook does the same).


### PR DESCRIPTION
Nowadays, it's unsafe to reveal which server is being used behind a web-site, such as Apache, nginx etc. (in our case we claim to use Netty) as attackers might profit from known security flaws in a specific product.

Therefore, we no longer advertise what we use in background. For debugging purposes, we do keep the host name delivering the content.