### PR TITLE
Adapt styling of sci-token-single-select component to changes in library

### DIFF
--- a/src/main/resources/assets/design-system/form.scss
+++ b/src/main/resources/assets/design-system/form.scss
@@ -18,17 +18,11 @@
   border-style: solid;
   border-radius: 0.25rem;
   border-color: $sirius-gray;
-  padding: 0.75rem;
+  padding: 0.25rem;
 }
 
-.sci-token-single-select.token-autocomplete-container.token-autocomplete-singleselect .token-autocomplete-input {
-  font-size: 1rem;
-  line-height: 1.5;
-  margin: 0;
-}
-
-.sci-token-single-select.token-autocomplete-container.token-autocomplete-singleselect .token-autocomplete-input:after {
-  top: 0.5rem;
+.sci-token-single-select.token-autocomplete-container.token-autocomplete-singleselect.token-autocomplete-has-value .token-autocomplete-delete-button {
+  right: 1.5rem;
 }
 
 // DISABLED STATE

--- a/src/main/resources/assets/design-system/form.scss
+++ b/src/main/resources/assets/design-system/form.scss
@@ -21,6 +21,10 @@
   padding: 0.25rem;
 }
 
+.sci-token-single-select.token-autocomplete-container.token-autocomplete-singleselect.token-autocomplete-has-value .token-autocomplete-input {
+  padding-right: 3.5rem;
+}
+
 .sci-token-single-select.token-autocomplete-container.token-autocomplete-singleselect.token-autocomplete-has-value .token-autocomplete-delete-button {
   right: 1.5rem;
 }


### PR DESCRIPTION
### Description

The token autocomplete CSS was changed when the optional clear button was introduced, requiring this change to fix the layout of our component.

**Before:**

![image](https://github.com/scireum/sirius-web/assets/2427877/161f1b64-a427-437b-96a9-525963e7fef9)

**After:**

![image](https://github.com/scireum/sirius-web/assets/2427877/89c3eb2b-b414-4012-9426-82b77bedb4bf)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11077](https://scireum.myjetbrains.com/youtrack/issue/OX-11077)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
