### PR TITLE
Delays logging of error message when invalid JSON content is fetched

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1954,7 +1954,7 @@ public class WebContext implements SubContext {
     public ObjectNode getJSONContent() {
         try {
             if (content == null) {
-                throw Exceptions.handle()
+                throw Exceptions.createHandled()
                                 .to(WebServer.LOG)
                                 .withSystemErrorMessage("Expected a valid JSON map as body of this request.")
                                 .handle();
@@ -1962,10 +1962,10 @@ public class WebContext implements SubContext {
             if (!content.isInMemory()
                 && content.getFile().length() > maxStructuredInputSize
                 && maxStructuredInputSize > 0) {
-                throw Exceptions.handle()
+                throw Exceptions.createHandled()
                                 .to(WebServer.LOG)
                                 .withSystemErrorMessage(
-                                        "Request body is too large to parse as JSON. The limit is %d bytes",
+                                        "Request body is too large to parse as JSON. The limit is %d bytes.",
                                         maxStructuredInputSize)
                                 .handle();
             }
@@ -1973,7 +1973,7 @@ public class WebContext implements SubContext {
         } catch (HandledException exception) {
             throw exception;
         } catch (Exception exception) {
-            throw Exceptions.handle()
+            throw Exceptions.createHandled()
                             .to(WebServer.LOG)
                             .error(exception)
                             .withSystemErrorMessage("Expected a valid JSON map as body of this request: %s (%s).")


### PR DESCRIPTION
For some calls it may not be easy to determine if it contains a JSON body or we want to try to access it anyway. With this change the caller can decide whether to log the thrown exception or not.

Fixes: [OX-10862](https://scireum.myjetbrains.com/youtrack/issue/OX-10862)