### PR TITLE
PDF Bookmark Support

### DIFF
--- a/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
@@ -78,6 +78,13 @@ public class TagliatellePDFContentHandler extends TagliatelleContentHandler {
     private String cleanHtml(String html) {
         Document document = Jsoup.parse(html);
 
+        // the parser is very strict in terms of what elements are accepted within the <head> element, and it does not
+        // know about additional valid elements like <bookmarks> that are valid for flying saucer; we need to move them
+        // back from the <body> to the <head> element
+        document.select("body > bookmarks").forEach(bookmarks -> {
+            document.head().appendChild(bookmarks);
+        });
+
         // in theory, the following two lines should be possible with a single CSS selector; however, in practice, Jsoup
         // does not select the style elements correctly when attempting that
         document.select("script").remove();


### PR DESCRIPTION
### Description

Keeps the `<bookmarks>` element in `<head>` during cleanup. Jsoup moves it to `<body>` during parsing as it is a non-standard header tag required by _flying saucer_ to generate PDF bookmarks (i.e. a PDF table of contents).

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-10783](https://scireum.myjetbrains.com/youtrack/issue/OX-10783)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
