### PR TITLE
Dialog: Indicate whether dialog was replaced in custom event

### DIFF
--- a/src/main/resources/default/assets/common/scripts/dialog.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/dialog.js.pasta
@@ -25,7 +25,7 @@
      */
     dialog.create = function (args) {
         if (_dialog) {
-            dialog.destroy();
+            dialog.destroy(true);
         }
 
         translationProvider = args ? args.translationProvider : function (key) {
@@ -128,8 +128,10 @@
 
     /**@
      * Closes the currently open dialog (if one is open) and cleans up listeners.
+     *
+     * @param {boolean} replaced whether the dialog was closed because another dialog was opened
      */
-    dialog.destroy = function () {
+    dialog.destroy = function (replaced) {
         if (_dialogBackground) {
             _dialogBackground.parentElement.removeChild(_dialogBackground);
             _dialogBackground = null;
@@ -139,7 +141,7 @@
         window.removeEventListener('keyup', destroyDialogEventHandler);
         document.documentElement.classList.remove('sci-dialog-static-body');
 
-        sirius.dispatchEvent('sci-dialog-destroyed');
+        sirius.dispatchEvent('sci-dialog-destroyed', document, {replaced: replaced});
     }
 
     /**@


### PR DESCRIPTION
### Description

This may be used by receivers of the event to determine whether the dialog was fully closed or just replaced by other content.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11057](https://scireum.myjetbrains.com/youtrack/issue/OX-11057)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
