### PR TITLE
Delay logging of error message when invalid JSON content is fetched

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1969,7 +1969,7 @@ public class WebContext implements SubContext {
                                         maxStructuredInputSize)
                                 .handle();
             }
-            return Json.parseObject(content.getString(getRequestEncoding()));
+            return Json.tryParseObject(content.getString(getRequestEncoding()));
         } catch (HandledException exception) {
             throw exception;
         } catch (Exception exception) {


### PR DESCRIPTION
For some calls it may not be easy to determine if it contains a JSON body or we want to try to access it anyway. With this change the caller can decide whether to log the thrown exception or not.

The previous solution of commit 0d19e75c1a56a33a22584b05f0d169c11de10ce5 of PR https://github.com/scireum/sirius-web/pull/1395 was incomplete in this regard as Json#parseObject always logs an error message to the main logger.

Fixes: [OX-10940](https://scireum.myjetbrains.com/youtrack/issue/OX-10940)