### PR TITLE
autoregister helperFactory

### DIFF
--- a/src/main/java/sirius/web/security/HelperFactory.java
+++ b/src/main/java/sirius/web/security/HelperFactory.java
@@ -8,6 +8,7 @@
 
 package sirius.web.security;
 
+import sirius.kernel.di.std.AutoRegister;
 import sirius.kernel.di.std.Priorized;
 
 import javax.annotation.Nonnull;
@@ -16,7 +17,7 @@ import javax.annotation.Nonnull;
  * Helpers are used by the {@link ScopeInfo} to perform certain tasks.
  * <p>
  * Note that a helper is created <b>once</b> per scope and not per user or request. Everything that is specific
- * to the user or request has the be in the request itself or the session.
+ * to the user or request has to be in the request itself or the session.
  * <p>
  * Variables can be annotated using {@link HelperConfig} and will be automatically filled with the value set in the
  * scope config. HOWEVER: Note that user specific overwrites of this config value cannot be applied. These values
@@ -24,6 +25,7 @@ import javax.annotation.Nonnull;
  *
  * @param <H> the type of helpers created by this factory
  */
+@AutoRegister
 public interface HelperFactory<H> extends Priorized {
 
     @Override


### PR DESCRIPTION
This is useful for Feature-flagged helpers in customizations which are scoped and not enabled in all scopes Without autoRegister the framework warns on the following code: 

```
@Register
public static class SubHelperFactory extends SuperHelperFactory {
	@Nonnull
	@Override
	public SuperHelper make(@Nonnull ScopeInfo scopeInfo) {
		if (!UserContext.getCurrentUser().hasPermission("feature-sub")) {
			return new SubHelper(scopeInfo);
 	    	}
 	   	return super.make(scopeInfo);
	}
}
```

### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14106](https://scireum.myjetbrains.com/youtrack/issue/SE-14106)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
