### PR TITLE
HTML Input for PDF Generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@
             <artifactId>utils-mail-dkim</artifactId>
             <version>2.0.1</version>
         </dependency>
+
+        <!-- Used to generate PDFs -->
         <dependency>
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,13 @@
             <version>9.8.0</version>
         </dependency>
 
+        <!-- Used to clean HTML before generating PDF -->
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+
         <!-- POI is used to generate excel exports -->
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
@@ -69,7 +69,6 @@ public class TagliatellePDFContentHandler extends TagliatelleContentHandler {
      * This is done by first generally removing all {@code <script>} elements from the entire document. Then, all
      * {@code <style>} style elements are deleted that are outside the {@code <header>} element. Finally, the DOM tree
      * is encoded as XHTML fit for the strict SAX parser employed by {@link ITextRenderer}.
-     * header element.
      *
      * @param html the HTML content to clean
      * @return the given content with problematic elements removed and encoded as valid XHTML

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
@@ -67,7 +67,7 @@ public class TagliatellePDFContentHandler extends TagliatelleContentHandler {
      * Cleans the given HTML content for use as input to the PDF generator.
      * <p>
      * This is done by first generally removing all {@code <script>} elements from the entire document. Then, all
-     * {@code <style>} style elements are deleted that are outside the {@code <header>} element. Finally, the DOM tree
+     * {@code <style>} elements are deleted that are outside the {@code <header>} element. Finally, the DOM tree
      * is encoded as XHTML fit for the strict SAX parser employed by {@link ITextRenderer}.
      *
      * @param html the HTML content to clean

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
@@ -10,6 +10,7 @@ package sirius.web.templates.pdf;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
@@ -82,6 +83,8 @@ public class TagliatellePDFContentHandler extends TagliatelleContentHandler {
         document.select("body style").remove();
 
         document.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+        document.outputSettings().escapeMode(Entities.EscapeMode.xhtml);
+        document.outputSettings().charset("UTF-8");
         return document.html();
     }
 


### PR DESCRIPTION
### Description

The _Flying Saucer_ PDF renderer requires XHTML as input, and we rely on the invoker to provide valid content. However, luckily, the world has moved on from XHTML. In order to relax the requirements and facilitate reuse of HTML templates, this PR introduces an additional processing step that removes problematic elements and ensures XHTML automatically.

Marked as **breaking** as PDF rendering should be checked after upgrading.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10783](https://scireum.myjetbrains.com/youtrack/issue/OX-10783)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
