### PR TITLE
Allows to retrieve the specified URI pattern of a route

### DIFF
--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -439,6 +439,10 @@ public class Route {
         return pattern.toString();
     }
 
+    public String getUri() {
+        return uri;
+    }
+
     /**
      * Invokes the route with the given parameters.
      *


### PR DESCRIPTION
This can be useful for logging ClickHouse events or other things.

Fixes: [OX-10830](https://scireum.myjetbrains.com/youtrack/issue/OX-10830)