### PR TITLE
Never fire the callback in sirius.ready twice

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -124,10 +124,11 @@ sirius.isFilled = function (value) {
  * @param callback the callback to execute once the DOM is completely ready
  */
 sirius.ready = function (callback) {
-    // Add as listener in case DOM is loading...
-    document.addEventListener("DOMContentLoaded", callback);
-    // Call manually is we're late...
-    if (document.readyState === "interactive" || document.readyState === "complete") {
+    if (document.readyState === "loading") {
+        // Add as listener in case DOM is loading...
+        document.addEventListener("DOMContentLoaded", callback);
+    } else {
+        // Call manually if we're late...
         callback();
     }
 }


### PR DESCRIPTION
### Description
Sometimes the DOMContentLoaded event is fired after document.readyState already changed to 'interactive'. In this case, the callback is actually called twice with our approach.

This commit ensures that the callback is only called once.

See https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState for possible values
See https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event (actually gives the same code as an example)

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14083](https://scireum.myjetbrains.com/youtrack/issue/SE-14083)
- This PR is related to PR: scireum/sellsite/pull/12139

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
