### PR TITLE
Fixes SemaphoreContext for Single Processor

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
+++ b/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
@@ -13,15 +13,17 @@ import sirius.kernel.async.SubContext;
 import java.util.concurrent.Semaphore;
 
 /**
- * This class is used to limit the number of concurrent resource handling operations per belonging CallContext.
+ * Used to limit the number of concurrent resource handling operations per belonging
+ * {@link sirius.kernel.async.CallContext}.
  * <p>
- * The usecase is that we want to control the number of spawned threads to avoid overloading the
+ * The use case is that we want to control the number of spawned threads to avoid overloading the
  * system with too many concurrent operations.
  */
 public class SemaphoreContext implements SubContext {
 
     /**
-     * We use only the half of the available processors to avoid overloading the system.
+     * Used as the number of initial permits to avoid overloading the system with too many concurrent as each permit
+     * should be used to handle a single operation.
      */
     private static final int HALF_THE_AVAILABLE_PROCESSORS =
             Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);

--- a/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
+++ b/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
@@ -23,7 +23,8 @@ public class SemaphoreContext implements SubContext {
     /**
      * We use only the half of the available processors to avoid overloading the system.
      */
-    private static final int HALF_THE_AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors() / 2;
+    private static final int HALF_THE_AVAILABLE_PROCESSORS =
+            Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
 
     private final Semaphore semaphore;
 


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

On a system with a single processor, 1 divided by 2 equals 0 for integer calculations. As no permits are added but only acquired and released, starting with 0 permits leads to endless waiting.

This resulted in PDFs with images not being created at all.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-962](https://scireum.myjetbrains.com/youtrack/issue/SIRI-962)
- This PR is related to PR: #1383 

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
