### PR TITLE
SE-13618: Extend the checks of the TemplateCompiler to include missing required attributes

### DIFF
--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -434,7 +434,7 @@ public class TemplateCompiler extends InputProcessor {
      * @param attributes the set of attributes which were parsed
      */
     private void checkMissingAttributes(TagHandler handler, Set<String> attributes) {
-        Set<String> missingAttributes = handler.getRequiredAttributeNames();
+        Set<String> missingAttributes = new HashSet<>(handler.getRequiredAttributeNames());
         missingAttributes.removeAll(attributes);
         if (!missingAttributes.isEmpty()) {
             missingAttributes.forEach(attr -> context.error(reader.current(),

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -8,14 +8,14 @@
 
 package sirius.pasta.tagliatelle.compiler;
 
-import sirius.kernel.tokenizer.Char;
-import sirius.kernel.tokenizer.ParseError;
-import sirius.kernel.tokenizer.Position;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.PriorityParts;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
+import sirius.kernel.tokenizer.Char;
+import sirius.kernel.tokenizer.ParseError;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.Pasta;
 import sirius.pasta.noodle.Callable;
 import sirius.pasta.noodle.ConstantCall;
@@ -33,7 +33,9 @@ import sirius.web.services.JSONStructuredOutput;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Compiles a sources file into a {@link sirius.pasta.tagliatelle.Template}.
@@ -369,6 +371,8 @@ public class TemplateCompiler extends InputProcessor {
      * @param handler the handler to add the attributes to
      */
     private void parseAttributes(TagHandler handler) {
+        // Collect all parsed attributes.
+        Set<String> attributes = new HashSet<>();
         while (true) {
             skipWhitespaces();
             if (reader.current().isEndOfInput() || reader.current().is('>', '/')) {
@@ -379,6 +383,8 @@ public class TemplateCompiler extends InputProcessor {
             verifyAttributeNameAndType(handler, name, attributeType);
             if (attributeType == null) {
                 attributeType = String.class;
+            } else {
+                attributes.add(name);
             }
 
             skipWhitespaces();
@@ -416,6 +422,27 @@ public class TemplateCompiler extends InputProcessor {
                 handler.setAttribute(name, expression);
             }
             consumeExpectedCharacter('"');
+        }
+
+        checkMissingAttributes(handler, attributes);
+    }
+
+    /**
+     * Checks if all required attributes are present.
+     *
+     * @param handler    the tag handler
+     * @param attributes the set of attributes which were parsed
+     */
+    private void checkMissingAttributes(TagHandler handler, Set<String> attributes) {
+        // Check if all required attributes are present.
+        Set<String> missingAttributes = handler.getAttributeNames(true);
+        missingAttributes.removeAll(attributes);
+        if (!missingAttributes.isEmpty()) {
+            // If we have required attributes left, we report them as missing
+            missingAttributes.forEach(attr -> context.error(reader.current(),
+                                                            "Missing required attribute. %s missing the required attribute '%s'.",
+                                                            handler.getTagName(),
+                                                            attr));
         }
     }
 

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -435,7 +435,7 @@ public class TemplateCompiler extends InputProcessor {
      */
     private void checkMissingAttributes(TagHandler handler, Set<String> attributes) {
         // Check if all required attributes are present.
-        Set<String> missingAttributes = handler.getAttributeNames(true);
+        Set<String> missingAttributes = handler.getRequiredAttributeNames();
         missingAttributes.removeAll(attributes);
         if (!missingAttributes.isEmpty()) {
             // If we have required attributes left, we report them as missing

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -434,11 +434,9 @@ public class TemplateCompiler extends InputProcessor {
      * @param attributes the set of attributes which were parsed
      */
     private void checkMissingAttributes(TagHandler handler, Set<String> attributes) {
-        // Check if all required attributes are present.
         Set<String> missingAttributes = handler.getRequiredAttributeNames();
         missingAttributes.removeAll(attributes);
         if (!missingAttributes.isEmpty()) {
-            // If we have required attributes left, we report them as missing
             missingAttributes.forEach(attr -> context.error(reader.current(),
                                                             "Missing required attribute. %s missing the required attribute '%s'.",
                                                             handler.getTagName(),

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Compiles a sources file into a {@link sirius.pasta.tagliatelle.Template}.
@@ -436,14 +437,13 @@ public class TemplateCompiler extends InputProcessor {
      * @param attributes the set of attributes which were parsed
      */
     private void checkMissingAttributes(TagHandler handler, Set<String> attributes) {
-        Set<String> missingAttributes = new HashSet<>(handler.getRequiredAttributeNames());
-        missingAttributes.removeAll(attributes);
-        if (!missingAttributes.isEmpty()) {
-            missingAttributes.forEach(attr -> context.error(reader.current(),
-                                                            "Missing required attribute. %s missing the required attribute '%s'.",
-                                                            handler.getTagName(),
-                                                            attr));
-        }
+        handler.getRequiredAttributeNames()
+               .stream()
+               .filter(Predicate.not(attributes::contains))
+               .forEach(attr -> context.error(reader.current(),
+                                              "Missing required attribute. %s missing the required attribute '%s'.",
+                                              handler.getTagName(),
+                                              attr));
     }
 
     private void parseAttributeExpression(TagHandler handler,

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -384,6 +384,8 @@ public class TemplateCompiler extends InputProcessor {
             if (attributeType == null) {
                 attributeType = String.class;
             } else {
+                // verifyAttributeNameAndType(...) already reports an error if the attributeType is unknown.
+                // We only save the found and defined attributes.
                 attributes.add(name);
             }
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
@@ -18,7 +18,9 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:arg</tt> which specifies a template argument.
@@ -156,5 +158,10 @@ public class ArgTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME, PARAM_TYPE));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
@@ -18,7 +18,6 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
@@ -162,6 +162,6 @@ public class ArgTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME, PARAM_TYPE));
+        return Set.of(PARAM_NAME, PARAM_TYPE);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
@@ -18,8 +18,10 @@ import sirius.pasta.tagliatelle.emitter.ExtraBlockEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Handles <tt>i:block</tt> which specifies a template section passed into a tag invocation.
@@ -84,5 +86,10 @@ public class BlockTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
@@ -18,7 +18,6 @@ import sirius.pasta.tagliatelle.emitter.ExtraBlockEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
@@ -90,6 +90,6 @@ public class BlockTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME));
+        return Set.of(PARAM_NAME);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
@@ -86,6 +86,6 @@ public class DefineTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME));
+        return Set.of(PARAM_NAME);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
@@ -16,7 +16,9 @@ import sirius.pasta.tagliatelle.emitter.PushLocalEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:define</tt> which defines a string as the evaluation result of its body.
@@ -80,5 +82,10 @@ public class DefineTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
@@ -16,7 +16,6 @@ import sirius.pasta.tagliatelle.emitter.PushLocalEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
@@ -74,6 +74,6 @@ public class DynamicInvokeTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(ATTR_TEMPLATE));
+        return Set.of(ATTR_TEMPLATE);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
@@ -16,7 +16,9 @@ import sirius.pasta.tagliatelle.emitter.DynamicInvokeTemplateEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:dynamicInvoke</tt> which invokes or inlines a given template.
@@ -68,5 +70,10 @@ public class DynamicInvokeTag extends TagHandler {
     public Class<?> getExpectedAttributeType(String name) {
         // Accept anything, we don't know yet what to expect at runtime....
         return Callable.class;
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(ATTR_TEMPLATE));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
@@ -16,7 +16,6 @@ import sirius.pasta.tagliatelle.emitter.DynamicInvokeTemplateEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
@@ -18,8 +18,11 @@ import sirius.pasta.tagliatelle.TemplateExtension;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:extensions</tt> which invokes all extensions with the given name.
@@ -85,5 +88,10 @@ public class ExtensionsTag extends InvokeTag {
         }
 
         return Callable.class;
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(ATTR_TARGET));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
@@ -18,9 +18,7 @@ import sirius.pasta.tagliatelle.TemplateExtension;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
@@ -92,6 +92,6 @@ public class ExtensionsTag extends InvokeTag {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(ATTR_TARGET));
+        return Set.of(ATTR_TARGET);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
@@ -91,6 +91,6 @@ public class ExtraBlockTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME));
+        return Set.of(PARAM_NAME);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
@@ -17,7 +17,6 @@ import sirius.pasta.tagliatelle.emitter.ExtraBlockEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
@@ -17,7 +17,9 @@ import sirius.pasta.tagliatelle.emitter.ExtraBlockEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Permits to add an extra block to the global render context.
@@ -85,5 +87,10 @@ public class ExtraBlockTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
@@ -121,6 +121,6 @@ public class ForTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_ITEMS, PARAM_TYPE, PARAM_VAR));
+        return Set.of(PARAM_ITEMS, PARAM_TYPE, PARAM_VAR);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
@@ -18,7 +18,6 @@ import sirius.pasta.tagliatelle.emitter.LoopState;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
@@ -18,7 +18,9 @@ import sirius.pasta.tagliatelle.emitter.LoopState;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:for</tt> which emits its body for each item in an {@link Iterable}.
@@ -115,5 +117,10 @@ public class ForTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_ITEMS, PARAM_TYPE, PARAM_VAR));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
@@ -15,7 +15,9 @@ import sirius.pasta.tagliatelle.emitter.ConditionalEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:if</tt> which emits its body if a condition is met.
@@ -70,5 +72,10 @@ public class IfTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of("test"));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
@@ -76,6 +76,6 @@ public class IfTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of("test"));
+        return Set.of("test");
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
@@ -15,7 +15,6 @@ import sirius.pasta.tagliatelle.emitter.ConditionalEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
@@ -79,6 +79,6 @@ public class IncludeTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(ATTR_NAME));
+        return Set.of(ATTR_NAME);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
@@ -17,7 +17,6 @@ import sirius.web.resources.Resources;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
@@ -17,7 +17,9 @@ import sirius.web.resources.Resources;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:include</tt> which includes the contents of the given resource without any processing.
@@ -73,5 +75,10 @@ public class IncludeTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(ATTR_NAME));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/InvokeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/InvokeTag.java
@@ -18,7 +18,9 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:invoke</tt> which invokes or inlines a given template.
@@ -114,6 +116,21 @@ public class InvokeTag extends TagHandler {
             // Accept anything, we don't want to report errors based on previous errors...
             return Callable.class;
         }
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        Set<String> result = new HashSet<>();
+        result.add(ATTR_TEMPLATE);
+
+        if (ensureThatTemplateIsPresent()) {
+            for (TemplateArgument arg : template.getArguments()) {
+                if (arg.getDefaultValue() == null) {
+                    result.add(arg.getName());
+                }
+            }
+        }
+        return result;
     }
 
     private boolean ensureThatTemplateIsPresent() {

--- a/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
@@ -17,7 +17,9 @@ import sirius.pasta.tagliatelle.emitter.PushLocalEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:local</tt> which defines a local variable.
@@ -91,5 +93,10 @@ public class LocalTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME, PARAM_VALUE));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
@@ -17,7 +17,6 @@ import sirius.pasta.tagliatelle.emitter.PushLocalEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
@@ -97,6 +97,6 @@ public class LocalTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME, PARAM_VALUE));
+        return Set.of(PARAM_NAME, PARAM_VALUE);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
@@ -15,7 +15,6 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
@@ -84,6 +84,6 @@ public class PragmaTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME));
+        return Set.of(PARAM_NAME);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
@@ -15,7 +15,9 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:pragma</tt> which defines a pragma (key / value pair) for a template.
@@ -78,5 +80,10 @@ public class PragmaTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
@@ -16,7 +16,6 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
@@ -16,7 +16,9 @@ import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:render</tt> which emits the block with the given name.
@@ -78,5 +80,10 @@ public class RenderTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(PARAM_NAME));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
@@ -84,6 +84,6 @@ public class RenderTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(PARAM_NAME));
+        return Set.of(PARAM_NAME);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
@@ -98,6 +98,6 @@ public class SassTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of(SOURCE_ATTRIBUTE));
+        return Set.of(SOURCE_ATTRIBUTE);
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:sass</tt> which renders a SASS file into the current template as compiled CSS.
@@ -92,5 +94,10 @@ public class SassTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of(SOURCE_ATTRIBUTE));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
@@ -15,7 +15,6 @@ import sirius.pasta.tagliatelle.emitter.SwitchEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
@@ -15,7 +15,9 @@ import sirius.pasta.tagliatelle.emitter.SwitchEmitter;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Handles <tt>i:switch</tt> which can hold multiple blocks which are only rendered if their name matches an expression.
@@ -67,5 +69,10 @@ public class SwitchTag extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        return new HashSet<>(List.of("test"));
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
@@ -73,6 +73,6 @@ public class SwitchTag extends TagHandler {
 
     @Override
     public Set<String> getRequiredAttributeNames() {
-        return new HashSet<>(List.of("test"));
+        return Set.of("test");
     }
 }

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
@@ -96,12 +96,10 @@ public abstract class TagHandler {
     }
 
     /**
-     * Returns all attribute names.
-     *
-     * @param required if <tt>true</tt> only required attributes are returned, otherwise all attributes are returned.
+     * Returns all required attribute names.
      * @return a set of all attribute names.
      */
-    public Set<String> getAttributeNames(boolean required) {
+    public Set<String> getRequiredAttributeNames() {
         return Collections.emptySet();
     }
 

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
@@ -24,9 +24,11 @@ import sirius.web.resources.Resources;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Handles a tag detected by the {@link sirius.pasta.tagliatelle.compiler.TemplateCompiler}.
@@ -91,6 +93,16 @@ public abstract class TagHandler {
         }
 
         return attributes.get(name);
+    }
+
+    /**
+     * Returns all attribute names.
+     *
+     * @param required if <tt>true</tt> only required attributes are returned, otherwise all attributes are returned.
+     * @return a set of all attribute names.
+     */
+    public Set<String> getAttributeNames(boolean required) {
+        return Collections.emptySet();
     }
 
     /**

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TaglibTagHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TaglibTagHandler.java
@@ -13,6 +13,9 @@ import sirius.pasta.tagliatelle.Template;
 import sirius.pasta.tagliatelle.TemplateArgument;
 import sirius.pasta.tagliatelle.emitter.CompositeEmitter;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Handles the invocation of a user-defined tag.
  * <p>
@@ -49,5 +52,16 @@ public class TaglibTagHandler extends TagHandler {
         }
 
         return super.getExpectedAttributeType(name);
+    }
+
+    @Override
+    public Set<String> getRequiredAttributeNames() {
+        Set<String> result = new HashSet<>();
+        for (TemplateArgument arg : template.getArguments()) {
+            if (arg.getDefaultValue() == null) {
+                result.add(arg.getName());
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
The TemplateCompiler currently ignores if there are missing attributes that are required because of a missing default value. This circumstance ist only detected during the rendering of the page.

The changes to the TemplateCompiler is now checking for these missing attributes as an early warning to the programmer. Especialy if the templates are overwritten by an artefact.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13618](https://scireum.myjetbrains.com/youtrack/issue/SE-13618)
<!-- - This PR is related to PR: URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
