### PR TITLE
Support the use of URLSearchParams and String in sirius.postJson

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -260,12 +260,13 @@ sirius.getJSON = function (url, params) {
  * Calls the given URL, posts the given params and retrieves the resulting JSON.
  * <p>
  * The parameters can either be specified as an object with key-value pairs (where the value is either a string or an
- * array of strings), or directly as a URLSearchParams.
+ * array of strings), directly as a URLSearchParams, or as a query string.
  *
- * @param url the URL to invoke
- * @param params the parameters to send POST data (parameters with 'undefined' values are not sent to the server)
- * @param [useSearchParams] if true, the parameters are sent as URLSearchParams instead of FormData. If the parameters
- *        are specified as URLSearchParams or query string, this is ignored
+ * @param {RequestInfo|URL} url the URL to invoke
+ * @param {Object|string|URLSearchParams} params the parameters to send POST data (parameters with 'undefined' values
+ *        are not sent to the server)
+ * @param {boolean} [useSearchParams] if true, the parameters are sent as URLSearchParams instead of FormData. If the
+ *        parameters are specified as URLSearchParams or query string, this is ignored
  * @returns {Promise<any>} the received JSON data
  */
 sirius.postJson = function (url, params, useSearchParams) {

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -258,19 +258,29 @@ sirius.getJSON = function (url, params) {
 
 /**@
  * Calls the given URL, posts the given params and retrieves the resulting JSON.
+ * <p>
+ * The parameters can either be specified as an object with key-value pairs (where the value is either a string or an
+ * array of strings), or directly as a URLSearchParams.
  *
  * @param url the URL to invoke
  * @param params the parameters to send POST data (parameters with 'undefined' values are not sent to the server)
- * @param [useSearchParams] if true, the parameters are sent as URLSearchParams instead of FormData
+ * @param [useSearchParams] if true, the parameters are sent as URLSearchParams instead of FormData. If the parameters
+ *        are specified as URLSearchParams they are always sent as such.
  * @returns {Promise<any>} the received JSON data
  */
 sirius.postJson = function (url, params, useSearchParams) {
-    let body = sirius.convertObjectToFormData(params);
-    if (useSearchParams) {
+    let body;
+
+    if (typeof params === 'string' || params instanceof URLSearchParams) {
+        body = params;
+    } else if (useSearchParams) {
         // Convert the body to URLSearchParams, this may be necessary when using problematic characters in field names
         // that are converted/replaced by the multipart decoder of Netty.
-        body = new URLSearchParams(body);
+        body = new URLSearchParams(sirius.convertObjectToFormData(params));
+    } else {
+        body = sirius.convertObjectToFormData(params);
     }
+
     return fetch(url, {
         method: "post",
         body: body

--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -265,7 +265,7 @@ sirius.getJSON = function (url, params) {
  * @param url the URL to invoke
  * @param params the parameters to send POST data (parameters with 'undefined' values are not sent to the server)
  * @param [useSearchParams] if true, the parameters are sent as URLSearchParams instead of FormData. If the parameters
- *        are specified as URLSearchParams they are always sent as such.
+ *        are specified as URLSearchParams or query string, this is ignored
  * @returns {Promise<any>} the received JSON data
  */
 sirius.postJson = function (url, params, useSearchParams) {

--- a/src/main/resources/default/assets/common/ie-polyfill.js.pasta
+++ b/src/main/resources/default/assets/common/ie-polyfill.js.pasta
@@ -4,8 +4,8 @@
 
 ___invoke("/assets/common/common-polyfills.js.pasta")
 ___include("/assets/common/libs/es6-promise/es6-promise.min.js")
-___include("/assets/common/libs/fetch/fetch.umd.js")
 ___include("/assets/common/libs/url-search-params/url-search-params.js")
 ___include("/assets/common/libs/formdata/formdata.min.js")
+___include("/assets/common/libs/fetch/fetch.umd.js")
 ___include("/assets/common/libs/remove/remove.js")
 ___include("/assets/common/libs/ie11CustomProperties/ie11CustomProperties.js")


### PR DESCRIPTION
### Description
This allows the use of `URLSearchParams` and `String` as the 'params' parameter in `sirius.postJson`, which sometimes are easier to build than an object.

The second commit allows `URLSearchParams` in the `fetch` polyfill.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14122](https://scireum.myjetbrains.com/youtrack/issue/SE-14122)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
