### PR TITLE
Core JS - Allow to send POST data as urlencoded instead of multipart form data

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -252,12 +252,19 @@ sirius.getJSON = function (url, params) {
  *
  * @param url the URL to invoke
  * @param params the parameters to send POST data (parameters with 'undefined' values are not sent to the server)
+ * @param [useSearchParams] if true, the parameters are sent as URLSearchParams instead of FormData
  * @returns {Promise<any>} the received JSON data
  */
-sirius.postJson = function (url, params) {
+sirius.postJson = function (url, params, useSearchParams) {
+    let body = sirius.convertObjectToFormData(params);
+    if (useSearchParams) {
+        // Convert the body to URLSearchParams, this may be necessary when using problematic characters in field names
+        // that are converted/replaced by the multipart decoder of Netty.
+        body = new URLSearchParams(body);
+    }
     return fetch(url, {
         method: "post",
-        body: sirius.convertObjectToFormData(params)
+        body: body
     }).then(function (response) {
         return response.json();
     });


### PR DESCRIPTION
### Description

Netty seems to replace some characters like commas, colons, semicolons, ... with spaces when reading the multipart form data in `HttpPostMultipartRequestDecoder::getContentDispositionAttribute`. This may be problematic when trying to match the parameter names to data.

To circumvent this in a non breaking fashion we add a new optional parameter that converts the FormData into an URLSearchParams object. This way data is sent with content type `application/x-www-form-urlencoded` instead of `multipart/form-data`.

see:
https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java#L875
https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java#L1293

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10757](https://scireum.myjetbrains.com/youtrack/issue/OX-10757)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
