### PR TITLE
Prevents dialog from exceeding the window size

### DIFF
--- a/src/main/resources/default/assets/common/styles/dialog.scss
+++ b/src/main/resources/default/assets/common/styles/dialog.scss
@@ -12,6 +12,8 @@
   flex-basis: 600px;
   max-width: 800px;
   min-height: 200px;
+  max-height: 100%;
+  max-width: 100%;
 
   #sci-dialog-header {
     border-bottom: 1px solid;


### PR DESCRIPTION
This makes the dialog more robust against some edge cases.

**Before:**

![image](https://github.com/scireum/sirius-web/assets/2427877/5fc565f2-8226-4227-93af-2885d498b904)

**After:**

![image](https://github.com/scireum/sirius-web/assets/2427877/c6080749-a56d-4ba6-9f12-501cc8689809)


Fixes: [OX-10841](https://scireum.myjetbrains.com/youtrack/issue/OX-10841)