### PR TITLE
Update disabled text input background color

### DIFF
--- a/src/main/resources/assets/design-system/form.scss
+++ b/src/main/resources/assets/design-system/form.scss
@@ -39,5 +39,5 @@ textarea.sci-text-input[disabled],
 input.sci-text-input[readonly],
 textarea.sci-text-input[readonly] {
   border-color: #747474;
-  background-color: #E6E6E6;
+  background-color: #E9ECEF;
 }


### PR DESCRIPTION
This is done to match the color scheme of Tycho after the Bootstrap 5 upgrade.

**Before:**

![image](https://github.com/scireum/sirius-web/assets/2427877/1705999e-6e8b-44e5-af03-1180207016ac)

**After:**

![image](https://github.com/scireum/sirius-web/assets/2427877/d5fdd9d5-c3a9-499c-a0a7-46da8e4efbdf)

Fixes: [OX-10841](https://scireum.myjetbrains.com/youtrack/issue/OX-10841)