### PR TITLE
Noodle - Only detect intrinsic NLS get call for single parameter calls

### DIFF
--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -77,7 +77,9 @@ public class MethodCall extends Call {
     @SuppressWarnings({"java:S3776", "java:S1541"})
     @Explain("We rather keep all optimizations in one place.")
     private Node optimizeIntrinsics() {
-        if (NLS.class.equals(method.getDeclaringClass()) && "get".equals(method.getName())) {
+        if (NLS.class.equals(method.getDeclaringClass())
+            && "get".equals(method.getName())
+            && parameterNodes.length == 1) {
             return new IntrinsicCall(getPosition(),
                                      method.getGenericReturnType(),
                                      OpCode.INTRINSIC_NLS_GET,


### PR DESCRIPTION
The previous logic also optimized NLS get calls with multiple parameters (there is a variant with an int for singular/plural and one with a string for a forced language) to the NLS get call with the single string parameter for the key. This meant that the other two variants were not callable in Noodle scripts and Tagliatelle templates.

Fixes: [OX-10611](https://scireum.myjetbrains.com/youtrack/issue/OX-10611)