### PR TITLE
Improves scripting capabilities of Noodle

### DIFF
--- a/src/main/java/sirius/pasta/noodle/Environment.java
+++ b/src/main/java/sirius/pasta/noodle/Environment.java
@@ -12,7 +12,7 @@ package sirius.pasta.noodle;
  * Defines an environment which permits to access shared variables.
  * <p>
  * For example a <b>Tagliatelle</b> template is a bunch of scripts which share all arguments and local variables
- * of the template. Therefore, an environment (in the form of {@link sirius.pasta.tagliatelle.rendering.LocalRenderContext}
+ * of the template. Therefore, an environment (in the form of {@link sirius.pasta.tagliatelle.rendering.LocalRenderContext})
  * is provided to share these.
  */
 public interface Environment {

--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -296,14 +296,13 @@ public class Invocation {
         int initialIP = instructionPointer + 1;
         int contextOffset = pop(int.class);
         Class<?> samInterface = pop(Class.class);
-        Environment lambdaEnvironment = LambdaEnvironment.create(environment, contextOffset, numLocals);
         push(Proxy.newProxyInstance(getClass().getClassLoader(),
                                     new Class[]{samInterface},
                                     new LambdaHandler(initialIP,
                                                       contextOffset,
                                                       numLocals,
                                                       compiledMethod,
-                                                      lambdaEnvironment)));
+                                                      environment)));
     }
 
     private void handleJumpFalse(int index) {

--- a/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
@@ -296,11 +296,11 @@ public class TypeTools {
     public static Class<?> simplifyToClass(Type type, Class<?> fallback) {
         // Try to resolve type parameters into their actual values if possible.
         // This will propagate type parameters down a call chain.
-        if (type instanceof Class<?>) {
-            return (Class<?>) type;
+        if (type instanceof Class<?> clazz) {
+            return clazz;
         }
-        if (type instanceof ParameterizedType) {
-            return (Class<?>) ((ParameterizedType) type).getRawType();
+        if (type instanceof ParameterizedType parameterizedType) {
+            return (Class<?>) parameterizedType.getRawType();
         }
 
         return fallback;

--- a/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
@@ -287,7 +287,7 @@ public class TypeTools {
     }
 
     /**
-     * Tries to reduces the given type to a <tt>Class</tt>.
+     * Tries to reduce the given type to a <tt>Class</tt>.
      *
      * @param type     the type to reduce
      * @param fallback used if the type cannot be reduced, e.g. for an unresolved type variable.

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/LambdaNode.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/LambdaNode.java
@@ -68,10 +68,10 @@ public class LambdaNode extends Node {
     }
 
     public Class<?> getSamInterface() {
-        return TypeTools.simplifyToClass(samInterface, Class.class);
+        return TypeTools.simplifyToClass(samInterface, Object.class);
     }
 
-    public void setSamInterface(Class<?> samInterface) {
+    public void setSamInterface(Type samInterface) {
         this.samInterface = samInterface;
     }
 
@@ -99,7 +99,7 @@ public class LambdaNode extends Node {
 
     @Override
     public void emit(Assembler assembler) {
-        assembler.emitPushConstant(samInterface, position);
+        assembler.emitPushConstant(getSamInterface(), position);
         assembler.emitPushConstant(localsOffset, position);
         assembler.emitByteCode(OpCode.LAMBDA, numberOfLocals, position);
         Assembler.Label endLabel = assembler.createLabel();

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -235,6 +235,12 @@ public class MethodCall extends Call {
             }
         }
 
+        if (type.isInterface()) {
+            // Interfaces don't report the Object methods (like getClass()) within type.getMethods() - therefore,
+            // we give this a final try here, before giving up...
+            return findMethod(Object.class, name, parameterTypes);
+        }
+
         throw new NoSuchMethodException(name);
     }
 

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
@@ -86,6 +86,10 @@ public class NoodleExample {
         };
     }
 
+    public static <E> void propagateTypes(Class<E> type, Consumer<E> consumer) {
+        // This isn't actually invoked, as we only check if Noodle can propagate the type from type to consumer..
+    }
+
     public NoodleTestRef getRef() {
         return ref;
     }

--- a/src/test/kotlin/sirius/pasta/noodle/compiler/CompilerTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/compiler/CompilerTest.kt
@@ -182,6 +182,14 @@ class CompilerTest {
     }
 
     @Test
+    fun `Interfaces support Object methods`() {
+        assert(
+                compile("NoodleExample.intConsumer().getClass().getName()").call(SimpleEnvironment()).toString()
+                        .startsWith("sirius.pasta.noodle.compiler.NoodleExample")
+        )
+    }
+
+    @Test
     fun `Types can be derived from generic super classes`() {
         assertEquals(
                 "42",

--- a/src/test/kotlin/sirius/pasta/noodle/compiler/CompilerTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/compiler/CompilerTest.kt
@@ -147,6 +147,12 @@ class CompilerTest {
     }
 
     @Test
+    fun `type propagation with generic lambdas work`() {
+        // We expect the following to compile properly by forwarding the type from the first parameter to the second...
+        compile("NoodleExample.propagateTypes(String.class, |s| { s.startsWith('x'); })")
+    }
+
+    @Test
     fun `Exceptions in lambdas work`() {
         assertThrows<ScriptingException> {
             // An undeclared exception is thrown within a lambda...

--- a/src/test/kotlin/sirius/web/http/CSRFTokenTest.kt
+++ b/src/test/kotlin/sirius/web/http/CSRFTokenTest.kt
@@ -15,8 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Streams
 import java.net.HttpURLConnection
-import java.net.URL
-
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import kotlin.test.assertEquals
 
@@ -34,8 +33,9 @@ class CSRFTokenTest {
     @Test
     fun `safePOST() works if the token is present via GET`() {
 
-        val connection = URL("http://localhost:9999/test/provide-security-token").openConnection() as HttpURLConnection
-        connection.setRequestMethod("GET")
+        val connection =
+                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
         connection.connect()
         val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
 
@@ -63,64 +63,68 @@ class CSRFTokenTest {
     @Test
     fun `safePOST() works if correct token is present via POST`() {
 
-        val connection = URL("http://localhost:9999/test/provide-security-token").openConnection() as HttpURLConnection
-        connection.setRequestMethod("GET")
+        val connection =
+                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
         connection.connect()
         val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
 
 
-        val connection2 = URL(
-            "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
-        ).openConnection() as HttpURLConnection
-        connection2.setRequestMethod("POST")
+        val connection2 = URI(
+                "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
+        ).toURL().openConnection() as HttpURLConnection
+        connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-            HttpHeaderNames.COOKIE.toString(),
-            connection.headerFields["set-cookie"]?.get(0)
+                HttpHeaderNames.COOKIE.toString(),
+                connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
-        assertEquals(200, connection2.getResponseCode())
+        assertEquals(200, connection2.responseCode)
     }
 
     @Test
     fun `safePOST() success on POST if expired token is provided`() {
 
-        val connection = URL("http://localhost:9999/test/provide-security-token").openConnection() as HttpURLConnection
-        connection.setRequestMethod("GET")
+        val connection =
+                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
         connection.connect()
         val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
         TestRequest.GET("/test/expire-security-token").execute()
 
-        val connection2 = URL(
-            "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
-        ).openConnection() as HttpURLConnection
-        connection2.setRequestMethod("POST")
+        val connection2 = URI(
+                "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
+        ).toURL().openConnection() as HttpURLConnection
+        connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-            HttpHeaderNames.COOKIE.toString(),
-            connection.headerFields["set-cookie"]?.get(0)
+                HttpHeaderNames.COOKIE.toString(),
+                connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
-        assertEquals(200,connection2.getResponseCode())
+        assertEquals(200, connection2.responseCode)
     }
 
     @Test
     fun `safePOST() works if false token is given via POST`() {
 
-        val connection = URL("http://localhost:9999/test/provide-security-token").openConnection() as HttpURLConnection
-        connection.setRequestMethod("GET")
+        val connection =
+                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
         connection.connect()
 
         val connection2 =
-            URL("http://localhost:9999/test/fake-delete-data?CSRFToken=w-r-o-n-g-t-o-k-e-n").openConnection() as HttpURLConnection
-        connection2.setRequestMethod("POST")
+                URI("http://localhost:9999/test/fake-delete-data?CSRFToken=w-r-o-n-g-t-o-k-e-n").toURL()
+                        .openConnection() as HttpURLConnection
+        connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-            HttpHeaderNames.COOKIE.toString(),
-            connection.headerFields["set-cookie"]?.get(0)
+                HttpHeaderNames.COOKIE.toString(),
+                connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
-        assertEquals(500,connection2.getResponseCode())
+        assertEquals(500, connection2.responseCode)
     }
 
     @Test
@@ -128,7 +132,7 @@ class CSRFTokenTest {
 
         val result = TestRequest.POST("/test/fake-delete-data-unsafe").execute()
 
-        assertEquals(HttpResponseStatus.OK,result.status)
+        assertEquals(HttpResponseStatus.OK, result.status)
     }
 
     @Test
@@ -136,7 +140,7 @@ class CSRFTokenTest {
 
         val result = TestRequest.GET("/test/fake-delete-data-unsafe").execute()
 
-        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR,result.status)
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, result.status)
     }
 
     @Test
@@ -150,32 +154,34 @@ class CSRFTokenTest {
     @Test
     fun `ensureSafePOST() goes wrong on POST if false token is given`() {
 
-        val connection = URL(
-            "http://localhost:9999/test/fake-delete-data-ensure-safe?CSRFToken=w-r-o-n-g-t-o-k-e-n"
-        ).openConnection() as HttpURLConnection
-        connection.setRequestMethod("POST")
+        val connection = URI(
+                "http://localhost:9999/test/fake-delete-data-ensure-safe?CSRFToken=w-r-o-n-g-t-o-k-e-n"
+        ).toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
         connection.connect()
 
-        assertEquals(401,connection.responseCode )
+        assertEquals(401, connection.responseCode)
     }
 
     @Test
     fun `ensureSafePOST() works as intended if correct token is given via POST`() {
 
-        val connection = URL("http://localhost:9999/test/provide-security-token").openConnection() as HttpURLConnection
-        connection.setRequestMethod("GET")
+        val connection =
+                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
         connection.connect()
-        val token = String(Streams.toByteArray(connection.getInputStream()), StandardCharsets.UTF_8)
+        val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
 
         val connection2 =
-            URL("http://localhost:9999/test/fake-delete-data-ensure-safe?CSRFToken=$token").openConnection() as HttpURLConnection
-        connection2.setRequestMethod("POST")
+                URI("http://localhost:9999/test/fake-delete-data-ensure-safe?CSRFToken=$token").toURL()
+                        .openConnection() as HttpURLConnection
+        connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-            HttpHeaderNames.COOKIE.toString(),
-            connection.headerFields["set-cookie"]?.get(0)
+                HttpHeaderNames.COOKIE.toString(),
+                connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
-        assertEquals(200,connection2.getResponseCode())
+        assertEquals(200, connection2.getResponseCode())
     }
 }


### PR DESCRIPTION
- We now support lambdas which call themselves recursively or which are invoked in parallel (by having distinct local environments)
- We added the Object protocol to all interfaces, so that methods like getClass() can be invoked on them
- We improved parameter type propagation for lambdas, e.g. for methods like `<E> void foo(Class<E> type, Consumer<E> consumer)` where the first parameter would determine the type for the second (the lambda parameter).