### PR TITLE
Logs aggregatable route in page impression events

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -230,7 +230,7 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private void executeRoute(WebContext webContext, Route route, List<Object> params) throws Exception {
-        webContext.setAttribute(ATTRIBUTE_MATCHED_ROUTE, route.getPattern());
+        webContext.setAttribute(ATTRIBUTE_MATCHED_ROUTE, route.getUri());
 
         if (route.getApiResponseFormat() != null) {
             executeApiCall(webContext, route, params);


### PR DESCRIPTION
The previously logged string representation of the route matching pattern is hard to read and also not as easy to aggregate. Now we actually log the route URI as it is defined in the Routed annotation of each route.

Its known and accepted that this means, that old and new events for the same route are not easily aggregatable together.

Fixes: [OX-10830](https://scireum.myjetbrains.com/youtrack/issue/OX-10830)