### PR TITLE
Add small CSS helpers for 100% and 110% line height

### DIFF
--- a/src/main/resources/assets/design-system/text.scss
+++ b/src/main/resources/assets/design-system/text.scss
@@ -69,6 +69,14 @@
   white-space: nowrap !important;
 }
 
+.sci-line-height-100 {
+  line-height: 1 !important;
+}
+
+.sci-line-height-110 {
+  line-height: 1.1 !important;
+}
+
 .sci-line-height-125 {
   line-height: 1.25 !important;
 }


### PR DESCRIPTION
### Description

These are useful in combination with the `sci-text-smaller` and `sci-text-smallest` font sizes in tight spaces.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11018](https://scireum.myjetbrains.com/youtrack/issue/OX-11018)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
