### PR TITLE
CSS Comments Fix

### DIFF
--- a/src/main/resources/default/assets/tycho/lib.css.pasta
+++ b/src/main/resources/default/assets/tycho/lib.css.pasta
@@ -1,6 +1,7 @@
-//
-// A list of all licenses can be obtained via /licenses
-//
+/*
+ * A list of all licenses can be obtained via /licenses
+ */
+
 ___include("/assets/tycho/libs/bootstrap/css/bootstrap.min.css")
 ___include("/assets/tycho/libs/bootstrap-colorpicker/css/bootstrap-colorpicker.min.css")
 ___include("/assets/tycho/libs/token-autocomplete/token-autocomplete.css")

--- a/src/main/resources/default/assets/wondergem/wondergem.css.pasta
+++ b/src/main/resources/default/assets/wondergem/wondergem.css.pasta
@@ -1,6 +1,6 @@
-//
-// A list of all licenses can be obtained via /licenses
-//
+/*
+ * A list of all licenses can be obtained via /licenses
+ */
 
 <i:include name="/assets/wondergem/bootstrap/css/bootstrap.min.css"/>
 


### PR DESCRIPTION
When attempting an upgrade to Bootstrap 5, the non-standard comment signs caused the first CSS rule of the included file not to load. Only `/* … */` is a valid CSS comment.