### PR TITLE
PDF Rendering: Automagic Rewriting of Plain URLs

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -51,27 +51,27 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
                                                  UserAgentCallback userAgentCallback,
                                                  int cssWidth,
                                                  int cssHeight) {
-        Element e = box.getElement();
-        if (e == null) {
+        Element element = box.getElement();
+        if (element == null) {
             return null;
         }
 
-        String nodeName = e.getNodeName();
+        String nodeName = element.getNodeName();
         if (!TAG_TYPE_IMG.equals(nodeName)) {
             return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
         }
 
-        String src = e.getAttribute(ATTR_SRC);
-        if (Strings.isEmpty(src)) {
+        String source = element.getAttribute(ATTR_SRC);
+        if (Strings.isEmpty(source)) {
             return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
         }
 
         try {
-            String protocol = Strings.split(src, "://").getFirst();
+            String protocol = Strings.split(source, "://").getFirst();
             PdfReplaceHandler handler = findHandler(protocol);
-            return new AsyncLoadedImageElement(handler, userAgentCallback, src, cssWidth, cssHeight);
-        } catch (Exception ex) {
-            Exceptions.handle(ex);
+            return new AsyncLoadedImageElement(handler, userAgentCallback, source, cssWidth, cssHeight);
+        } catch (Exception exception) {
+            Exceptions.handle(exception);
         }
 
         return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -21,6 +21,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.web.templates.pdf.handlers.PdfReplaceHandler;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Used by the XHTMLRenderer (creating PDFs) to replace img elements by their referenced image.
@@ -61,7 +62,7 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
             return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
         }
 
-        String source = element.getAttribute(ATTR_SRC);
+        String source = rewriteLegacyUrl(element.getAttribute(ATTR_SRC));
         if (Strings.isEmpty(source)) {
             return super.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
         }
@@ -84,5 +85,16 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
                        .orElseThrow(() -> new UnsupportedOperationException(Strings.apply(
                                "No handler for protocol '%s' could be found",
                                protocol)));
+    }
+
+    private String rewriteLegacyUrl(String url) {
+        for (PdfReplaceHandler handler : handlers) {
+            Optional<String> rewrittenUrl = handler.tryRewritePlainUrl(url);
+            if (rewrittenUrl.isPresent()) {
+                return rewrittenUrl.get();
+            }
+        }
+
+        return url;
     }
 }

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -21,6 +21,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * Represents a image replace handler that is used by {@link sirius.web.templates.pdf.ImageReplacedElementFactory} to
@@ -32,6 +33,16 @@ public abstract class PdfReplaceHandler implements Priorized {
     @Override
     public int getPriority() {
         return Priorized.DEFAULT_PRIORITY;
+    }
+
+    /**
+     * Attempts to rewrite a plain URL to a PDF-compatible one.
+     *
+     * @param url the plain URL to rewrite
+     * @return an optional containing the new URL if the plain URL could be rewritten, an empty optional otherwise
+     */
+    public Optional<String> tryRewritePlainUrl(String url) {
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -119,7 +119,10 @@ public abstract class PdfReplaceHandler implements Priorized {
     }
 
     @Nonnull
-    private static Tuple<Integer, Integer> downscaleResource(int cssWidth, int cssHeight, int imageWidth, int imageHeight) {
+    private static Tuple<Integer, Integer> downscaleResource(int cssWidth,
+                                                             int cssHeight,
+                                                             int imageWidth,
+                                                             int imageHeight) {
 
         // First, check if we need to scale down the width
         if (imageWidth > cssWidth) {
@@ -138,7 +141,10 @@ public abstract class PdfReplaceHandler implements Priorized {
     }
 
     @Nonnull
-    private static Tuple<Integer, Integer> upscaleResource(int cssWidth, int cssHeight, int imageWidth, int imageHeight) {
+    private static Tuple<Integer, Integer> upscaleResource(int cssWidth,
+                                                           int cssHeight,
+                                                           int imageWidth,
+                                                           int imageHeight) {
 
         // First, scale up only the width
         imageHeight = cssWidth * imageHeight / imageWidth;

--- a/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
@@ -11,12 +11,14 @@ package sirius.web.templates.pdf.handlers;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.UserAgentCallback;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * Resolves resource:// URIs that are referencing {@link Resources} to resized images while maintaining the image
@@ -24,6 +26,9 @@ import javax.annotation.Nullable;
  */
 @Register
 public class ResourcePdfReplaceHandler extends PdfReplaceHandler {
+
+    @ConfigValue("product.baseUrl")
+    private String productBaseUrl;
 
     @Part
     private Resources resources;
@@ -45,5 +50,20 @@ public class ResourcePdfReplaceHandler extends PdfReplaceHandler {
         }
 
         return null;
+    }
+
+    @Override
+    public Optional<String> tryRewritePlainUrl(String url) {
+        if (!url.startsWith(productBaseUrl)) {
+            return Optional.empty();
+        }
+
+        // remap plain asset URLs to the resource:// scheme
+        int indexOfAssets = url.indexOf("/assets/");
+        if (indexOfAssets >= 0) {
+            return Optional.of("resource:/" + url.substring(indexOfAssets));
+        }
+
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
### Description

Usually, the HTML code for PDF rendering requires special URLs when embedding media, such as `resource://assets/xyz`. This makes reuse of generic HTML templates harder, as it would require to replace such links for use in a PDF rendering setting. This PR provides `PdfReplaceHandler` instances with the option to detect and re-write plain URLs (such as `https://<server>/assets/xyz`) such that they can be processed onward.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10783](https://scireum.myjetbrains.com/youtrack/issue/OX-10783)
- This PR is related to PR: #1455 

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
