### PR TITLE
Resolving URLs that uses http but redirects to https

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -92,7 +92,7 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
             Exceptions.handle(exception);
             return;
         }
-        if (attempt <= MAX_ATTEMPTS) {
+        if (attempt < MAX_ATTEMPTS) {
             Wait.millis(500);
             startResolvingResource(uri, handler, semaphore, attempt + 1);
         } else if (exception != null) {

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -69,7 +69,7 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
         try {
             String protocol = Strings.split(src, "://").getFirst();
             PdfReplaceHandler handler = findHandler(protocol);
-            return new AsyncLoadedImageElement(handler, src, cssWidth, cssHeight);
+            return new AsyncLoadedImageElement(handler, uac, src, cssWidth, cssHeight);
         } catch (Exception ex) {
             Exceptions.handle(ex);
         }

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -46,9 +46,9 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
     }
 
     @Override
-    public ReplacedElement createReplacedElement(LayoutContext c,
+    public ReplacedElement createReplacedElement(LayoutContext layoutContext,
                                                  BlockBox box,
-                                                 UserAgentCallback uac,
+                                                 UserAgentCallback userAgentCallback,
                                                  int cssWidth,
                                                  int cssHeight) {
         Element e = box.getElement();
@@ -58,23 +58,23 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
 
         String nodeName = e.getNodeName();
         if (!TAG_TYPE_IMG.equals(nodeName)) {
-            return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
+            return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
         }
 
         String src = e.getAttribute(ATTR_SRC);
         if (Strings.isEmpty(src)) {
-            return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
+            return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
         }
 
         try {
             String protocol = Strings.split(src, "://").getFirst();
             PdfReplaceHandler handler = findHandler(protocol);
-            return new AsyncLoadedImageElement(handler, uac, src, cssWidth, cssHeight);
+            return new AsyncLoadedImageElement(handler, userAgentCallback, src, cssWidth, cssHeight);
         } catch (Exception ex) {
             Exceptions.handle(ex);
         }
 
-        return super.createReplacedElement(c, box, uac, cssWidth, cssHeight);
+        return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
     }
 
     private PdfReplaceHandler findHandler(String protocol) {

--- a/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
@@ -31,6 +31,9 @@ public class HttpPdfReplaceHandler extends PdfReplaceHandler {
     @Nullable
     public FSImage resolveUri(String uri, UserAgentCallback userAgentCallback, int cssWidth, int cssHeight)
             throws Exception {
-        return resizeImage(new ITextFSImage(Image.getInstance(uri)), cssWidth, cssHeight);
+        if (userAgentCallback == null) {
+            return resizeImage(new ITextFSImage(Image.getInstance(uri)), cssWidth, cssHeight);
+        }
+        return resizeImage(userAgentCallback.getImageResource(uri).getImage(), cssWidth, cssHeight);
     }
 }


### PR DESCRIPTION
### Description

The newly implemented option of resolving images that is very efficiently does not work completely reliably in a few cases. For example, if we have URLs that are specified with http but automatically redirect to https. Although this happens very rarely, it should still work. The old, more expensive method via the UserAgentCallback handles this very well. As we only need this in a few exceptions, we only use the fallback if it has not worked twice with the new method.

### Additional Notes

- This PR fixes or works on following ticket(s): https://scireum.myjetbrains.com/youtrack/issue/SIRI-961/URI-Resolve-Fehler-bei-http-https
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1371

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
