### PR TITLE
Use jackson mapper from sirius kernel at JSONStructuredOutput

### DIFF
--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -205,7 +205,7 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     @Override
     public void writeProperty(String name, Object data) {
         if (data instanceof JsonNode jsonNode) {
-            writePreformattedProperty(name, jsonNode.toString());
+            writePreformattedProperty(name, Json.write(jsonNode));
         } else {
             writePlainProperty(name, data);
         }


### PR DESCRIPTION
- so our common settings get used
- required e.g. for datatypes like java8 dates