### PR TITLE
Adds block based logic to override the labels for single and multiSelect

### DIFF
--- a/src/main/resources/default/taglib/t/multiSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/multiSelect.html.pasta
@@ -20,8 +20,14 @@
 </i:pragma>
 
 <div class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
-    <i:if test="isFilled(label)">
-        <label class="form-label"><span class="@labelClass">@label</span></label>
+    <i:local name="labelBlock" value="@renderToString('label')"/>
+    <i:if test="isFilled(labelBlock)">
+        <i:render name="label"/>
+        <i:else>
+            <i:if test="isFilled(label)">
+                <label class="form-label"><span class="@labelClass">@label</span></label>
+            </i:if>
+        </i:else>
     </i:if>
 
     <i:local name="addon" value="@renderToString('addon')"/>

--- a/src/main/resources/default/taglib/t/singleSelect.html.pasta
+++ b/src/main/resources/default/taglib/t/singleSelect.html.pasta
@@ -20,8 +20,14 @@
 </i:pragma>
 
 <div class="form-group mb-3 @UserContext.get().signalFieldError(name) @class">
-    <i:if test="isFilled(label)">
-        <label class="form-label"><span class="@labelClass">@label</span></label>
+    <i:local name="labelBlock" value="@renderToString('label')"/>
+    <i:if test="isFilled(labelBlock)">
+        <i:render name="label"/>
+        <i:else>
+            <i:if test="isFilled(label)">
+                <label class="form-label"><span class="@labelClass">@label</span></label>
+            </i:if>
+        </i:else>
     </i:if>
 
     <i:local name="addon" value="@renderToString('addon')"/>


### PR DESCRIPTION
Allows to override the label. Will be used in OX to show the real parameter name along the label:

![Bildschirmfoto 2024-07-15 um 13 56 31](https://github.com/user-attachments/assets/9874c14e-362d-4eeb-8bad-618b6383a748)

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11038](https://scireum.myjetbrains.com/youtrack/issue/OX-11038)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

