### PR TITLE
Colorpicker: Stops displaying color code when no color is set

### DIFF
--- a/src/main/resources/default/taglib/t/colorpicker.html.pasta
+++ b/src/main/resources/default/taglib/t/colorpicker.html.pasta
@@ -26,14 +26,14 @@
     </i:if>
 
     <div class="input-group">
-        <input id="@textId"
+        <input @if(isFilled(fieldName)) { name="@fieldName" }
+               id="@textId"
                type="text"
                value="@UserContext.get().getFieldValue(name, value)"
                class="form-control input-block-level @fieldClass"
                @if (isFilled(placeholder)) { placeholder="@placeholder" }
                @if (isFilled(tabIndex)) { tabindex="@tabIndex" }/>
-        <input @if(isFilled(fieldName)) { name="@fieldName" }
-               id="@colorId"
+        <input id="@colorId"
                type="color"
                value="@UserContext.get().getFieldValue(name, value)"
                class="form-control form-control-color"
@@ -58,7 +58,9 @@
             });
 
             _textInput.addEventListener('change', () => {
-                _textInput.value = sirius.convertColorToHex(_textInput.value);
+                if (_textInput.value.length > 0) {
+                    _textInput.value = sirius.convertColorToHex(_textInput.value);
+                }
             });
 
             _colorInput.addEventListener('input', () => {


### PR DESCRIPTION
Before:
<img width="1661" alt="image" src="https://github.com/scireum/sirius-web/assets/150906388/84aadb74-9359-47f7-ac10-f5f1400e44e6">

After:
<img width="1662" alt="image" src="https://github.com/scireum/sirius-web/assets/150906388/4daf767f-35ed-4d37-bc21-9a3b00966741">

Fixes: SIRI-940