### PR TITLE
Fix t:datefield for bootstrap-5 migration

### DIFF
--- a/src/main/resources/default/taglib/t/datefield.html.pasta
+++ b/src/main/resources/default/taglib/t/datefield.html.pasta
@@ -19,8 +19,8 @@
 
 <i:pragma name="description" value="Renders a date input field within a Tycho template"/>
 
-<i:local name="valueAsLocalDate"
-         value="@NLS.parseUserString(java.time.LocalDate.class, UserContext.get().getFieldValue(name, value))"/>
+<i:local name="effectiveValue" value="UserContext.get().getFieldValue(name, value)"/>
+<i:local name="min" value="noPastDates ? today() : java.time.LocalDate.of(1900,1,1)"/>
 
 <div class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
     <i:if test="isFilled(label) || forceLabel">
@@ -31,8 +31,10 @@
         <input @if(isFilled(fieldName)) { name="@fieldName" }
                @if(isFilled(id)) { id="@id" }
                type="date"
-               value="@valueAsLocalDate"
-               @if (noPastDates) { min="@today()" }
+               value="@effectiveValue"
+               min="@min"
+               max="2100-12-31"
+               oninvalid="document.querySelector('.single-click-pending-js').classList.remove('single-click-pending-js');"
                autocomplete="off"
                class="form-control input-block-level"
                @if (isFilled(placeholder)) { placeholder="@placeholder" }


### PR DESCRIPTION
In sirius.kernel.commons.AdvancedDateParser#ensureValidYear we only allow values between 1900 - 2100. So we also can do this in the Frontend via min and max values at the date input. Also the oninvalid event must reset the single-click.pending-js on the save button, because otherwise (after an invalid input) we can never press save-button again, The value now will nomore be parsed twice, so we have to fix a breaking change....

HINT: copy-pasting into a datefield is with the date-input no more available (in contrast to the before-bs5-version) and not easy to fix. Maybe a small hack like onpaste()-event could be a solution, but input-sanitizing would be the next problem then...

BREAKING: We have to use @toMachineString(dateFieldValue) for all values in t:datefields now.

- fixes: SIRI-938