### PR TITLE
Tycho - Allow to control precision of date time field

### DIFF
--- a/src/main/resources/default/taglib/t/dateTimeField.html.pasta
+++ b/src/main/resources/default/taglib/t/dateTimeField.html.pasta
@@ -15,6 +15,7 @@
 <i:arg name="readonly" type="boolean" default="false"/>
 <i:arg name="min" type="String" default="1900-01-01T00:00:00"/>
 <i:arg name="max" type="String" default="2100-12-31T00:00:00"/>
+<i:arg name="step" type="int" default="60"/>
 
 <i:pragma name="description" value="Renders a date and time input field within a Tycho template"/>
 
@@ -31,6 +32,7 @@
                class="form-control input-block-level"
                min="@min"
                max="@max"
+               step="@step"
                @if (isFilled(placeholder)) { placeholder="@placeholder" }
                @if (readonly) { disabled readonly }/>
     </div>


### PR DESCRIPTION
### Description

By default the step setting of datetime-local inputs is 60 (seconds), which means seconds are hidden by default and can't be altered. This may be (and is) required in some cases.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11656](https://scireum.myjetbrains.com/youtrack/issue/OX-11656)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/11715

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
