### PR TITLE
Sets required system property for test on sonar execution

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ steps:
     image: scireum/sirius-build-jdk21
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
-      - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report sonar:sonar -Dsonar.projectKey=${DRONE_REPO_NAME}
+      - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report sonar:sonar -Dsonar.projectKey=${DRONE_REPO_NAME} -Dsun.net.http.allowRestrictedHeaders=true
     volumes: *scireum_volumes
     when:
       event:


### PR DESCRIPTION
Our sonar executions that run after a tag creation are broken for a while. Propably because this system property is missing. 