### PR TITLE
`<i:sass>`

### DIFF
--- a/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
@@ -13,13 +13,11 @@ import sirius.kernel.di.std.Register;
 import sirius.pasta.tagliatelle.TemplateArgument;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 import sirius.pasta.tagliatelle.emitter.ConstantEmitter;
-import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Handles <tt>i:include</tt> which includes the contents of the given resource without any processing.
@@ -63,19 +61,9 @@ public class IncludeTag extends TagHandler {
 
     @Override
     public void apply(CompositeEmitter targetBlock) {
-        String resourcePath = getConstantAttribute(ATTR_NAME).asString();
-        if (!resourcePath.startsWith("/assets") && !resourcePath.startsWith("assets/")) {
-            throw new IllegalArgumentException("For security reasons only assets can be included. Invalid path: "
-                                               + resourcePath);
-        }
-
-        Optional<Resource> resource = resources.resolve(resourcePath);
-        if (resource.isEmpty()) {
-            getCompilationContext().error(getStartOfTag(), "Cannot find the resource: %s", resourcePath);
-            return;
-        }
-
-        targetBlock.addChild(new ConstantEmitter(getStartOfTag()).append(resource.get().getContentAsString()));
+        tryResolveAssetResource(getConstantAttribute(ATTR_NAME).asString()).ifPresent(resource -> {
+            targetBlock.addChild(new ConstantEmitter(getStartOfTag()).append(resource.getContentAsString()));
+        });
     }
 
     @Override

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
@@ -1,0 +1,96 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.tagliatelle.tags;
+
+import sirius.kernel.commons.Files;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.tokenizer.ParseException;
+import sirius.pasta.tagliatelle.TemplateArgument;
+import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
+import sirius.pasta.tagliatelle.emitter.ConstantEmitter;
+import sirius.web.sass.Generator;
+import sirius.web.sass.Parser;
+import sirius.web.sass.ast.Stylesheet;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Handles <tt>i:sass</tt> which renders a SASS file into the current template as compiled CSS.
+ */
+public class SassTag extends TagHandler {
+
+    private static final String SASS_ELEMENT = "i:sass";
+
+    private static final String SOURCE_ATTRIBUTE = "source";
+
+    /**
+     * Creates new tags of type {@value #SASS_ELEMENT}.
+     */
+    @Register
+    public static class Factory implements TagHandlerFactory {
+
+        @Nonnull
+        @Override
+        public String getName() {
+            return SASS_ELEMENT;
+        }
+
+        @Override
+        public TagHandler createHandler() {
+            return new SassTag();
+        }
+
+        @Override
+        public List<TemplateArgument> reportArguments() {
+            return Collections.singletonList(new TemplateArgument(String.class,
+                                                                  SOURCE_ATTRIBUTE,
+                                                                  "Contains the path of the SASS file to render."));
+        }
+
+        @Override
+        public String getDescription() {
+            return "Renders a SASS file into the current template as compiled CSS.";
+        }
+    }
+
+    @Override
+    public void apply(CompositeEmitter targetBlock) {
+        tryResolveAssetResource(getConstantAttribute(SOURCE_ATTRIBUTE).asString()).ifPresent(resource -> {
+            try (Reader reader = new StringReader(resource.getContentAsString())) {
+                Parser parser = new Parser(Files.getFilenameAndExtension(resource.getPath()), reader);
+                Stylesheet stylesheet = parser.parse();
+
+                Generator generator = new Generator();
+                generator.importStylesheet(stylesheet);
+                generator.compile();
+
+                targetBlock.addChild(new ConstantEmitter(getStartOfTag()).append(generator.toString()));
+            } catch (IOException | ParseException exception) {
+                getCompilationContext().error(getStartOfTag(),
+                                              "Cannot access the resource: %s (%s)",
+                                              resource.getPath(),
+                                              exception.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public Class<?> getExpectedAttributeType(String name) {
+        if (SOURCE_ATTRIBUTE.equals(name)) {
+            return String.class;
+        }
+
+        return super.getExpectedAttributeType(name);
+    }
+}

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
@@ -8,8 +8,10 @@
 
 package sirius.pasta.tagliatelle.tags;
 
-import sirius.kernel.tokenizer.Position;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.Callable;
 import sirius.pasta.noodle.ConstantCall;
 import sirius.pasta.noodle.ScriptingException;
@@ -17,16 +19,22 @@ import sirius.pasta.noodle.compiler.VariableScoper;
 import sirius.pasta.tagliatelle.compiler.TemplateCompilationContext;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 import sirius.pasta.tagliatelle.emitter.Emitter;
+import sirius.web.resources.Resource;
+import sirius.web.resources.Resources;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Handles a tag detected by the {@link sirius.pasta.tagliatelle.compiler.TemplateCompiler}.
  */
 public abstract class TagHandler {
+
+    @Part
+    private static Resources resources;
 
     protected Position startOfTag;
     protected TemplateCompilationContext compilationContext;
@@ -238,5 +246,29 @@ public abstract class TagHandler {
      */
     public void afterTag() {
         this.scope.pop();
+    }
+
+    /**
+     * Attempts to resolve the given path into a resource.
+     *
+     * @param path the path to resolve
+     * @return the resolved resource, or an empty optional if the resource cannot be found
+     */
+    protected Optional<Resource> tryResolveAssetResource(String path) {
+        if (Strings.isEmpty(path)) {
+            return Optional.empty();
+        }
+
+        if (!path.startsWith("/assets") && !path.startsWith("assets/")) {
+            getCompilationContext().error(getStartOfTag(), "Path must point to an asset. Given: %s", path);
+            return Optional.empty();
+        }
+
+        Optional<Resource> resource = resources.resolve(path);
+        if (resource.isEmpty()) {
+            getCompilationContext().error(getStartOfTag(), "Cannot find the resource: %s", path);
+        }
+
+        return resource;
     }
 }

--- a/src/main/java/sirius/web/sass/Generator.java
+++ b/src/main/java/sirius/web/sass/Generator.java
@@ -512,7 +512,6 @@ public class Generator {
      * @param out the target for the generated output
      * @throws IOException in case of an io error in the underlying writer
      */
-
     public void generate(Output out) throws IOException {
         for (Section section : sections) {
             section.generate(out);

--- a/src/main/java/sirius/web/sass/Parser.java
+++ b/src/main/java/sirius/web/sass/Parser.java
@@ -8,6 +8,10 @@
 
 package sirius.web.sass;
 
+import sirius.kernel.tokenizer.Char;
+import sirius.kernel.tokenizer.ParseException;
+import sirius.kernel.tokenizer.Token;
+import sirius.kernel.tokenizer.Tokenizer;
 import sirius.web.sass.ast.Attribute;
 import sirius.web.sass.ast.Color;
 import sirius.web.sass.ast.Expression;
@@ -24,10 +28,6 @@ import sirius.web.sass.ast.Value;
 import sirius.web.sass.ast.ValueList;
 import sirius.web.sass.ast.Variable;
 import sirius.web.sass.ast.VariableReference;
-import sirius.kernel.tokenizer.Char;
-import sirius.kernel.tokenizer.ParseException;
-import sirius.kernel.tokenizer.Token;
-import sirius.kernel.tokenizer.Tokenizer;
 
 import java.io.Reader;
 import java.util.ArrayList;

--- a/src/main/java/sirius/web/sass/ast/Attribute.java
+++ b/src/main/java/sirius/web/sass/ast/Attribute.java
@@ -17,6 +17,7 @@ package sirius.web.sass.ast;
  * </pre>
  */
 public class Attribute {
+
     private final String name;
     private Expression expression;
 

--- a/src/main/java/sirius/web/sass/ast/MediaFilter.java
+++ b/src/main/java/sirius/web/sass/ast/MediaFilter.java
@@ -15,7 +15,8 @@ import sirius.web.sass.Scope;
  * Represents an attribute filter used in a media query like "(min-width: 13px)".
  */
 public class MediaFilter implements Expression {
-    private String name;
+
+    private final String name;
     private Expression expression;
 
     /**

--- a/src/main/java/sirius/web/sass/ast/NamedParameter.java
+++ b/src/main/java/sirius/web/sass/ast/NamedParameter.java
@@ -18,8 +18,8 @@ import sirius.web.sass.Scope;
  */
 public class NamedParameter implements Expression {
 
-    private String name;
-    private Expression value;
+    private final String name;
+    private final Expression value;
 
     /**
      * Creates a new parameter for the given name and value.

--- a/src/main/java/sirius/web/sass/ast/Number.java
+++ b/src/main/java/sirius/web/sass/ast/Number.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
  * Represents a number, which might possibly also have a unit like "px" or "%".
  */
 public class Number implements Expression {
+
     private final String value;
     private final String unit;
 

--- a/src/main/java/sirius/web/sass/ast/Operation.java
+++ b/src/main/java/sirius/web/sass/ast/Operation.java
@@ -17,6 +17,7 @@ import java.util.Locale;
  * Represents a binary operation.
  */
 public class Operation implements Expression {
+
     private final String op;
     private final Expression left;
     private Expression right;

--- a/src/main/java/sirius/web/sass/ast/Section.java
+++ b/src/main/java/sirius/web/sass/ast/Section.java
@@ -22,6 +22,7 @@ import java.util.List;
  * SASS section (with nested sections) as well, as flattened CSS sections and media queries.
  */
 public class Section {
+
     private final List<List<String>> selectors = new ArrayList<>();
     private final List<Expression> mediaQueries = new ArrayList<>();
     private final List<String> extendedSections = new ArrayList<>();

--- a/src/main/java/sirius/web/sass/ast/Stylesheet.java
+++ b/src/main/java/sirius/web/sass/ast/Stylesheet.java
@@ -16,11 +16,11 @@ import java.util.List;
  */
 public class Stylesheet {
 
-    private String name;
-    private List<Variable> variables = new ArrayList<>();
-    private List<Mixin> mixins = new ArrayList<>();
-    private List<Section> sections = new ArrayList<>();
-    private List<String> imports = new ArrayList<>();
+    private final String name;
+    private final List<Variable> variables = new ArrayList<>();
+    private final List<Mixin> mixins = new ArrayList<>();
+    private final List<Section> sections = new ArrayList<>();
+    private final List<String> imports = new ArrayList<>();
 
     /**
      * Creates a new stylesheet with the given name

--- a/src/main/java/sirius/web/sass/ast/Value.java
+++ b/src/main/java/sirius/web/sass/ast/Value.java
@@ -15,7 +15,8 @@ import sirius.web.sass.Scope;
  * Represents a plain value.
  */
 public class Value implements Expression {
-    private String contents;
+
+    private final String contents;
 
     /**
      * Creates a new value representing the given contents a value.

--- a/src/main/java/sirius/web/sass/ast/ValueList.java
+++ b/src/main/java/sirius/web/sass/ast/ValueList.java
@@ -19,6 +19,7 @@ import java.util.List;
  * Represents a list of values.
  */
 public class ValueList implements Expression {
+
     private final List<Expression> elements = new ArrayList<>();
     private boolean keepCommas = false;
 

--- a/src/main/java/sirius/web/sass/ast/VariableReference.java
+++ b/src/main/java/sirius/web/sass/ast/VariableReference.java
@@ -15,7 +15,8 @@ import sirius.web.sass.Scope;
  * References a variable like "$test".
  */
 public class VariableReference implements Expression {
-    private String name;
+
+    private final String name;
 
     /**
      * Creates a new reference for the given variable.


### PR DESCRIPTION
### Description

Provides `<i:sass>` for compiling a SASS file and including the resulting CSS directly into a template. Also includes some code maintenance.

```html
<head>
    <style>
        <i:sass source="/assets/pdf/datasheet.scss"/>
    </style>
</head>
```

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10782](https://scireum.myjetbrains.com/youtrack/issue/OX-10782)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
