### PR TITLE
Positioning: Images in PDF

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -45,6 +45,13 @@ import java.util.concurrent.Semaphore;
 public final class AsyncLoadedImageElement implements ITextReplacedElement {
 
     private static final int MAX_ATTEMPTS = 3;
+    private static final String TEXT_ALIGN = "text-align";
+    private static final String VERTICAL_ALIGN = "vertical-align";
+    private static final String MIDDLE = "middle";
+    private static final String BOTTOM = "bottom";
+    private static final String CENTER = "center";
+    private static final String RIGHT = "right";
+
     private final Thread resolvingThread;
     private final int cssWidth;
     private final int cssHeight;
@@ -169,16 +176,16 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
     }
 
     @Override
-    public void paint(RenderingContext c, ITextOutputDevice outputDevice, BlockBox box) {
-        Rectangle contentBounds = box.getContentAreaEdge(box.getAbsX(), box.getAbsY(), c);
+    public void paint(RenderingContext context, ITextOutputDevice outputDevice, BlockBox box) {
+        Rectangle contentBounds = box.getContentAreaEdge(box.getAbsX(), box.getAbsY(), context);
         if (waitAndGetImage() != null) {
             Tuple<Integer, Integer> centerPosition;
 
             Map<String, CSSPrimitiveValue> cssMap =
-                    c.getCss().getCascadedPropertiesMap(box.getContainingBlock().getElement());
+                    context.getCss().getCascadedPropertiesMap(box.getContainingBlock().getElement());
             centerPosition = computePosition(contentBounds,
-                                             cssMap.get("vertical-align"),
-                                             cssMap.get("text-align"));
+                                             cssMap.get(VERTICAL_ALIGN),
+                                             cssMap.get(TEXT_ALIGN));
             outputDevice.drawImage(image, centerPosition.getFirst(), centerPosition.getSecond());
         }
     }
@@ -189,15 +196,15 @@ public final class AsyncLoadedImageElement implements ITextReplacedElement {
         int x = contentBounds.x;
         int y = contentBounds.y;
 
-        if (Strings.isEmpty(verticalPosition) || "middle".equals(verticalPosition.getStringValue())) {
+        if (Strings.isEmpty(verticalPosition) || MIDDLE.equals(verticalPosition.getStringValue())) {
             y += (cssHeight - image.getHeight()) / 2;
-        } else if ("bottom".equals(verticalPosition.getStringValue())) {
+        } else if (BOTTOM.equals(verticalPosition.getStringValue())) {
             y += cssHeight - image.getHeight();
         }
 
-        if (Strings.isEmpty(horizontalPosition) || "center".equals(horizontalPosition.getStringValue())) {
+        if (Strings.isEmpty(horizontalPosition) || CENTER.equals(horizontalPosition.getStringValue())) {
             x += (cssWidth - image.getWidth()) / 2;
-        } else if ("right".equals(horizontalPosition.getStringValue())) {
+        } else if (RIGHT.equals(horizontalPosition.getStringValue())) {
             x += cssWidth - image.getWidth();
         }
 

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -100,9 +100,18 @@ public abstract class PdfReplaceHandler implements Priorized {
      * @return a new width and height fitting into a rectangle defined by cssWidth/cssHeight
      */
     private Tuple<Integer, Integer> computeResizeBox(int cssWidth, int cssHeight, FSImage fsImage) {
-        if (cssWidth == -1 || cssHeight == -1) {
+        if (cssWidth == -1 && cssHeight == -1) {
             return null;
         }
+
+        if (cssWidth == -1) {
+            cssWidth = fsImage.getWidth();
+        }
+
+        if (cssHeight == -1) {
+            cssHeight = fsImage.getHeight();
+        }
+
         if (fsImage == null) {
             return null;
         }

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -103,7 +103,6 @@ public abstract class PdfReplaceHandler implements Priorized {
         if (cssWidth == -1 || cssHeight == -1) {
             return null;
         }
-
         if (fsImage == null) {
             return null;
         }

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -100,16 +100,8 @@ public abstract class PdfReplaceHandler implements Priorized {
      * @return a new width and height fitting into a rectangle defined by cssWidth/cssHeight
      */
     private Tuple<Integer, Integer> computeResizeBox(int cssWidth, int cssHeight, FSImage fsImage) {
-        if (cssWidth == -1 && cssHeight == -1) {
+        if (cssWidth == -1 || cssHeight == -1) {
             return null;
-        }
-
-        if (cssWidth == -1) {
-            cssWidth = fsImage.getWidth();
-        }
-
-        if (cssHeight == -1) {
-            cssHeight = fsImage.getHeight();
         }
 
         if (fsImage == null) {


### PR DESCRIPTION
### Description
In the surrounding container, the values text-align and vertical-align can now be used to align the image.

We can now use the CSS properties text-align and vertical-align to align images in a PDF. To do this, we need the image in a container. This can then receive the corresponding CSS rules.

### Tasks:
Previously, horizontal and vertical centering was the default. This is still the case now, so nothing should change unless the CSS properties text-align or vertical-align already exist. These properties would now take effect. It is therefore necessary to check whether an alignment is already specified in the CSS.

### Examples:
```
<div class="container">
    <img class="img" src="..."/>
</div>
```
```
<style>
    .container {
        vertical-align: bottom;
        text-align: center;
    }

    .container .img {
        width: 4cm;
        height: 8cm;
    }
</style>
```
![image](https://github.com/user-attachments/assets/46d5f81a-619c-44d4-bf7c-af01a6db0536)


### Additional Notes

- This PR fixes or works on following ticket(s): https://scireum.myjetbrains.com/youtrack/issue/SIRI-969/PDF-Bilder-Skalierung-und-Zentrierung

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
