### PR TITLE
Makes mail authentication on transport configurable

### DIFF
--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -33,6 +33,7 @@ import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Exceptions;
+import sirius.web.security.UserContext;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -504,7 +505,10 @@ class SendMailTask implements Runnable {
     protected Transport getSMTPTransport(Session session, SMTPConfiguration config) {
         try {
             Transport transport = session.getTransport();
-            transport.connect(config.getMailHost(), config.getMailUser(), config.getMailPassword());
+            String password = UserContext.getSettings().get("mail.useTransportAuthentication").asBoolean() ?
+                              config.getMailPassword() :
+                              null;
+            transport.connect(config.getMailHost(), config.getMailUser(), password);
             return transport;
         } catch (Exception e) {
             throw Exceptions.handle()

--- a/src/main/resources/scope-conf/mail.conf
+++ b/src/main/resources/scope-conf/mail.conf
@@ -31,4 +31,7 @@ mail {
 
     # Whether E-Mail addresses should be encoded with punycode/IDN for e.g. äöüß in international mails
     usePunycode = false
+
+    # Whether the mail server requires early authentication
+    useTransportAuthentication = false
 }


### PR DESCRIPTION
- the password was introduced recently to fix a specific smtp server error
- it seems to make problems with other mail server implementations

Fixes: SE-13522