### PR TITLE
Add CSS helpers for setting inline flex display property

### DIFF
--- a/src/main/resources/assets/design-system/display.scss
+++ b/src/main/resources/assets/design-system/display.scss
@@ -6,6 +6,10 @@
   display: flex !important;
 }
 
+.sci-d-inline-flex {
+  display: inline-flex !important;
+}
+
 .sci-d-inline-block {
   display: inline-block !important;
 }
@@ -28,6 +32,10 @@
     display: flex !important;
   }
 
+  .sci-d-sm-inline-flex {
+    display: inline-flex !important;
+  }
+
   .sci-d-sm-inline-block {
     display: inline-block !important;
   }
@@ -46,6 +54,10 @@
     display: flex !important;
   }
 
+  .sci-d-md-inline-flex {
+    display: inline-flex !important;
+  }
+
   .sci-d-md-inline-block {
     display: inline-block !important;
   }
@@ -62,6 +74,10 @@
 
   .sci-d-lg-flex {
     display: flex !important;
+  }
+
+  .sci-d-lg-inline-flex {
+    display: inline-flex !important;
   }
 
   .sci-d-lg-inline-block {


### PR DESCRIPTION
### Description

Adds:
- `sci-d-inline-flex`
- `sci-d-sm-inline-flex`
- `sci-d-md-inline-flex`
- `sci-d-lg-inline-flex`

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-949](https://scireum.myjetbrains.com/youtrack/issue/SIRI-949)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
