### PR TITLE
Introduces a config option to control smtp server identity check

### DIFF
--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -29,6 +29,7 @@ public class SMTPConfiguration {
     private String mailSenderName;
     private boolean useSenderAndEnvelopeFrom;
     private String trustedServers;
+    private boolean checkServerIdentity;
 
     @ConfigValue("mail.smtp.host")
     private static String smtpHost;
@@ -53,6 +54,9 @@ public class SMTPConfiguration {
 
     @ConfigValue("mail.smtp.trustedServers")
     private static String smtpTrustedServers;
+
+    @ConfigValue("mail.smtp.checkServerIdentity")
+    private static boolean smtpCheckServerIdentity;
 
     private SMTPConfiguration() {
     }
@@ -113,6 +117,11 @@ public class SMTPConfiguration {
         return this;
     }
 
+    public SMTPConfiguration setCheckServerIdentity(boolean checkServerIdentity) {
+        this.checkServerIdentity = checkServerIdentity;
+        return this;
+    }
+
     /**
      * Creates a new configuration based on the config files.
      *
@@ -128,7 +137,8 @@ public class SMTPConfiguration {
                                 .setMailSender(smtpSender)
                                 .setMailSenderName(smtpSenderName)
                                 .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom)
-                                .setTrustedServers(smtpTrustedServers);
+                                .setTrustedServers(smtpTrustedServers)
+                                .setCheckServerIdentity(smtpCheckServerIdentity);
     }
 
     /**
@@ -156,7 +166,8 @@ public class SMTPConfiguration {
                                 .setMailSender(settings.get("mail.sender").getString())
                                 .setMailSenderName(settings.get("mail.senderName").getString())
                                 .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean())
-                                .setTrustedServers(settings.get("mail.trustedServers").getString());
+                                .setTrustedServers(settings.get("mail.trustedServers").getString())
+                                .setCheckServerIdentity(settings.get("mail.checkServerIdentity").asBoolean());
     }
 
     /**
@@ -193,6 +204,15 @@ public class SMTPConfiguration {
      */
     public String getTrustedServers() {
         return trustedServers;
+    }
+
+    /**
+     * Determines if the server identity should be checked.
+     *
+     * @return <tt>true</tt> if the server identity should be checked, <tt>false</tt> otherwise
+     */
+    public boolean isCheckServerIdentity() {
+        return checkServerIdentity;
     }
 
     /**

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -75,6 +75,7 @@ class SendMailTask implements Runnable {
     private static final String MAIL_FROM = "mail.from";
     private static final String MAIL_SMTP_HOST = "mail.smtp.host";
     private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+    private static final String MAIL_SMTP_CHECKSERVERIDENTITY = "mail.smtp.ssl.checkserveridentity";
     private static final String MAIL_SMTP_SSL_TRUST = "mail.smtp.ssl.trust";
     private static final String MAIL_SMTP_PORT = "mail.smtp.port";
     private static final String MAIL_SMTP_CONNECTIONTIMEOUT = "mail.smtp.connectiontimeout";
@@ -382,6 +383,7 @@ class SendMailTask implements Runnable {
 
         props.setProperty(MAIL_TRANSPORT_PROTOCOL, config.getProtocol().getProtocol());
         props.setProperty(MAIL_SMTP_STARTTLS_ENABLE, Boolean.toString(config.getProtocol().isStarttls()));
+        props.setProperty(MAIL_SMTP_CHECKSERVERIDENTITY, Boolean.toString(config.isCheckServerIdentity()));
         if (Strings.isFilled(config.getTrustedServers())) {
             props.setProperty(MAIL_SMTP_SSL_TRUST, config.getTrustedServers());
         }

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -577,6 +577,10 @@ mail {
         # CA signatures are apparently ignored, and only the listed servers are trusted! Set to "*" to trust any server.
         trustedServers = ""
 
+        # Controls whether the server identity should be checked against the hostname of the server.
+        # See: mail.smtp.ssl.checkserveridentity https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
+        checkServerIdentity = true
+
         # Contains the settings required to enable DKIM
         dkim {
 

--- a/src/main/resources/scope-conf/mail.conf
+++ b/src/main/resources/scope-conf/mail.conf
@@ -25,6 +25,10 @@ mail {
     # CA signatures are apparently ignored, and only the listed servers are trusted! Set to "*" to trust any server.
     trustedServers = ""
 
+    # Controls whether the server identity should be checked against the hostname of the server.
+    # See: mail.smtp.ssl.checkserveridentity https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html
+    checkServerIdentity = true
+
     # Whether E-Mail addresses with non-ascii-symbols are considered valid
     # The mail server needs to support SMTPUTF8 for this to work, see https://datatracker.ietf.org/doc/html/rfc6531
     allow-utf-8 = false


### PR DESCRIPTION
### Description
- The default value was changed by angus implementation https://github.com/eclipse-ee4j/angus-mail/pull/14/files
- We keep the more secure default value, but make it configurable if less strict settings are required by mail server

### Additional Notes
- This PR fixes or works on following ticket(s): [SIRI-983](https://scireum.myjetbrains.com/youtrack/issue/SIRI-983)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
