### PR TITLE
Expand the functionality of the query string helper

### DIFF
--- a/src/main/java/sirius/web/http/QueryString.java
+++ b/src/main/java/sirius/web/http/QueryString.java
@@ -15,10 +15,10 @@ import sirius.kernel.commons.Values;
 import javax.annotation.Nonnull;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Wraps a {@link QueryStringDecoder} to provide some additional boilerplate methods.
@@ -119,7 +119,7 @@ public class QueryString {
      *
      * @return a collection of all parameters in the query string
      */
-    public Collection<String> getParameterNames() {
+    public Set<String> getParameterNames() {
         return new LinkedHashSet<>(decoder.parameters().keySet());
     }
 

--- a/src/main/java/sirius/web/http/QueryString.java
+++ b/src/main/java/sirius/web/http/QueryString.java
@@ -88,7 +88,7 @@ public class QueryString {
     }
 
     /**
-     * Determines if a the given parameter is present in the query string.
+     * Determines if the given parameter is present in the query string.
      * <p>
      * This can be used to distinguish a missing parameter from <tt>param=</tt>.
      *

--- a/src/main/java/sirius/web/http/QueryString.java
+++ b/src/main/java/sirius/web/http/QueryString.java
@@ -64,7 +64,17 @@ public class QueryString {
      */
     @Nonnull
     public Value get(@Nonnull String key) {
-        return getParameters(key).stream().findFirst().map(Value::of).orElse(Value.EMPTY);
+        List<String> values = getParameters(key);
+        if (values.isEmpty()) {
+            // No entries
+            return Value.EMPTY;
+        }
+        if (values.size() == 1) {
+            // Exactly one entry
+            return Value.of(values.getFirst());
+        }
+        // Many entries
+        return Value.of(values);
     }
 
     /**

--- a/src/main/java/sirius/web/http/QueryString.java
+++ b/src/main/java/sirius/web/http/QueryString.java
@@ -57,10 +57,17 @@ public class QueryString {
 
     /**
      * Returns the first value of the given parameter wrapped as value.
+     * <p>
+     * This has these possible outcomes:
+     * <ul>
+     *     <li>If the parameter is present and has a value, the value is returned wrapped in a Value.</li>
+     *     <li>If the parameter is present multiple times, the list of values is returned wrapped in a Value.</li>
+     *     <li>If the parameter is present but has no value (e.g. <tt>param=</tt>), an empty Value is returned.</li>
+     *     <li>If the parameter is not present, an empty Value is returned.</li>
+     *  </ul>
      *
      * @param key the name of the parameter to fetch
-     * @return the first value which was part of the query string in the given URI or an empty value if the parameter
-     * isn't present
+     * @return a Value representing the provided data.
      */
     @Nonnull
     public Value get(@Nonnull String key) {
@@ -79,9 +86,17 @@ public class QueryString {
 
     /**
      * Returns the query string parameter with the given name.
+     * <p>
+     * This has these possible outcomes:
+     * <ul>
+     *     <li>If the parameter is present and has a value, the value is returned.</li>
+     *     <li>If the parameter is present multiple times, the first value is returned.</li>
+     *     <li>If the parameter is present but has no value (e.g. <tt>param=</tt>), an empty string is returned.</li>
+     *     <li>If the parameter is not present, <tt>null</tt> is returned.</li>
+     * </ul>
      *
      * @param key the name of the parameter to fetch
-     * @return the first value or <tt>null</tt> if the parameter was not set or empty
+     * @return the first value or empty string if parameter is empty or <tt>null</tt> if the parameter was not set
      */
     public String getParameter(String key) {
         return Values.of(getParameters(key)).at(0).getString();
@@ -101,9 +116,17 @@ public class QueryString {
 
     /**
      * Returns all values present for the given parameter.
+     * <p>
+     * This has these possible outcomes:
+     * <ul>
+     *     <li>If the parameter is present and has a value, a list of all values is returned.</li>
+     *     <li>If the parameter is present multiple times, a list of all values is returned.</li>
+     *     <li>If the parameter is present but has no value (e.g. <tt>param=</tt>), a list with an empty string is returned.</li>
+     *     <li>If the parameter is not present, an empty list is returned.</li>
+     * </ul>
      *
      * @param key the name of the parameter to fetch
-     * @return a list of all values for the given parameter or an empty list if no value is present
+     * @return a list of all values for the given parameter or an empty list if the parameter is not present
      */
     @Nonnull
     public List<String> getParameters(@Nonnull String key) {

--- a/src/main/java/sirius/web/http/QueryString.java
+++ b/src/main/java/sirius/web/http/QueryString.java
@@ -10,10 +10,14 @@ package sirius.web.http;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 import sirius.kernel.commons.Value;
+import sirius.kernel.commons.Values;
 
 import javax.annotation.Nonnull;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -24,12 +28,21 @@ public class QueryString {
     private final QueryStringDecoder decoder;
 
     /**
-     * Parses the given URI using a {@link QueryStringDecoder}.
+     * Parses the given URI string (consisting of path and query parameters) using a {@link QueryStringDecoder}.
      *
-     * @param uri the uri to parse
+     * @param uri the URI string to parse
      */
     public QueryString(@Nonnull String uri) {
         decoder = new QueryStringDecoder(uri, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Parses the given URI using a {@link QueryStringDecoder}.
+     *
+     * @param uri the URI to parse
+     */
+    public QueryString(URI uri) {
+        decoder = new QueryStringDecoder(uri);
     }
 
     /**
@@ -52,6 +65,16 @@ public class QueryString {
     @Nonnull
     public Value get(@Nonnull String key) {
         return getParameters(key).stream().findFirst().map(Value::of).orElse(Value.EMPTY);
+    }
+
+    /**
+     * Returns the query string parameter with the given name.
+     *
+     * @param key the name of the parameter to fetch
+     * @return the first value or <tt>null</tt> if the parameter was not set or empty
+     */
+    public String getParameter(String key) {
+        return Values.of(getParameters(key)).at(0).getString();
     }
 
     /**
@@ -78,8 +101,16 @@ public class QueryString {
         if (values == null) {
             return Collections.emptyList();
         }
-
         return values;
+    }
+
+    /**
+     * Returns a collection of all parameter names.
+     *
+     * @return a collection of all parameters in the query string
+     */
+    public Collection<String> getParameterNames() {
+        return new LinkedHashSet<>(decoder.parameters().keySet());
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -572,6 +572,7 @@ public class WebContext implements SubContext {
      *
      * @param key the key used to look for the value
      * @return a Value representing the provided data.
+     * @see QueryString#get(String)
      */
     @Nonnull
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
@@ -1122,7 +1123,7 @@ public class WebContext implements SubContext {
      * If a POST request with query string is present, parameters in the query string have precedence.
      *
      * @param key the name of the parameter to fetch
-     * @return the first value or <tt>null</tt> if the parameter was not set or empty
+     * @return the first value or empty string if parameter is empty or <tt>null</tt> if the parameter was not set
      */
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public String getParameter(String key) {
@@ -1137,6 +1138,7 @@ public class WebContext implements SubContext {
      *
      * @param key the name of the parameter to fetch
      * @return all values in the query string
+     * @see QueryString#getParameters(String)
      */
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public List<String> getParameters(String key) {

--- a/src/test/kotlin/sirius/web/http/QueryStringTest.kt
+++ b/src/test/kotlin/sirius/web/http/QueryStringTest.kt
@@ -13,6 +13,9 @@ import sirius.kernel.commons.Value
 import java.net.URI
 import kotlin.test.*
 
+/**
+ * Tests the [QueryString] helper.
+ */
 class QueryStringTest {
 
     companion object {

--- a/src/test/kotlin/sirius/web/http/QueryStringTest.kt
+++ b/src/test/kotlin/sirius/web/http/QueryStringTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http
+
+import org.junit.jupiter.api.Test
+import sirius.kernel.commons.Value
+import java.net.URI
+import kotlin.test.*
+
+class QueryStringTest {
+
+    companion object {
+        private const val TEST_URI = "/test?param1=value1&param2=value1&param2=value2&param3=&param4"
+    }
+
+    @Test
+    fun `parses URI string correctly`() {
+        val queryString = QueryString(TEST_URI)
+        assertEquals("/test", queryString.path())
+        assertEquals(setOf("param1", "param2", "param3", "param4"), queryString.parameterNames)
+    }
+
+    @Test
+    fun `parses URI correctly`() {
+        val queryString: QueryString = QueryString(URI.create(TEST_URI))
+        assertEquals("/test", queryString.path())
+        assertEquals(setOf("param1", "param2", "param3", "param4"), queryString.parameterNames)
+    }
+
+    @Test
+    fun `'get' handles parameters as expected`() {
+        val queryString = QueryString(TEST_URI)
+
+        // Parameter with a single value is wrapped in Value
+        assertEquals(Value.of("value1"), queryString.get("param1"))
+
+        // Parameter with multiple values is wrapped as a list in Value
+        assertEquals(Value.of(listOf("value1", "value2")), queryString.get("param2"))
+
+        // Parameter with empty value is represented as empty Value
+        assertTrue { queryString.get("param3").isEmptyString }
+
+        // Parameter without value is represented as empty Value
+        assertTrue { queryString.get("param4").isEmptyString }
+
+        // Non-existing parameter is represented as empty Value
+        assertTrue { queryString.get("param5").isEmptyString }
+    }
+
+    @Test
+    fun `'getParameter' handles parameters as expected`() {
+        val queryString = QueryString(TEST_URI)
+
+        // Parameter with a single value is given as is
+        assertEquals("value1", queryString.getParameter("param1"))
+
+        // Parameter with multiple values gives the first value
+        assertEquals("value1", queryString.getParameter("param2"))
+
+        // Parameter with empty value is represented as empty string
+        assertEquals("", queryString.getParameter("param3"))
+
+        // Parameter without value is represented as empty string
+        assertEquals("", queryString.getParameter("param4"))
+
+        // Non-existing parameter is represented as null
+        assertNull(queryString.getParameter("param5"))
+    }
+
+    @Test
+    fun `'getParameters' handles parameters as expected`() {
+        val queryString = QueryString(TEST_URI)
+
+        // Parameter with a single value is given as a list of values
+        queryString.getParameters("param1").apply {
+            assertNotNull(this)
+            assertEquals(1, this.size)
+            assertTrue { this.contains("value1") }
+        }
+
+        // Parameter with multiple values is given as a list of values
+        queryString.getParameters("param2").apply {
+            assertNotNull(this)
+            assertEquals(2, this.size)
+            assertTrue { this.contains("value1") && this.contains("value2") }
+        }
+
+        // Parameter with empty value is represented as a list with a single empty string
+        queryString.getParameters("param3").apply {
+            assertNotNull(this)
+            assertEquals(1, this.size)
+            assertTrue { this.contains("") }
+        }
+
+        // Parameter without value is represented as a list with a single empty string
+        queryString.getParameters("param4").apply {
+            assertNotNull(this)
+            assertEquals(1, this.size)
+            assertTrue { this.contains("") }
+        }
+
+        // Non-existing parameter is represented as an empty list
+        queryString.getParameters("param5").apply {
+            assertNotNull(this)
+            assertTrue { this.isEmpty() }
+        }
+    }
+
+    @Test
+    fun `'hasParameter' handles parameters as expected`() {
+        val queryString = QueryString(TEST_URI)
+
+        // Parameter with a single value is flagged as present
+        assertTrue { queryString.hasParameter("param1") }
+
+        // Parameter with multiple values is flagged as present
+        assertTrue { queryString.hasParameter("param2") }
+
+        // Parameter with empty value is flagged as present
+        assertTrue { queryString.hasParameter("param3") }
+
+        // Parameter without value is flagged as present
+        assertTrue { queryString.hasParameter("param4") }
+
+        // Non-existing parameter is flagged as missing
+        assertFalse { queryString.hasParameter("param5") }
+    }
+}


### PR DESCRIPTION
### BREAKING CHANGE

The function `QueryString::get` now behaves the same as `WebContext::get` when requesting a parameter that has multiple values.
Before it always only returned the first value, now it returns all values.

### Description

And use it in the `WebContext` class to simplify/extract the logic.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-963](https://scireum.myjetbrains.com/youtrack/issue/SIRI-963)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
