### PR TITLE
Tooltips for `<t:iconInlineInfo>`

### DIFF
--- a/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
+++ b/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
@@ -2,23 +2,36 @@
 <i:arg type="String" name="value" default=""/>
 <i:arg type="Object" name="effectiveValue" default="isFilled(value) ? value : renderToString('body')"/>
 <i:arg type="String" name="class" default=""/>
+<i:arg name="title" type="String" default=""/>
+<i:arg name="link" type="String" default=""/>
 
 <i:pragma name="description">
     Renders an icon + value pair which is rendered as a single block.
 </i:pragma>
 
+<i:local name="wrapper"
+         value="@isFilled(link) ? 'a' : 'span'"/>
+
 <i:if test="isFilled(effectiveValue)">
     <span class="d-flex flew-row text-small mb-2 me-2 @class">
-        <span class="text-sirius-gray-dark ">
-            <i class="@icon"></i>
-        </span>
-        <span class="ps-1 overflow-hidden text-break">
-            <i:if test="isFilled(value)">
-                @value
-                <i:else>
-                    <i:raw>@effectiveValue</i:raw>
-                </i:else>
-            </i:if>
-        </span>
+        <@wrapper @if (isFilled(link)) { href="@link" } @if (isFilled(title)) {
+              title="@title"
+              aria-label="@title"
+              data-bs-toggle="tooltip"
+              }
+              class="@if (isFilled(title) || isFilled(link)) { card-link } text-decoration-none"
+              style="color: inherit">
+            <span class="text-sirius-gray-dark text-black">
+                <i class="@icon"></i>
+            </span>
+            <span class="ps-1 overflow-hidden text-break">
+                <i:if test="isFilled(value)">
+                    @value
+                    <i:else>
+                        <i:raw>@effectiveValue</i:raw>
+                    </i:else>
+                </i:if>
+            </span>
+        </@wrapper>
     </span>
 </i:if>

--- a/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
+++ b/src/main/resources/default/taglib/t/iconInlineInfo.html.pasta
@@ -1,7 +1,7 @@
-<i:arg type="String" name="icon"/>
-<i:arg type="String" name="value" default=""/>
-<i:arg type="Object" name="effectiveValue" default="isFilled(value) ? value : renderToString('body')"/>
-<i:arg type="String" name="class" default=""/>
+<i:arg name="icon" type="String"/>
+<i:arg name="value" type="String" default=""/>
+<i:arg name="effectiveValue" type="Object" default="isFilled(value) ? value : renderToString('body')"/>
+<i:arg name="class" type="String" default=""/>
 <i:arg name="title" type="String" default=""/>
 <i:arg name="link" type="String" default=""/>
 


### PR DESCRIPTION
### Description

When using `<t:iconInlineInfo>` within `<t:datacard>`, users may want to know more about the information displayed, depending on how obvious the icon is. The new `title` property allows to set such information, which will be displayed as BS tooltip and rendered as ARIA label.

In order to make this work, the tooltip technically needs to become a link, thus overriding the card's own link. It is thus convenient to also pass the link property to allow seamless navigation.

### Screenie

<img width="843" alt="Screenshot 2024-04-25 at 15 05 17" src="https://github.com/scireum/sirius-web/assets/36069303/386b66da-4bbb-4076-94c0-52db423585d7">
