### PR TITLE
Add some CSS helper class for common cursor variants

### DIFF
--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -42,6 +42,46 @@
   cursor: pointer;
 }
 
+.sci-cursor-default {
+  cursor: default;
+}
+
+.sci-cursor-help {
+  cursor: help;
+}
+
+.sci-cursor-wait {
+  cursor: wait;
+}
+
+.sci-cursor-move {
+  cursor: move;
+}
+
+.sci-cursor-not-allowed {
+  cursor: not-allowed;
+}
+
+.sci-cursor-crosshair {
+  cursor: crosshair;
+}
+
+.sci-cursor-zoom-in {
+  cursor: zoom-in;
+}
+
+.sci-cursor-zoom-out {
+  cursor: zoom-out;
+}
+
+.sci-cursor-text {
+  cursor: text;
+}
+
+.sci-cursor-none {
+  cursor: none;
+}
+
 .sci-border-radius-0 {
   border-radius: 0;
 }


### PR DESCRIPTION
### Description

Took the most common cursors from [this list](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#keyword) and added them as helper classes next to the already defined `sci-cursor-pointer`.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11120](https://scireum.myjetbrains.com/youtrack/issue/OX-11120)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
