### PR TITLE
Fixes authentication errors against SMTP servers which require early passwords

### DIFF
--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -504,7 +504,7 @@ class SendMailTask implements Runnable {
     protected Transport getSMTPTransport(Session session, SMTPConfiguration config) {
         try {
             Transport transport = session.getTransport();
-            transport.connect(config.getMailHost(), config.getMailUser(), null);
+            transport.connect(config.getMailHost(), config.getMailUser(), config.getMailPassword());
             return transport;
         } catch (Exception e) {
             throw Exceptions.handle()


### PR DESCRIPTION
We already provide the password via an authenticator implementation (sirius.web.mails.SendMailTask.MailAuthenticator). However SMTPTransport#sendMessage does evaluate the password set this way only after the initial connection.

The transport seems to then normally challenge the client for a password which is after the first round set correctly. However for some SMTP servers (e.g. SMTP relays with strict rules) which require early authentication, this is not enough.

Setting the password at the transport will in turn set the password on a URLName object which **IS** getting evaluated early.

Fixes: SE-13522