### PR TITLE
fix selectable hasMore entry for wondergem selectfield

### DIFF
--- a/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
+++ b/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
@@ -354,22 +354,24 @@ var multiSelect = function (args) {
                 var responseTokens = [];
                 var suggestionAdded = false;
                 response.completions.forEach(function (completion) {
-                    responseTokens.push({
-                        // label is the text displayed in the dropdown. should be what is given as "description"
-                        // by the service. but use other texts as fallback.
-                        label: completion.description || completion.text || completion.id,
-                        value: completion.id,
-                        type: 'basic'
-                    });
-
-                    if (!suggestions.getTokenForValue(completion.id)) {
-                        suggestionAdded = true;
-                        suggestions.addSuggestion({
-                            // label is the text displayed in the tokenfield. should be what is given as "text"
+                    if (!completion.disabled) {
+                        responseTokens.push({
+                            // label is the text displayed in the dropdown. should be what is given as "description"
                             // by the service. but use other texts as fallback.
-                            label: completion.text || completion.description || completion.id,
-                            value: completion.id
+                            label: completion.description || completion.text || completion.id,
+                            value: completion.id,
+                            type: 'basic'
                         });
+
+                        if (!suggestions.getTokenForValue(completion.id)) {
+                            suggestionAdded = true;
+                            suggestions.addSuggestion({
+                                // label is the text displayed in the tokenfield. should be what is given as "text"
+                                // by the service. but use other texts as fallback.
+                                label: completion.text || completion.description || completion.id,
+                                value: completion.id
+                            });
+                        }
                     }
                 });
                 if (suggestionAdded) {


### PR DESCRIPTION
With SE-12851 we introduced a not selectable ... hasMore label, but this does not work properly for wondergem select-fields. The inclusion in wondergem is disproportionately complex, that's why we simple remove and not show the entry for wondergem

- fixes: SIRI-934