### PR TITLE
CSS Design System - Improve calculation of pill border radius

### DIFF
--- a/src/main/resources/assets/design-system/design-system.scss
+++ b/src/main/resources/assets/design-system/design-system.scss
@@ -5,8 +5,8 @@ $lg-min-width: 1200px;
 :root {
   --sci-base-unit: 16px;
   // Defines the border radius for design elements like buttons, inputs, cards, etc.
-  --sci-border-radius: calc(0.25 * var(--sci-base-unit));
-  --sci-border-width: calc(0.125 * var(--sci-base-unit));
+  --sci-border-radius: calc(0.25 * var(--sci-base-unit)); // Default: 4px / 0.25rem
+  --sci-border-width: calc(0.125 * var(--sci-base-unit)); // Default: 2px / 0.125rem
 }
 
 @import "/assets/tycho/styles/sirius-colors";

--- a/src/main/resources/assets/design-system/margin-padding.scss
+++ b/src/main/resources/assets/design-system/margin-padding.scss
@@ -1,8 +1,9 @@
 :root {
-  --sci-margin-1: calc(0.5 * var(--sci-base-unit)); // 8px / 0.5rem
-  --sci-margin-2: calc(2 * var(--sci-margin-1)); // 16px / 1rem
-  --sci-margin-3: calc(3 * var(--sci-margin-1)); // 24px / 1.5rem
-  --sci-margin-4: calc(4 * var(--sci-margin-1)); // 32px / 2rem
+  --sci-margin-1: calc(0.5 * var(--sci-base-unit)); // Default: 8px / 0.5rem
+  --sci-margin-05: calc(0.5 * var(--sci-margin-1)); // Default: 4px / 0.25rem
+  --sci-margin-2: calc(2 * var(--sci-margin-1)); // Default: 16px / 1rem
+  --sci-margin-3: calc(3 * var(--sci-margin-1)); // Default: 24px / 1.5rem
+  --sci-margin-4: calc(4 * var(--sci-margin-1)); // Default: 32px / 2rem
 }
 
 .sci-m-1 {

--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -227,8 +227,9 @@
 }
 
 .sci-pill {
-  padding: calc(0.25 * var(--sci-base-unit)) calc(0.5 * var(--sci-base-unit));
-  border-radius: calc(4 * var(--sci-border-radius));
+  padding: var(--sci-margin-05) var(--sci-margin-1);
+  // Set radius to half of font size + padding, resulting in a pill shape that doesn't get distorted
+  border-radius: calc((var(--sci-font-size-smaller) + var(--sci-margin-1)) / 2);
 
   font-size: var(--sci-font-size-smaller);
   line-height: 1;

--- a/src/main/resources/assets/design-system/text.scss
+++ b/src/main/resources/assets/design-system/text.scss
@@ -1,13 +1,13 @@
 :root {
-  --sci-font-size-base: var(--sci-base-unit);
-  --sci-font-size-smallest: calc(0.7 * var(--sci-font-size-base));
-  --sci-font-size-smaller: calc(0.9 * var(--sci-font-size-base));
-  --sci-font-size-larger: calc(1.25 * var(--sci-font-size-base));
-  --sci-font-size-h1: calc(2.25 * var(--sci-font-size-base));
-  --sci-font-size-h2: calc(1.75 * var(--sci-font-size-base));
-  --sci-font-size-h3: calc(1.5 * var(--sci-font-size-base));
-  --sci-font-size-h4: calc(1.25 * var(--sci-font-size-base));
-  --sci-font-size-h5: calc(1.1 * var(--sci-font-size-base));
+  --sci-font-size-base: var(--sci-base-unit); // Default: 16px / 1rem
+  --sci-font-size-smallest: calc(0.7 * var(--sci-font-size-base));  // Default: 11.2px / 0.7rem
+  --sci-font-size-smaller: calc(0.9 * var(--sci-font-size-base)); // Default: 14.4px / 0.9rem
+  --sci-font-size-larger: calc(1.25 * var(--sci-font-size-base)); // Default: 20px / 1.25rem
+  --sci-font-size-h1: calc(2.25 * var(--sci-font-size-base)); // Default: 36px / 2.25rem
+  --sci-font-size-h2: calc(1.75 * var(--sci-font-size-base)); // Default: 28px / 1.75rem
+  --sci-font-size-h3: calc(1.5 * var(--sci-font-size-base)); // Default: 24px / 1.5rem
+  --sci-font-size-h4: calc(1.25 * var(--sci-font-size-base)); // Default: 20px / 1.25rem
+  --sci-font-size-h5: calc(1.1 * var(--sci-font-size-base)); // Default: 17.6px / 1.1rem
 }
 
 .sci-enable-font {


### PR DESCRIPTION
### Description
The shape was actually correct as browsers cap the applied border radius to half the height, but this should ensure proper behaviour when overriding font size or base unit.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11040](https://scireum.myjetbrains.com/youtrack/issue/OX-11040)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
