### PR TITLE
also set t:textarea to disabled if readonly to have correct css

### DIFF
--- a/src/main/resources/default/taglib/t/textarea.html.pasta
+++ b/src/main/resources/default/taglib/t/textarea.html.pasta
@@ -28,7 +28,7 @@
               rows="@rows"
               class="form-control input-block-level @fieldClass"
               @if (isFilled(placeholder)) { placeholder="@placeholder" }
-              @if (readonly) { readonly }>@UserContext.get().getFieldValue(name, value)</textarea>
+              @if (readonly) { disabled readonly }>@UserContext.get().getFieldValue(name, value)</textarea>
 
     <i:if test="isFilled(help)">
         <small class="form-text text-muted">


### PR DESCRIPTION
Bootstrap 5 requires disabled to have the gray background and readonly textarea should also be disabled like t:textfield and t:datefield.
- fixes: SIRI-936