### PR TITLE
Implements new CSS class for links to be stretched over an element

### DIFF
--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -281,3 +281,13 @@
     transform: rotate(360deg);
   }
 }
+
+.sci-stretched-link::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  content:"";
+}


### PR DESCRIPTION
### Description
Uses the contents of Bootstraps' stretched-link class

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11030](https://scireum.myjetbrains.com/youtrack/issue/OX-11030)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
