### PR TITLE
Checks if we need to downscale the height after upscaling the width

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -108,20 +108,18 @@ public abstract class PdfReplaceHandler implements Priorized {
         }
 
         if (fsImage.getWidth() > cssWidth || fsImage.getHeight() > cssHeight) {
-            return downscaleResource(cssWidth, cssHeight, fsImage);
+            return downscaleResource(cssWidth, cssHeight, fsImage.getWidth(), fsImage.getHeight());
         }
 
         if (cssWidth > fsImage.getWidth() && cssHeight > fsImage.getHeight()) {
-            return upscaleResource(cssWidth, cssHeight, fsImage);
+            return upscaleResource(cssWidth, cssHeight, fsImage.getWidth(), fsImage.getHeight());
         }
 
         return null;
     }
 
     @Nonnull
-    private static Tuple<Integer, Integer> downscaleResource(int cssWidth, int cssHeight, FSImage fsImage) {
-        int imageWidth = fsImage.getWidth();
-        int imageHeight = fsImage.getHeight();
+    private static Tuple<Integer, Integer> downscaleResource(int cssWidth, int cssHeight, int imageWidth, int imageHeight) {
 
         // First, check if we need to scale down the width
         if (imageWidth > cssWidth) {
@@ -139,10 +137,13 @@ public abstract class PdfReplaceHandler implements Priorized {
     }
 
     @Nonnull
-    private static Tuple<Integer, Integer> upscaleResource(int cssWidth, int cssHeight, FSImage fsImage) {
-        if (fsImage.getWidth() > fsImage.getHeight()) {
-            return Tuple.create(cssWidth, (cssWidth * fsImage.getHeight()) / fsImage.getWidth());
-        }
-        return Tuple.create((cssHeight * fsImage.getWidth()) / fsImage.getHeight(), cssHeight);
+    private static Tuple<Integer, Integer> upscaleResource(int cssWidth, int cssHeight, int imageWidth, int imageHeight) {
+
+        // First, scale up only the width
+        imageHeight = cssWidth * imageHeight / imageWidth;
+        imageWidth = cssWidth;
+
+        // After upscaling the width, we might need to downscale the height
+        return downscaleResource(cssWidth, cssHeight, imageWidth, imageHeight);
     }
 }

--- a/src/test/kotlin/sirius/web/templates/pdf/handlers/PdfReplaceHandlerTest.kt
+++ b/src/test/kotlin/sirius/web/templates/pdf/handlers/PdfReplaceHandlerTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf.handlers
+
+import com.lowagie.text.ImgRaw
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.xhtmlrenderer.pdf.ITextFSImage
+import sirius.kernel.SiriusExtension
+import kotlin.test.assertEquals
+
+@ExtendWith(SiriusExtension::class)
+class PdfReplaceHandlerTest {
+
+    @Test
+    fun `scaling up the resource`() {
+        val handler = ResourcePdfReplaceHandler()
+        val rawImage = ITextFSImage(ImgRaw(50, 20, 1, 1, null))
+        val scaledImage = handler.resizeImage(rawImage, 100, 100)
+        assertEquals(100, scaledImage.width)
+        assertEquals(40, scaledImage.height)
+    }
+
+    @Test
+    fun `scaling up the width and scaling down the height`() {
+        val handler = ResourcePdfReplaceHandler()
+        val rawImage = ITextFSImage(ImgRaw(60, 50, 1, 1, null))
+        val scaledImage = handler.resizeImage(rawImage, 100, 60)
+        assertEquals(72, scaledImage.width)
+        assertEquals(60, scaledImage.height)
+    }
+
+    @Test
+    fun `scaling down the resource`() {
+        val handler = ResourcePdfReplaceHandler()
+        val rawImage = ITextFSImage(ImgRaw(150, 20, 1, 1, null))
+        val scaledImage = handler.resizeImage(rawImage, 100, 100)
+        assertEquals(100, scaledImage.width)
+        assertEquals(13, scaledImage.height)
+    }
+
+    @Test
+    fun `scaling down the height`() {
+        val handler = ResourcePdfReplaceHandler()
+        val rawImage = ITextFSImage(ImgRaw(50, 200, 1, 1, null))
+        val scaledImage = handler.resizeImage(rawImage, 100, 100)
+        assertEquals(25, scaledImage.width)
+        assertEquals(100, scaledImage.height)
+    }
+}


### PR DESCRIPTION
Depending on how the maximum permitted sizes for an image are specified, it may be that both the width and height are too small and therefore need to be scaled up. If we scale up the width first, it may well be that the height is too high for the specified maximum height.

Example:
Maximum width: 100px
Maximum height: 20px

Image:
50px wide and 15px high

After we have scaled up the width, the image would be :
100px wide and 30px high

The height of the image is now too high and we need to scale it down once.