### PR TITLE
Filter out hidden elements in sirius.addElementVisibleListener

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -381,6 +381,12 @@ sirius.addElementVisibleListener = function (selector, listener, distanceFactor)
         const factor = distanceFactor || 1;
         const rect = element.getBoundingClientRect();
 
+        // Simple visibility check to ignore hidden elements
+        if (rect.height === 0 || rect.width === 0) {
+            return false;
+        }
+
+        // Check the position relative to the view port
         const verticalMargin = rect.height * factor;
         const horizontalMargin = rect.width * factor;
         const clientHeight = document.documentElement.clientHeight;


### PR DESCRIPTION
### Description
Hidden elements have a bounding client rect at the top of the viewport and thus the listener is triggered immediately after the page is loaded.

This adds a simple check for visibility by checking the width and height of the bounding client rect.

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13968](https://scireum.myjetbrains.com/youtrack/issue/SE-13968)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
