### PR TITLE
Returns the oauth access token "expires at" date

### DIFF
--- a/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
+++ b/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
@@ -44,7 +44,8 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
         String refreshToken = response.required(OAuth.REFRESH_TOKEN).asText("");
         String type = response.required(OAuth.TOKEN_TYPE).asText("");
         long accessTokenExpiresIn = response.path(OAuth.EXPIRES_IN).asLong(0L);
-        LocalDateTime accessTokenExpiresAt = LocalDateTime.now().plusSeconds(accessTokenExpiresIn);
+        LocalDateTime accessTokenExpiresAt =
+                accessTokenExpiresIn > 0 ? LocalDateTime.now().plusSeconds(accessTokenExpiresIn) : null;
         if (OAuth.TOKEN_TYPE_BEARER.equalsIgnoreCase(type)) {
             try {
                 // Try to read the exact refresh token expiration date from the JWT token itself

--- a/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
+++ b/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
@@ -22,10 +22,12 @@ import java.time.ZoneOffset;
  * @param accessToken           the access token received from the authorization server
  * @param refreshToken          the refresh token received from the authorization server
  * @param type                  the type of the tokens received from the authorization server, e.g. "Bearer" or "MAC"
+ * @param accessTokenExpiresAt  the date at which the access token expires, might be null if the server response
+ *                              contains no information
  * @param refreshTokenExpiresAt the date at which the refresh token expires, might be estimated if no JWT bearer
  *                              token is given
  */
-public record ReceivedTokens(String accessToken, String refreshToken, String type,
+public record ReceivedTokens(String accessToken, String refreshToken, String type, LocalDateTime accessTokenExpiresAt,
                              LocalDateTime refreshTokenExpiresAt) {
 
     private static final long TWO_DAYS_IN_SECONDS = 2 * 24 * 60 * 60L;
@@ -41,26 +43,27 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
         String accessToken = response.required(OAuth.ACCESS_TOKEN).asText("");
         String refreshToken = response.required(OAuth.REFRESH_TOKEN).asText("");
         String type = response.required(OAuth.TOKEN_TYPE).asText("");
+        long accessTokenExpiresIn = response.path(OAuth.EXPIRES_IN).asLong(0L);
+        LocalDateTime accessTokenExpiresAt = LocalDateTime.now().plusSeconds(accessTokenExpiresIn);
         if (OAuth.TOKEN_TYPE_BEARER.equalsIgnoreCase(type)) {
             try {
                 // Try to read the exact refresh token expiration date from the JWT token itself
                 LocalDateTime refreshTokenExpiresAt =
                         JWT.decode(refreshToken).getExpiresAtAsInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
-                return new ReceivedTokens(accessToken, refreshToken, type, refreshTokenExpiresAt);
+                return new ReceivedTokens(accessToken, refreshToken, type, accessTokenExpiresAt, refreshTokenExpiresAt);
             } catch (JWTDecodeException exception) {
                 // No valid JWT, fall back to implementation from OAuth expires_in or the default value
             }
         }
 
-        // Check if the 'expires in' field, actually meant for the access token, is better than our default tomorrow.
-        long expiresIn = response.path(OAuth.EXPIRES_IN).asLong(0L);
-        if (expiresIn > TWO_DAYS_IN_SECONDS) {
-            LocalDateTime expiresDate = LocalDateTime.now().plusSeconds(expiresIn);
-            return new ReceivedTokens(accessToken, refreshToken, type, expiresDate);
+        // Check if the 'expires in' field, actually meant for the access token, is better than our refresh token
+        // default expires value tomorrow.
+        if (accessTokenExpiresIn > TWO_DAYS_IN_SECONDS) {
+            return new ReceivedTokens(accessToken, refreshToken, type, accessTokenExpiresAt, accessTokenExpiresAt);
         }
 
         // Use default value tomorrow, we expect a refresh token to be valid at least for one more day
         LocalDateTime expiresDate = LocalDateTime.now().plusDays(MINIMUM_REFRESH_EXPIRES_DAYS);
-        return new ReceivedTokens(accessToken, refreshToken, type, expiresDate);
+        return new ReceivedTokens(accessToken, refreshToken, type, accessTokenExpiresAt, expiresDate);
     }
 }


### PR DESCRIPTION
### Description
Returns the oauth access token "expires at" date in case the server did return it. 
Providing this information e.g. gives the API caller the possibility to refresh the token if required. The usage is optional, if not set, the implemention in sirius will trigger a refresh if the provided access token could not be used to authenticate at server. 

Technically this is breaking. But it should have no impact on API users as only the framework should use the constructor with the changed parameters.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13502](https://scireum.myjetbrains.com/youtrack/issue/SE-13502)

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
