### PR TITLE
Improves the performance of resolving the images

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -1,0 +1,160 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf;
+
+import org.xhtmlrenderer.extend.FSImage;
+import org.xhtmlrenderer.extend.ReplacedElement;
+import org.xhtmlrenderer.layout.LayoutContext;
+import org.xhtmlrenderer.pdf.ITextImageElement;
+import org.xhtmlrenderer.pdf.ITextOutputDevice;
+import org.xhtmlrenderer.pdf.ITextReplacedElement;
+import org.xhtmlrenderer.render.BlockBox;
+import org.xhtmlrenderer.render.RenderingContext;
+import sirius.kernel.commons.Tuple;
+import sirius.kernel.health.Exceptions;
+import sirius.web.templates.pdf.handlers.PdfReplaceHandler;
+
+import javax.annotation.Nonnull;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+
+/**
+ * Represents an image that is loaded asynchronously.
+ * <p>
+ * To improve performance, we resolve the image in a background thread.
+ * The image is only fully loaded and scaled when it is time to be drawn. Until then, the element is only a placeholder
+ * for the image loaded in the background. It therefore makes no sense to access the actual image.
+ * <p>
+ * {@link AsyncLoadedImageElement#getIntrinsicHeight()} and {@link AsyncLoadedImageElement#getIntrinsicWidth()} only
+ * provide the width and height of the box in which the image is later rendered.
+ * <p>
+ * The actual image is centered in this box.
+ */
+public final class AsyncLoadedImageElement implements ITextReplacedElement {
+
+    private final int cssWidth;
+    private final int cssHeight;
+    private final ForkJoinTask<FSImage> imageForkJoinTask;
+    private FSImage image;
+    private Point location;
+    private ReplacedElement fallbackElement;
+
+    /**
+     * Creates a new element which loads the image asynchronously.
+     *
+     * @param handler   the handler to use to resolve the URI
+     * @param uri       the URI to resolve
+     * @param cssWidth  the width of the box in which the image is later rendered
+     * @param cssHeight the height of the box in which the image is later rendered
+     */
+    public AsyncLoadedImageElement(PdfReplaceHandler handler, String uri, int cssWidth, int cssHeight) {
+        this.cssHeight = cssHeight;
+        this.cssWidth = cssWidth;
+        this.location = new Point(0, 0);
+
+        imageForkJoinTask = createImageResolveTask(handler, uri, cssWidth, cssHeight);
+        ForkJoinPool.commonPool().submit(imageForkJoinTask);
+    }
+
+    @Nonnull
+    private static ForkJoinTask<FSImage> createImageResolveTask(PdfReplaceHandler handler, String uri, int cssWidth, int cssHeight) {
+        return ForkJoinTask.adapt(() -> {
+            try {
+                return handler.resolveUri(uri, null, cssWidth, cssHeight);
+            } catch (Exception e) {
+                Exceptions.handle(e);
+            }
+            return null;
+        });
+    }
+
+    private FSImage waitAndGetImage() {
+        if (image != null) {
+            return image;
+        }
+
+        try {
+            image = imageForkJoinTask.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Exceptions.handle(e);
+        } catch (ExecutionException e) {
+            Exceptions.handle(e);
+        }
+        return image;
+    }
+
+    @Override
+    public void paint(RenderingContext c, ITextOutputDevice outputDevice, BlockBox box) {
+        Rectangle contentBounds = box.getContentAreaEdge(box.getAbsX(), box.getAbsY(), c);
+        if (waitAndGetImage() != null) {
+            Tuple<Integer, Integer> centerPosition = computeCenterPosition(contentBounds);
+            outputDevice.drawImage(image, centerPosition.getFirst(), centerPosition.getSecond());
+        } else if (fallbackElement != null) {
+            outputDevice.drawImage(((ITextImageElement) fallbackElement).getImage(), contentBounds.x, contentBounds.y);
+        }
+    }
+
+    private Tuple<Integer, Integer> computeCenterPosition(Rectangle contentBounds) {
+        int x = (cssWidth - image.getWidth()) / 2;
+        int y = (cssHeight - image.getHeight()) / 2;
+        return Tuple.create(contentBounds.x + x, contentBounds.y + y);
+    }
+
+    @Override
+    public int getIntrinsicWidth() {
+        return cssWidth;
+    }
+
+    @Override
+    public int getIntrinsicHeight() {
+        return cssHeight;
+    }
+
+    @Override
+    public Point getLocation() {
+        return location;
+    }
+
+    @Override
+    public void setLocation(int x, int y) {
+        location = new Point(x, y);
+    }
+
+    @Override
+    public void detach(LayoutContext c) {
+        // nothing to do
+    }
+
+    @Override
+    public boolean isRequiresInteractivePaint() {
+        return false;
+    }
+
+    @Override
+    public int getBaseline() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasBaseline() {
+        return false;
+    }
+
+    public ReplacedElement getFallbackElement() {
+        return fallbackElement;
+    }
+
+    public void setFallbackElement(ReplacedElement fallbackElement) {
+        this.fallbackElement = fallbackElement;
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -56,28 +56,25 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
             return null;
         }
 
-        ReplacedElement fallBackElement = super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
         String nodeName = e.getNodeName();
         if (!TAG_TYPE_IMG.equals(nodeName)) {
-            return fallBackElement;
+            return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
         }
 
         String src = e.getAttribute(ATTR_SRC);
         if (Strings.isEmpty(src)) {
-            return fallBackElement;
+            return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
         }
 
         try {
             String protocol = Strings.split(src, "://").getFirst();
             PdfReplaceHandler handler = findHandler(protocol);
-            AsyncLoadedImageElement imageElement = new AsyncLoadedImageElement(handler, src, cssWidth, cssHeight);
-            imageElement.setFallbackElement(fallBackElement);
-            return imageElement;
+            return new AsyncLoadedImageElement(handler, src, cssWidth, cssHeight);
         } catch (Exception ex) {
             Exceptions.handle(ex);
         }
 
-        return fallBackElement;
+        return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
     }
 
     private PdfReplaceHandler findHandler(String protocol) {

--- a/src/main/java/sirius/web/templates/pdf/ResourceHandlingSemaphore.java
+++ b/src/main/java/sirius/web/templates/pdf/ResourceHandlingSemaphore.java
@@ -1,0 +1,41 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates.pdf;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * This class is used to limit the number of concurrent resource handling operations.
+ * <p>
+ * This is used to avoid overloading the system with too many concurrent resource handling operations.
+ */
+public class ResourceHandlingSemaphore {
+
+    /**
+     * We use only the half of the available processors to avoid overloading the system.
+     */
+    private static final int HALF_THE_AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors() / 2;
+    private static Semaphore semaphore;
+
+    private ResourceHandlingSemaphore() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Returns the semaphore instance.
+     *
+     * @return the semaphore instance
+     */
+    public static Semaphore get() {
+        if (semaphore == null) {
+            semaphore = new Semaphore(HALF_THE_AVAILABLE_PROCESSORS);
+        }
+        return semaphore;
+    }
+}

--- a/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
@@ -8,8 +8,10 @@
 
 package sirius.web.templates.pdf.handlers;
 
+import com.lowagie.text.Image;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.pdf.ITextFSImage;
 import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nullable;
@@ -29,6 +31,6 @@ public class HttpPdfReplaceHandler extends PdfReplaceHandler {
     @Nullable
     public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
             throws Exception {
-        return resizeImage(userAgentCallback.getImageResource(uri).getImage(), cssWidth, cssHeight);
+        return resizeImage(new ITextFSImage(Image.getInstance(uri)), cssWidth, cssHeight);
     }
 }


### PR DESCRIPTION
If many (more than 100) PDF pages with images are to be rendered, this takes a very long time (sometimes over 90 seconds). This should be improved by separating the resolving and scaling of the image into a separate thread.

Each image requests a slot on a free thread in a common thread pool.

Until the image has been loaded and scaled, it is merely a placeholder with the dimensions of the box in which it is to be placed later.

Fixes: SE-13398