### PR TITLE
Revert a failed dependency upgrade/switch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,9 @@
 
         <!-- Used to send and receive mails -->
         <dependency>
-            <groupId>jakarta.mail</groupId>
-            <artifactId>jakarta.mail-api</artifactId>
-            <version>2.1.3</version>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>


### PR DESCRIPTION
Switching from jakarta.mail (which does not have recent releases) to jaka.mail-api (which has recent releases) was done by accident, as the API does not provide any implementation that is required for actually sending mails.