### PR TITLE
Datasheet: Acquires a token before starting the thread

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -14,6 +14,7 @@ import org.xhtmlrenderer.pdf.ITextOutputDevice;
 import org.xhtmlrenderer.pdf.ITextReplacedElement;
 import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.RenderingContext;
+import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.health.Exceptions;
 import sirius.web.templates.pdf.handlers.PdfReplaceHandler;
@@ -55,16 +56,14 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
         this.cssWidth = cssWidth;
         this.location = new Point(0, 0);
 
-        Semaphore semaphore = ResourceHandlingSemaphore.get();
-        try {
-            semaphore.acquire();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            Exceptions.handle(e);
-        }
+        Semaphore semaphore = CallContext.getCurrent().getOrCreateSubContext(SemaphoreContext.class).getSemaphore();
         resolvingThread = Thread.startVirtualThread(() -> {
             try {
+                semaphore.acquire();
                 image = handler.resolveUri(uri, null, cssWidth, cssHeight);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Exceptions.handle(e);
             } catch (Exception e) {
                 Exceptions.handle(e);
             } finally {
@@ -77,6 +76,7 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
      * Returns the resolved image.
      * <p>
      * When we call this method, we really need the resolved image. Therefore, we wait until the image is resolved.
+     *
      * @return the resolved image or <tt>null</tt> if the image could not be resolved
      */
     private FSImage waitAndGetImage() {

--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -56,13 +56,15 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
         this.location = new Point(0, 0);
 
         Semaphore semaphore = ResourceHandlingSemaphore.get();
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Exceptions.handle(e);
+        }
         resolvingThread = Thread.startVirtualThread(() -> {
             try {
-                semaphore.acquire();
                 image = handler.resolveUri(uri, null, cssWidth, cssHeight);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                Exceptions.handle(e);
             } catch (Exception e) {
                 Exceptions.handle(e);
             } finally {

--- a/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
+++ b/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
@@ -8,6 +8,8 @@
 
 package sirius.web.templates.pdf;
 
+import sirius.kernel.async.SubContext;
+
 import java.util.concurrent.Semaphore;
 
 /**
@@ -15,27 +17,33 @@ import java.util.concurrent.Semaphore;
  * <p>
  * This is used to avoid overloading the system with too many concurrent resource handling operations.
  */
-public class ResourceHandlingSemaphore {
+public class SemaphoreContext implements SubContext {
 
     /**
      * We use only the half of the available processors to avoid overloading the system.
      */
     private static final int HALF_THE_AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors() / 2;
-    private static Semaphore semaphore;
 
-    private ResourceHandlingSemaphore() {
-        // Prevent instantiation
-    }
+    private final Semaphore semaphore;
 
     /**
-     * Returns the semaphore instance.
-     *
-     * @return the semaphore instance
+     * Initializes a new semaphore context which uses a semaphore to limit the number of concurrent resource handling.
      */
-    public static Semaphore get() {
-        if (semaphore == null) {
-            semaphore = new Semaphore(HALF_THE_AVAILABLE_PROCESSORS);
-        }
-        return semaphore;
+    public SemaphoreContext() {
+        this.semaphore = new Semaphore(HALF_THE_AVAILABLE_PROCESSORS);
+    }
+
+    public Semaphore getSemaphore() {
+        return this.semaphore;
+    }
+
+    @Override
+    public SubContext fork() {
+        return this;
+    }
+
+    @Override
+    public void detach() {
+        // GC will take care of the semaphore
     }
 }

--- a/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
+++ b/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
@@ -15,8 +15,8 @@ import java.util.concurrent.Semaphore;
 /**
  * This class is used to limit the number of concurrent resource handling operations per belonging CallContext.
  * <p>
- *  The usecase is that we want to control the number of spawned threads to avoid overloading the 
- *  system with too many concurrent operations.
+ * The usecase is that we want to control the number of spawned threads to avoid overloading the
+ * system with too many concurrent operations.
  */
 public class SemaphoreContext implements SubContext {
 

--- a/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
+++ b/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
@@ -13,9 +13,10 @@ import sirius.kernel.async.SubContext;
 import java.util.concurrent.Semaphore;
 
 /**
- * This class is used to limit the number of concurrent resource handling operations.
+ * This class is used to limit the number of concurrent resource handling operations per belonging CallContext.
  * <p>
- * This is used to avoid overloading the system with too many concurrent resource handling operations.
+ *  The usecase is that we want to control the number of spawned threads to avoid overloading the 
+ *  system with too many concurrent operations.
  */
 public class SemaphoreContext implements SubContext {
 


### PR DESCRIPTION
To ensure that users with smaller requests are not blocked by users with large requests, the system waits for a token from the semaphore before starting a new thread. 

This prevents countless threads from running and simply waiting.