### PR TITLE
Allow to overwrite the new Netty post request limits

### DIFF
--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -14,6 +14,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
@@ -83,6 +84,12 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
 
     @ConfigValue("http.maxKeepalive")
     private static int maxKeepalive;
+
+    @ConfigValue("http.maxFormFields")
+    private static int maxPostFields;
+
+    @ConfigValue("http.maxFormBufferedBytes")
+    private static int maxFormBufferedBytes;
 
     /**
      * Creates a new instance and initializes some statistics.
@@ -456,7 +463,11 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
             if (WebServer.LOG.isFINE()) {
                 WebServer.LOG.FINE("POST/PUT-FORM: " + request.uri());
             }
-            HttpPostRequestDecoder postDecoder = new HttpPostRequestDecoder(WebServer.getHttpDataFactory(), request);
+            HttpPostRequestDecoder postDecoder = new HttpPostRequestDecoder(WebServer.getHttpDataFactory(),
+                                                                            request,
+                                                                            HttpConstants.DEFAULT_CHARSET,
+                                                                            maxPostFields,
+                                                                            maxFormBufferedBytes);
             currentContext.setPostDecoder(postDecoder);
         } else {
             if (WebServer.LOG.isFINE()) {

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -87,6 +87,14 @@ http {
     # Note that proxies (listed in firewall.proxyIPs are unlimited).
     maxKeepalive = 25
 
+    # Determines the maximum number of form fields to accept in a POST request.
+    # This is used to configure the Netty PostRequestDecoder accordingly.
+    maxFormFields = 512
+
+    # Determines the maximum number of buffered bytes when decoding a POST request field.
+    # This is used to configure the Netty PostRequestDecoder accordingly.
+    maxFormBufferedBytes = 1024
+
     # Determines if a P3P fake header disabling all p3p checks in Internet Explorer (which is one of the last user
     # agents caring about that). A detailed description of P3P can be found here: http://en.wikipedia.org/wiki/P3P
     addP3PHeader = true


### PR DESCRIPTION
And also initially sets a more generous limit for the maximum number of form fields in a request. Netty default was 128, increased to 512. Netty tests internally with a limit of 1024.