### PR TITLE
Overlay - Prevent closing when click is dragged from within overlay to background

### DIFF
--- a/src/main/resources/default/assets/common/scripts/overlay.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/overlay.js.pasta
@@ -15,6 +15,7 @@
      */
     let _overlay = null;
     let shouldEscClose = null;
+    let LEFT_MOUSE_BUTTON_CODE = 0;
 
     /**@
      * Creates a new (hidden) overlay. This can be made visible to the user afterwards by calling `overlay.showOverlay`.
@@ -79,8 +80,8 @@
         }
 
         if (yieldable) {
-            _overlay.addEventListener('click', function (event) {
-                if (event.target === _overlay) {
+            _overlay.addEventListener('mousedown', function (event) {
+                if (event.button === LEFT_MOUSE_BUTTON_CODE && event.target === _overlay) {
                     sirius.dispatchEvent('sci-overlay-dismissed');
                     overlay.destroyOverlay();
                 }


### PR DESCRIPTION
### Description

The previous behaviour is a result of this caveat of the click event:

If the button is pressed on one element and the pointer is moved outside the element before the button is released, the event is fired on the most specific ancestor element that contained both elements.

So if a click started within the overlay content and was dragged outside of it to the background (which can happen by accident when content with drag support is displayed inside the overlay) the overlay would suddenly close.

We now use the mousdown event so it only triggers when the click is started outside of the overlay content.

Tested on Desktop Chrome, Android Chrome & IE 11.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11077](https://scireum.myjetbrains.com/youtrack/issue/OX-11077)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
