### PR TITLE
Adds option to show the parameter name to single and multiSelect

### DIFF
--- a/src/main/resources/default/taglib/t/multiSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/multiSelect.html.pasta
@@ -2,6 +2,7 @@
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="labelClass" type="String" default="" description="Lists additional CSS classes to apply to the label."/>
 <i:arg name="name" type="String"/>
+<i:arg name="showName" type="boolean" default="false"/>
 <i:arg name="labelKey" type="String" default=""/>
 <i:arg name="label" type="String" default="@i18n(labelKey)"/>
 <i:arg name="helpKey" type="String" default=""/>
@@ -22,6 +23,9 @@
 <div class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
     <i:if test="isFilled(label)">
         <label class="form-label"><span class="@labelClass">@label</span></label>
+    </i:if>
+    <i:if test="showName">
+        <small class="form-text text-muted"><em>(@name)</em></small>
     </i:if>
 
     <i:local name="addon" value="@renderToString('addon')"/>

--- a/src/main/resources/default/taglib/t/multiSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/multiSelect.html.pasta
@@ -2,30 +2,33 @@
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="labelClass" type="String" default="" description="Lists additional CSS classes to apply to the label."/>
 <i:arg name="name" type="String"/>
-<i:arg name="showName" type="boolean" default="false"/>
 <i:arg name="labelKey" type="String" default=""/>
 <i:arg name="label" type="String" default="@i18n(labelKey)"/>
 <i:arg name="helpKey" type="String" default=""/>
 <i:arg name="help" type="String" default="@i18n(helpKey)"/>
-<i:arg name="placeholderKey" type="String" default="template.html.selects.selection" />
-<i:arg name="placeholder" type="String" default="@i18n(placeholderKey)" />
+<i:arg name="placeholderKey" type="String" default="template.html.selects.selection"/>
+<i:arg name="placeholder" type="String" default="@i18n(placeholderKey)"/>
 <i:arg name="readonly" type="boolean" default="false"/>
 <i:arg name="optional" type="boolean" default="false"/>
-<i:arg name="allowCustomEntries" type="boolean" default="false" />
+<i:arg name="allowCustomEntries" type="boolean" default="false"/>
 <i:arg name="suggestionUri" type="String" default=""/>
 
 <i:pragma name="description">
-    Renders a select field for a multiple value using the given parameters. Note that additional flags can be set via CSS
+    Renders a select field for a multiple value using the given parameters. Note that additional flags can be set via
+    CSS
     classes
     (i.e. "required", "admin-only").
 </i:pragma>
 
 <div class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
-    <i:if test="isFilled(label)">
-        <label class="form-label"><span class="@labelClass">@label</span></label>
-    </i:if>
-    <i:if test="showName">
-        <small class="form-text text-muted"><em>(@name)</em></small>
+    <i:local name="labelBlock" value="@renderToString('label')"/>
+    <i:if test="isFilled(labelBlock)">
+        <i:render name="label"/>
+        <i:else>
+            <i:if test="isFilled(label)">
+                <label class="form-label"><span class="@labelClass">@label</span></label>
+            </i:if>
+        </i:else>
     </i:if>
 
     <i:local name="addon" value="@renderToString('addon')"/>
@@ -69,6 +72,6 @@
             suggestionsUri: '@suggestionUri'
         });
 
-        <i:render name="script" />
+        <i:render name="script"/>
     });
 </script>

--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -2,6 +2,7 @@
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="labelClass" type="String" default="" description="Lists additional CSS classes to apply to the label."/>
 <i:arg name="name" type="String"/>
+<i:arg name="showName" type="boolean" default="false"/>
 <i:arg name="labelKey" type="String" default=""/>
 <i:arg name="label" type="String" default="@i18n(labelKey)"/>
 <i:arg name="helpKey" type="String" default=""/>
@@ -23,7 +24,9 @@
     <i:if test="isFilled(label)">
         <label class="form-label"><span class="@labelClass">@label</span></label>
     </i:if>
-
+    <i:if test="showName">
+        <small class="form-text text-muted"><em>(@name)</em></small>
+    </i:if>
     <i:local name="addon" value="@renderToString('addon')"/>
     <i:if test="isFilled(addon)">
         <div class="input-group">

--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -2,7 +2,6 @@
 <i:arg name="class" type="String" default="" description="Lists additional CSS classes to apply to the field."/>
 <i:arg name="labelClass" type="String" default="" description="Lists additional CSS classes to apply to the label."/>
 <i:arg name="name" type="String"/>
-<i:arg name="showName" type="boolean" default="false"/>
 <i:arg name="labelKey" type="String" default=""/>
 <i:arg name="label" type="String" default="@i18n(labelKey)"/>
 <i:arg name="helpKey" type="String" default=""/>
@@ -21,12 +20,16 @@
 </i:pragma>
 
 <div class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
-    <i:if test="isFilled(label)">
-        <label class="form-label"><span class="@labelClass">@label</span></label>
+    <i:local name="labelBlock" value="@renderToString('label')"/>
+    <i:if test="isFilled(labelBlock)">
+        <i:render name="label"/>
+        <i:else>
+            <i:if test="isFilled(label)">
+                <label class="form-label"><span class="@labelClass">@label</span></label>
+            </i:if>
+        </i:else>
     </i:if>
-    <i:if test="showName">
-        <small class="form-text text-muted"><em>(@name)</em></small>
-    </i:if>
+
     <i:local name="addon" value="@renderToString('addon')"/>
     <i:if test="isFilled(addon)">
         <div class="input-group">


### PR DESCRIPTION
### Description

The new parameter is helpful in applications where the user might be interested in the "real" parameter name, for example in the OX-showcases, where we have a label describing what the parameter stands for.

![Bildschirmfoto 2024-07-15 um 12 17 02](https://github.com/user-attachments/assets/f980b1ef-32a6-4d03-9714-cc5a83dbf3e6)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11038](https://scireum.myjetbrains.com/youtrack/issue/OX-11038)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

