### PR TITLE
Bugfix: Image Upload Button Must Not Submit Forms

### DIFF
--- a/src/main/resources/default/taglib/t/fileUpload.html.pasta
+++ b/src/main/resources/default/taglib/t/fileUpload.html.pasta
@@ -14,7 +14,8 @@
 <i:pragma name="description" value="Renders a file upload within a Tycho template"/>
 
 <div class="dropzone sirius-fileupload @class" id="@id">
-    <button class="dropzone-select btn @btnClass">
+    <button type="button"
+            class="dropzone-select btn @btnClass">
         <i class="fas fa-cloud-upload-alt"></i>
         <span class="pl-2 d-none d-xl-inline">
             @label

--- a/src/main/resources/default/taglib/t/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/t/imageUpload.html.pasta
@@ -26,7 +26,8 @@
         </div>
         <div class="dropzone-items mt-2 mb-2">
         </div>
-        <button class="dropzone-select btn btn-primary @btnClass">@label</button>
+        <button type="button"
+                class="dropzone-select btn btn-primary @btnClass">@label</button>
         <i:render name="body"/>
     </div>
 </div>


### PR DESCRIPTION
The default type of a button is "submit", leading the upload button to submit an entire form when wrapped in one. This rendered the button unusable in such cases.