### PR TITLE
Makes the searchHeader sticky by default

### DIFF
--- a/src/main/resources/default/taglib/t/searchHeader.html.pasta
+++ b/src/main/resources/default/taglib/t/searchHeader.html.pasta
@@ -2,7 +2,7 @@
 <i:arg name="baseUrl" type="String"/>
 <i:arg name="class" type="String" default=""/>
 <i:arg name="suppressSearch" type="boolean" default="false"/>
-<i:arg name="sticky" type="boolean" default="false" description="Specifies if the search header should be sticky." />
+<i:arg name="sticky" type="boolean" default="true" description="Specifies if the search header should be sticky." />
 
 
 <i:pragma name="description">


### PR DESCRIPTION
- Changed the default behavior of the searchHeader as it is now sticky

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1034](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1034)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

