### PR TITLE
fix t:radio - correct classes and according selector.

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/forms.scss
+++ b/src/main/resources/default/assets/tycho/styles/forms.scss
@@ -17,7 +17,7 @@
   content: "\f023";
 }
 
-.form-group.required label span::after {
+.form-group.required > label span::after {
   font-family: "Font Awesome 6 Free";
   font-weight: 900;
   font-size: .6em;

--- a/src/main/resources/default/taglib/t/radio.html.pasta
+++ b/src/main/resources/default/taglib/t/radio.html.pasta
@@ -16,12 +16,12 @@
         <input type="radio" name="@name" value="@key" @if (key== value) { checked="checked" } @if (readonly) {
                disabled="disabled" }/>
         <i:if test="isFilled(label)">
-            <span class="@if (required) { input-required }">
+            <span class="@if (required) { required }">
                 <i:raw>@label</i:raw>
             </span>
         </i:if>
         <i:if test="isFilled(help)">
-            <div class="from-text text-muted text-small">
+            <div class="form-text text-muted text-small">
                 <i:raw>@help</i:raw>
             </div>
         </i:if>


### PR DESCRIPTION
input-required does not exist anymore in BS5, from-text should be form-text Many radio-buttons with a required-* are not useful. With this approach you can add a required-* to a div with a t:radio inside as well, but the * will only occur on the heading label, not at the selectable values.
<img width="253" alt="Bildschirmfoto 2024-06-05 um 16 32 44" src="https://github.com/scireum/sirius-web/assets/55080004/dd3cdbd2-f7d8-4018-af1b-6eca8d63aeb5">


### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13684](https://scireum.myjetbrains.com/youtrack/issue/SE-13684)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
