### PR TITLE
fix css for sticky t:searchHeader on small screens

### DIFF
--- a/src/main/resources/default/taglib/t/searchHeader.html.pasta
+++ b/src/main/resources/default/taglib/t/searchHeader.html.pasta
@@ -9,7 +9,7 @@
     Renders a search bar to be used above a table or a list of data cards.
 </i:pragma>
 
-<div class="search-header-js card shadow-sm mb-4 @if(sticky) { sticky-md-top }" @if(sticky) { style="z-index: 999;" }>
+<div class="search-header-js card shadow-sm mb-4 @if(sticky) { sticky-top }" @if(sticky) { style="z-index: 999;" }>
     <div class="card-body">
         <div class="row">
             <div class="col flex-grow-1 @class">


### PR DESCRIPTION
### Description
with md it does not work on small screeens and also moves the search-line some ugly pixels down over content (see screenshot)
<img width="681" alt="Bildschirmfoto 2024-11-11 um 21 14 50" src="https://github.com/user-attachments/assets/26b99396-379b-44b2-8a1f-81581d57aa20">

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14153](https://scireum.myjetbrains.com/youtrack/issue/SE-14153)
- This PR is related to PR: #1473  <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
