### PR TITLE
Tycho - Support suggestion uris including predefined parameters

### DIFF
--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -66,11 +66,13 @@
                 placeholderText: '@placeholder',
                 suggestionsUri: '@suggestionUri',
                 suggestionsUriBuilder: function (query) {
-                    let baseUri = this.suggestionsUri + '?query=' + encodeURIComponent(query);
+                    let suggestionsUrl = new URL(this.suggestionsUri, window.location.origin);
+                    suggestionsUrl.searchParams.set('query', query);
+
                     if (_dependencyField) {
-                        return baseUri + '&dependentValue=' + encodeURIComponent(_dependencyField.tokenAutocomplete.val().join());
+                        suggestionsUrl.searchParams.set('dependentValue', _dependencyField.tokenAutocomplete.val().join());
                     }
-                    return baseUri;
+                    return suggestionsUrl.toString();
                 }
             }, <i:render name="autocompleteOptions"/>));
 


### PR DESCRIPTION
### Description

This was previously broken as the suggestionsUriBuilder simply appended the query with a ? separator, which breaks when the uri already contains a ? for given parameters.

**Example use:**
```html
<t:singleSelect
    name="actionfield-target"
    labelKey="GalleryImage.hotspot.action.video"
    suggestionUri="/actions/video/autocomplete?suggestCode=true"
    optional="true"/>
```

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-8268](https://scireum.myjetbrains.com/youtrack/issue/OX-8268)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
