### PR TITLE
Shortens encoded deeplink URL parameter value

### DIFF
--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -357,8 +357,17 @@ window.sirius.Continuity = (function () {
      * @returns {Object} the history state as an object
      */
     Continuity.prototype.parseStateUrlParam = function (param) {
-        const paramStateText = this.options.encodeStateParameter ? convertFromBinary(param) : param;
-        return JSON.parse(paramStateText);
+        if (!this.options.encodeStateParameter) {
+            return JSON.parse(param);
+        }
+        try {
+            // Try to decode the new binary format first.
+            return JSON.parse(convertFromBinary(param));
+        } catch (exception) {
+            // If the new format fails, try to decode the old legacy format.
+            // When this also fails we throw the exception.
+            return JSON.parse(convertFromLegacyBinary(param));
+        }
     };
 
     /**@
@@ -374,6 +383,21 @@ window.sirius.Continuity = (function () {
             bytes[i] = binary.charCodeAt(i);
         }
         return String.fromCharCode.apply(this, new Uint8Array(bytes.buffer));
+    }
+
+    /**@
+     * Converts the given binary base64 encoded representation into its original UTF-8 text.
+     *
+     * @param string the binary base64 encoded representation of a text
+     * @returns {string} the original text
+     */
+    function convertFromLegacyBinary(encoded) {
+        const binary = atob(encoded);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < bytes.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return String.fromCharCode.apply(this, new Uint16Array(bytes.buffer));
     }
 
     /**@

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -343,7 +343,7 @@ window.sirius.Continuity = (function () {
      * @returns {string} the binary base64 encoded representation of the text
      */
     function convertToBinary(string) {
-        const codeUnits = new Uint16Array(string.length);
+        const codeUnits = new Uint8Array(string.length);
         for (let i = 0; i < codeUnits.length; i++) {
             codeUnits[i] = string.charCodeAt(i);
         }
@@ -373,7 +373,7 @@ window.sirius.Continuity = (function () {
         for (let i = 0; i < bytes.length; i++) {
             bytes[i] = binary.charCodeAt(i);
         }
-        return String.fromCharCode.apply(this, new Uint16Array(bytes.buffer));
+        return String.fromCharCode.apply(this, new Uint8Array(bytes.buffer));
     }
 
     /**@

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -343,11 +343,7 @@ window.sirius.Continuity = (function () {
      * @returns {string} the binary base64 encoded representation of the text
      */
     function convertToBinary(string) {
-        const codeUnits = new Uint8Array(string.length);
-        for (let i = 0; i < codeUnits.length; i++) {
-            codeUnits[i] = string.charCodeAt(i);
-        }
-        return btoa(String.fromCharCode.apply(this, new Uint8Array(codeUnits.buffer)));
+        return btoa(string);
     }
 
     /**@
@@ -377,12 +373,7 @@ window.sirius.Continuity = (function () {
      * @returns {string} the original text
      */
     function convertFromBinary(encoded) {
-        const binary = atob(encoded);
-        const bytes = new Uint8Array(binary.length);
-        for (let i = 0; i < bytes.length; i++) {
-            bytes[i] = binary.charCodeAt(i);
-        }
-        return String.fromCharCode.apply(this, new Uint8Array(bytes.buffer));
+        return atob(encoded);
     }
 
     /**@

--- a/src/main/resources/default/assets/common/scripts/continuity.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/continuity.js.pasta
@@ -333,18 +333,8 @@ window.sirius.Continuity = (function () {
         }
 
         const paramStateText = JSON.stringify(paramState);
-        return this.options.encodeStateParameter ? convertToBinary(paramStateText) : paramStateText;
+        return this.options.encodeStateParameter ? btoa(paramStateText) : paramStateText;
     };
-
-    /**@
-     * Converts the given UTF-8 text to a binary base64 encoded representation.
-     *
-     * @param string the text to encode
-     * @returns {string} the binary base64 encoded representation of the text
-     */
-    function convertToBinary(string) {
-        return btoa(string);
-    }
 
     /**@
      * Parses the value of our history state deep-link parameter from the URL and transforms it into a JS Object.
@@ -358,23 +348,13 @@ window.sirius.Continuity = (function () {
         }
         try {
             // Try to decode the new binary format first.
-            return JSON.parse(convertFromBinary(param));
+            return JSON.parse(atob(param));
         } catch (exception) {
             // If the new format fails, try to decode the old legacy format.
             // When this also fails we throw the exception.
             return JSON.parse(convertFromLegacyBinary(param));
         }
     };
-
-    /**@
-     * Converts the given binary base64 encoded representation into its original UTF-8 text.
-     *
-     * @param string the binary base64 encoded representation of a text
-     * @returns {string} the original text
-     */
-    function convertFromBinary(encoded) {
-        return atob(encoded);
-    }
 
     /**@
      * Converts the given binary base64 encoded representation into its original UTF-8 text.


### PR DESCRIPTION
### Description

... by not mixing up integer char representations between 8 and 16 bit

This mixup lead to our deeplinks being two times as long as necessary while containing the same information.
As we used inverse logic for encoding and decoding this did not lead to any problems.

Deeplinks in the old format are still correctly read and "converted".

**Before:**

```
http://localhost:9000/p/SBI-H-INTERN?oxDeeplink=ewAiAHUAbgBpAHYAZQByAHMAYQBsAFMAZQBhAHIAYwBoAHwAMgAiADoAewAiAHYAaQBlAHcAIgA6ACIAZgBpAGwAdABlAHIAZQBkACIALAAiAGYAaQBsAHQAZQByAHMAIgA6AHsAIgBiAHIAYQBuAGQAIgA6AFsAIgBWAE8ANQAxADMAMwBJAEcARgBLADAARQA1AFMAVAAzAEkARgA5AEUASQBQADgARwBOADAAIgBdAH0ALAAiAHEAdQBlAHIAeQAiADoAIgBtAGEAcgBzACIALAAiAGgAaQBkAGQAZQBuAEYAaQBsAHQAZQByAHMAIgA6AHsAfQB9ACwAIgBvAHYAZQByAGwAYQB5ACIAOgB7ACIAdAB5AHAAZQAiADoAIgBvAHAAZQBuAFAAcgBvAGQAdQBjAHQARABhAHQAYQBzAGgAZQBlAHQAIgAsACIAYQByAGcAcwAiADoAewAiAHQAYQByAGcAZQB0ACIAOgAiAC4AcwBjAGkALQBvAHYAZQByAGwAYQB5ACAALgBvAHgAbwBtAGkALQBwAHIAbwBkAHUAYwB0AC0AZABhAHQAYQBzAGgAZQBlAHQALQBjAG8AbgB0AGEAaQBuAGUAcgAiACwAIgBzAHUAcABwAGwAaQBlAHIATgB1AG0AYgBlAHIAIgA6ACIAUwBCAEkAIgAsACIAaQB0AGUAbQBOAHUAbQBiAGUAcgAiADoAIgBNAEEAUgBTACIALAAiAHAAcgBvAGQAdQBjAHQASQBkACIAOgAiADcATQA0AEMAQwBRADYAMQBLAEYASgAwAEgAUQBMAEMAMQBPAEEAMQBKADUAOABVAFAAUwAiACwAIgB0AGUAeAB0AE8AcgBpAGcAaQBuAGEAbAAiADoAIgBBAGIAYgBpAGwAZAB1AG4AZwAgAOQAaABuAGwAaQBjAGgAIgAsACIAdABlAHgAdABTAHUAYgBzAHQAaQB0AHUAdABlACIAOgAiAEEAYgBiAGkAbABkAHUAbgBnACAAdwBlAGkAYwBoAHQAIABhAGIAIgB9AH0AfQA%3D
```

**After:**

```
http://localhost:9000/p/SBI-H-INTERN?oxDeeplink=eyJ1bml2ZXJzYWxTZWFyY2h8MiI6eyJ2aWV3IjoiZmlsdGVyZWQiLCJmaWx0ZXJzIjp7ImJyYW5kIjpbIlZPNTEzM0lHRkswRTVTVDNJRjlFSVA4R04wIl19LCJxdWVyeSI6Im1hcnMiLCJoaWRkZW5GaWx0ZXJzIjp7fX0sIm92ZXJsYXkiOnsidHlwZSI6Im9wZW5Qcm9kdWN0RGF0YXNoZWV0IiwiYXJncyI6eyJ0YXJnZXQiOiIuc2NpLW92ZXJsYXkgLm94b21pLXByb2R1Y3QtZGF0YXNoZWV0LWNvbnRhaW5lciIsInN1cHBsaWVyTnVtYmVyIjoiU0JJIiwiaXRlbU51bWJlciI6Ik1BUlMiLCJwcm9kdWN0SWQiOiI3TTRDQ1E2MUtGSjBIUUxDMU9BMUo1OFVQUyIsInRleHRPcmlnaW5hbCI6IkFiYmlsZHVuZyDkaG5saWNoIiwidGV4dFN1YnN0aXR1dGUiOiJBYmJpbGR1bmcgd2VpY2h0IGFiIn19fQ%3D%3D
```

--> URL decoded:

```
eyJ1bml2ZXJzYWxTZWFyY2h8MiI6eyJ2aWV3IjoiZmlsdGVyZWQiLCJmaWx0ZXJzIjp7ImJyYW5kIjpbIlZPNTEzM0lHRkswRTVTVDNJRjlFSVA4R04wIl19LCJxdWVyeSI6Im1hcnMiLCJoaWRkZW5GaWx0ZXJzIjp7fX0sIm92ZXJsYXkiOnsidHlwZSI6Im9wZW5Qcm9kdWN0RGF0YXNoZWV0IiwiYXJncyI6eyJ0YXJnZXQiOiIuc2NpLW92ZXJsYXkgLm94b21pLXByb2R1Y3QtZGF0YXNoZWV0LWNvbnRhaW5lciIsInN1cHBsaWVyTnVtYmVyIjoiU0JJIiwiaXRlbU51bWJlciI6Ik1BUlMiLCJwcm9kdWN0SWQiOiI3TTRDQ1E2MUtGSjBIUUxDMU9BMUo1OFVQUyIsInRleHRPcmlnaW5hbCI6IkFiYmlsZHVuZyDkaG5saWNoIiwidGV4dFN1YnN0aXR1dGUiOiJBYmJpbGR1bmcgd2VpY2h0IGFiIn19fQ==
```

--> Base64 decoded:

```JSON
{"universalSearch|2":{"view":"filtered","filters":{"brand":["VO5133IGFK0E5ST3IF9EIP8GN0"]},"query":"mars","hiddenFilters":{}},"overlay":{"type":"openProductDatasheet","args":{"target":".sci-overlay .oxomi-product-datasheet-container","supplierNumber":"SBI","itemNumber":"MARS","productId":"7M4CCQ61KFJ0HQLC1OA1J58UPS","textOriginal":"Abbildung �hnlich","textSubstitute":"Abbildung weicht ab"}}}
```

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-987](https://scireum.myjetbrains.com/youtrack/issue/SIRI-987)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
