### PR TITLE
Introduce an availability icon for order items

### DIFF
--- a/src/main/resources/assets/design-system/icons.scss
+++ b/src/main/resources/assets/design-system/icons.scss
@@ -52,6 +52,10 @@
   background-image: url(svgResource('/assets/images/icons/availability/made-to-order.svg'));
 }
 
+.sci-icon-availability-order_item {
+  background-image: url(svgResource('/assets/images/icons/availability/order-item.svg'));
+}
+
 .sci-icon-availability-out_of_stock {
   background-image: url(svgResource('/assets/images/icons/availability/out-of-stock.svg'));
 }

--- a/src/main/resources/assets/images/icons/availability/order-item.svg
+++ b/src/main/resources/assets/images/icons/availability/order-item.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle fill="#F4F4F4" cx="16" cy="16" r="16"></circle>
+    <circle stroke="#3562DA" stroke-width="3" fill="#AFC4FD" cx="16" cy="16" r="11.3"></circle>
+</svg>


### PR DESCRIPTION
Order items are items that a shop usually doesn't keep in stock, but still wants to sell. Rather than showing a red (unfriendly) icon, this commit allows the shop to show a more friendly blue icon.