### PR TITLE
Fixes the incorrect calculation of the dimensions

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -123,14 +123,14 @@ public abstract class PdfReplaceHandler implements Priorized {
         if (fsImage.getWidth() > cssWidth) {
             return Tuple.create(cssWidth, (cssWidth * fsImage.getHeight()) / fsImage.getWidth());
         }
-        return Tuple.create(cssHeight, (cssHeight * fsImage.getWidth()) / fsImage.getHeight());
+        return Tuple.create((cssHeight * fsImage.getWidth()) / fsImage.getHeight(), cssHeight);
     }
 
     @Nonnull
     private static Tuple<Integer, Integer> upscaleResource(int cssWidth, int cssHeight, FSImage fsImage) {
-        if (cssWidth > cssHeight) {
+        if (fsImage.getWidth() > fsImage.getHeight()) {
             return Tuple.create(cssWidth, (cssWidth * fsImage.getHeight()) / fsImage.getWidth());
         }
-        return Tuple.create(cssHeight, (cssHeight * fsImage.getWidth()) / fsImage.getHeight());
+        return Tuple.create((cssHeight * fsImage.getWidth()) / fsImage.getHeight(), cssHeight);
     }
 }


### PR DESCRIPTION
It was noticeable with particularly high images with a narrow width.

Some of the images ran across several pages of the PDF.

Some images also overlapped areas of the PDF that should not be overlapped:

Before:
![image](https://github.com/scireum/sirius-web/assets/119577649/2e392027-3a58-4f77-94ff-76ab5c8274fd)
<img width="354" alt="image" src="https://github.com/scireum/sirius-web/assets/119577649/ce0a8f17-5145-42f4-bb2c-e452e54c0aaf">


After:
<img width="1062" alt="image" src="https://github.com/scireum/sirius-web/assets/119577649/1a7d79ee-bc04-4ce6-9c84-aa31234e796c">
![image](https://github.com/scireum/sirius-web/assets/119577649/9553e5dd-635c-480e-add8-5986b42ac53e)


