### PR TITLE
Fixes leaking memory on pdf item loading

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -71,6 +71,7 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
         resolvingThread = Thread.startVirtualThread(() -> {
             UserContext.get().setCurrentScope(scopeInfo);
             startResolvingResource(uri, handler, callback, semaphore, 1);
+            CallContext.detach();
         });
     }
 


### PR DESCRIPTION
### Description
- each virtual thread keeps a CallContext as ThreadLocal
- by adding the ScopeInfo to the UserContext, those objects are kept as references to that ThreadLocal, and so will not be garbage collected
- so we explicitly need to free those resources after the image was loaded

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-974](https://scireum.myjetbrains.com/youtrack/issue/SIRI-974)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
