### PR TITLE
Adds a new Macro which checks whether the given guard string is defined or not

### DIFF
--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -41,7 +41,7 @@ public class IfNotDefinedMacro extends BasicMacro {
 
     @Override
     public boolean isConstant(CompilationContext context, List<Node> args) {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -1,0 +1,73 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.tagliatelle.macros;
+
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.tokenizer.Position;
+import sirius.pasta.noodle.Environment;
+import sirius.pasta.noodle.compiler.CompilationContext;
+import sirius.pasta.noodle.compiler.ir.Node;
+import sirius.pasta.noodle.macros.BasicMacro;
+import sirius.pasta.tagliatelle.rendering.GlobalRenderContext;
+import sirius.pasta.tagliatelle.rendering.LocalRenderContext;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Checks whether the given guard is defined or not.
+ */
+@Register
+public class IfNotDefinedMacro extends BasicMacro {
+
+    @Override
+    protected Class<?> getType() {
+        return boolean.class;
+    }
+
+    @Override
+    protected void verifyArguments(CompilationContext compilationContext, Position position, List<Class<?>> args) {
+        if (args.size() != 1) {
+            throw new IllegalArgumentException("Expected a single String as argument.");
+        }
+    }
+
+    @Override
+    public boolean isConstant(CompilationContext context, List<Node> args) {
+        return true;
+    }
+
+    @Override
+    public Object invoke(Environment environment, Object[] args) {
+        String guard = (String) args[0];
+        if (Strings.isFilled(guard) && environment instanceof LocalRenderContext localRenderContext) {
+                GlobalRenderContext globalRenderContext = localRenderContext.getGlobalContext();
+                if (globalRenderContext.getGuards().contains(guard)) {
+                    return false;
+                } else {
+                    globalRenderContext.getGuards().add(guard);
+                    return true;
+                }
+            }
+
+        return false;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Checks whether the given guard is defined or not.";
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "ifNotDefined";
+    }
+}

--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -22,7 +22,9 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
- * Checks whether the given guard is defined or not.
+ * Checks whether the given {@linkplain GlobalRenderContext#hasGuard(String) guard } is defined or not.
+ *
+ * @see GlobalRenderContext#addGuard(String)
  */
 @Register
 public class IfNotDefinedMacro extends BasicMacro {
@@ -48,21 +50,21 @@ public class IfNotDefinedMacro extends BasicMacro {
     public Object invoke(Environment environment, Object[] args) {
         String guard = (String) args[0];
         if (Strings.isFilled(guard) && environment instanceof LocalRenderContext localRenderContext) {
-                GlobalRenderContext globalRenderContext = localRenderContext.getGlobalContext();
-                if (globalRenderContext.hasGuard(guard)) {
-                    return false;
-                } else {
-                    globalRenderContext.addGuard(guard);
-                    return true;
-                }
+            GlobalRenderContext globalRenderContext = localRenderContext.getGlobalContext();
+            if (globalRenderContext.hasGuard(guard)) {
+                return false;
+            } else {
+                globalRenderContext.addGuard(guard);
+                return true;
             }
+        }
 
         return false;
     }
 
     @Override
     public String getDescription() {
-        return "Checks whether the given guard is defined or not.";
+        return "Checks whether the given guard is defined or not. If the guard is not defined, true is returned and the guard is added to a Set of guards to the global context of the template. This means that all subsequent calls to ifNotDefined with the same guard will return false. This allows to run a block/code exactly once per template. The behavior is somewhat similar to C/C++ #ifndef.";
     }
 
     @Nonnull

--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -64,7 +64,12 @@ public class IfNotDefinedMacro extends BasicMacro {
 
     @Override
     public String getDescription() {
-        return "Checks whether the given guard is defined or not. If the guard is not defined, true is returned and the guard is added to a Set of guards to the global context of the template. This means that all subsequent calls to ifNotDefined with the same guard will return false. This allows to run a block/code exactly once per template. The behavior is somewhat similar to C/C++ #ifndef.";
+        return """
+                Checks whether the given guard is defined or not. If the guard is not defined, true is returned and
+                the guard is added to a Set of guards to the global context of the template. This means that all
+                subsequent calls to ifNotDefined with the same guard will return false. This allows to run a
+                block/code exactly once per template. The behavior is somewhat similar to C/C++ #ifndef.
+                """;
     }
 
     @Nonnull

--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -49,10 +49,10 @@ public class IfNotDefinedMacro extends BasicMacro {
         String guard = (String) args[0];
         if (Strings.isFilled(guard) && environment instanceof LocalRenderContext localRenderContext) {
                 GlobalRenderContext globalRenderContext = localRenderContext.getGlobalContext();
-                if (globalRenderContext.getGuards().contains(guard)) {
+                if (globalRenderContext.hasGuard(guard)) {
                     return false;
                 } else {
-                    globalRenderContext.getGuards().add(guard);
+                    globalRenderContext.addGuard(guard);
                     return true;
                 }
             }

--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -36,7 +36,7 @@ public class IfNotDefinedMacro extends BasicMacro {
 
     @Override
     protected void verifyArguments(CompilationContext compilationContext, Position position, List<Class<?>> args) {
-        if (args.size() != 1) {
+        if (args.size() != 1 || !CompilationContext.isAssignableTo(args.getFirst(), String.class)) {
             throw new IllegalArgumentException("Expected a single String as argument.");
         }
     }

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/GlobalRenderContext.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/GlobalRenderContext.java
@@ -15,8 +15,10 @@ import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
@@ -37,6 +39,9 @@ public class GlobalRenderContext {
     protected StringBuilder buffer;
     protected Map<String, String> extraBlocks;
     protected UnaryOperator<String> escaper = GlobalRenderContext::escapeRAW;
+
+    private List<String> guards = new ArrayList<>();
+
     private static final Pattern OPENING_SCRIPT_TAG = Pattern.compile("<script(\\s.*)?>", Pattern.CASE_INSENSITIVE);
     private static final Pattern CLOSING_SCRIPT_TAG = Pattern.compile("</script>", Pattern.CASE_INSENSITIVE);
     private static final Pattern OPENING_STYLE_TAG = Pattern.compile("<style(\\s.*)?>", Pattern.CASE_INSENSITIVE);
@@ -381,5 +386,9 @@ public class GlobalRenderContext {
                 buffer.append("<!-- " + string + " -->");
             }
         }
+    }
+
+    public List<String> getGuards() {
+        return guards;
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/GlobalRenderContext.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/GlobalRenderContext.java
@@ -18,9 +18,11 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -40,7 +42,7 @@ public class GlobalRenderContext {
     protected Map<String, String> extraBlocks;
     protected UnaryOperator<String> escaper = GlobalRenderContext::escapeRAW;
 
-    private List<String> guards = new ArrayList<>();
+    private Set<String> guards = new HashSet<>();
 
     private static final Pattern OPENING_SCRIPT_TAG = Pattern.compile("<script(\\s.*)?>", Pattern.CASE_INSENSITIVE);
     private static final Pattern CLOSING_SCRIPT_TAG = Pattern.compile("</script>", Pattern.CASE_INSENSITIVE);
@@ -388,7 +390,21 @@ public class GlobalRenderContext {
         }
     }
 
-    public List<String> getGuards() {
-        return guards;
+    /**
+     * Checks if the given guard is defined or not.
+     *
+     * @param guard the guard String to check
+     * @return true if the guard is defined, false otherwise
+     */
+    public boolean hasGuard(String guard) {
+        return guards.contains(guard);
+    }
+
+    /**
+     * Adds the given guard to the list of defined guards.
+     * @param guard the guard String to add
+     */
+    public void addGuard(String guard) {
+        guards.add(guard);
     }
 }

--- a/src/main/resources/default/taglib/t/ifNotDefined.html.pasta
+++ b/src/main/resources/default/taglib/t/ifNotDefined.html.pasta
@@ -1,0 +1,10 @@
+<i:arg type="String" name="value" description="Contains a string which is used as a guard clause to determine whether the body should be rendered."/>
+
+<i:pragma name="description">
+    Checks whether the defined value is already specified. If the value is not defined, the body of the tag is rendered.
+    Similar to C/C++ #ifndef.
+</i:pragma>
+
+<i:if test="ifNotDefined(value)">
+    <i:render name="body"/>
+</i:if>


### PR DESCRIPTION
### Description

* Similar to C/C++ `#ifndef`
* Can be used to make sure that certain imports/code is only performed once per template.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1019](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1019)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

