### PR TITLE
SelectableTable - Fixes an issue with checkboxes still being checked after refresh in FireFox

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
@@ -1,4 +1,13 @@
 sirius.ready(function () {
+    // FireFox Fix: If a checkbox has been checked and someone refreshes the page, that checkbox is still checked
+    // without triggering a change event. Therefore, we are manually clearing all checkboxes on page load.
+    document.querySelectorAll('.select-table-row-checkbox-js:checked').forEach(function (_checkbox) {
+        _checkbox.checked = false;
+    });
+    document.querySelectorAll('.select-all-visible-table-rows-checkbox-js:checked').forEach(function (_selectAllCheckbox) {
+        _selectAllCheckbox.checked = false;
+    });
+
     document.querySelectorAll('.select-all-visible-table-rows-checkbox-js').forEach(function (_selectAllCheckbox) {
         const _table = _selectAllCheckbox.closest('table');
         // Handle changing the state of the select-all checkbox found in the table head row


### PR DESCRIPTION
FireFox decides to keep the former state of the checkboxes. Sadly without triggering a change event. Therefore, we manually have to clear the checkboxes on sirius.ready. This is fine since this behavior was "extra" all along as any other browser is not keeping the state of input fields...

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11093](https://scireum.myjetbrains.com/youtrack/issue/OX-11093)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

