### PR TITLE
Upgrade library versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ clone:
 
 steps:
   - name: compile
-    image: scireum/sirius-build-jdk22
+    image: scireum/sirius-build-jdk23
     commands:
       - mvn clean compile
     volumes: *scireum_volumes
@@ -28,7 +28,7 @@ steps:
         - push
 
   - name: cron_unit_tests
-    image: scireum/sirius-build-jdk22
+    image: scireum/sirius-build-jdk23
     commands:
       - mvn clean test -Dsun.net.http.allowRestrictedHeaders=true
     volumes: *scireum_volumes
@@ -48,7 +48,7 @@ steps:
         - cron
 
   - name: test
-    image: scireum/sirius-build-jdk22
+    image: scireum/sirius-build-jdk23
     commands:
       - mvn clean test -Dtest.excluded.groups=nightly -Dsun.net.http.allowRestrictedHeaders=true
     volumes: *scireum_volumes
@@ -57,7 +57,7 @@ steps:
         - pull_request
 
   - name: deploy
-    image: scireum/sirius-build-jdk22
+    image: scireum/sirius-build-jdk23
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean deploy -DskipTests
@@ -77,7 +77,7 @@ steps:
         - tag
 
   - name: sonar
-    image: scireum/sirius-build-jdk22
+    image: scireum/sirius-build-jdk23
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report sonar:sonar -Dsonar.projectKey=${DRONE_REPO_NAME} -Dsun.net.http.allowRestrictedHeaders=true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>12.1.1</version>
+        <version>13.0.0</version>
     </parent>
     <artifactId>sirius-web</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>dev-43.1.0</sirius.kernel>
+        <sirius.kernel>dev-44.0.0</sirius.kernel>
     </properties>
 
     <repositories>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>
-            <version>9.11.1</version>
+            <version>9.11.2</version>
         </dependency>
 
         <!-- Used to clean HTML before generating PDF -->

--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,14 @@
         <dependency>
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>
-            <version>9.8.0</version>
+            <version>9.11.1</version>
         </dependency>
 
         <!-- Used to clean HTML before generating PDF -->
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.17.2</version>
+            <version>1.18.3</version>
         </dependency>
 
         <!-- Used to render SVG into PDF -->
@@ -118,30 +118,18 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.2.5</version>
+            <version>5.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.2.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- Required, as the version provided by poi-ooxml has security issues -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.26.1</version>
+            <version>5.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.pjfanning</groupId>
             <artifactId>excel-streaming-reader</artifactId>
-            <version>4.3.1</version>
+            <version>5.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.h2database</groupId>
@@ -154,7 +142,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.22</version>
+            <version>2.2.26</version>
         </dependency>
 
         <dependency>
@@ -170,7 +158,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.109.Final</version>
+                <version>4.1.115.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -563,7 +563,11 @@ public class ExcelExport {
             throw Exceptions.handle(e);
         } finally {
             if (workbook instanceof SXSSFWorkbook sxssfWorkbook) {
-                sxssfWorkbook.dispose();
+                try {
+                    sxssfWorkbook.close();
+                } catch (IOException e) {
+                    throw Exceptions.handle(e);
+                }
             }
         }
     }

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -125,8 +125,8 @@ public class ExcelExport {
             this.colWidthInPixel = colWidthInPixel;
             try {
                 determineImageSize(fileData);
-            } catch (IOException e) {
-                throw Exceptions.handle(e);
+            } catch (IOException exception) {
+                throw Exceptions.handle(exception);
             }
         }
 
@@ -382,8 +382,8 @@ public class ExcelExport {
                                             .collect(Collectors.joining(", ")));
                     return;
                 }
-            } catch (SQLException e) {
-                Exceptions.ignore(e);
+            } catch (SQLException exception) {
+                Exceptions.ignore(exception);
             }
         }
         cell.setCellValue(createRichTextString(obj.toString()));
@@ -559,14 +559,14 @@ public class ExcelExport {
                 }
                 workbook.write(out);
             }
-        } catch (IOException e) {
-            throw Exceptions.handle(e);
+        } catch (IOException exception) {
+            throw Exceptions.handle(exception);
         } finally {
             if (workbook instanceof SXSSFWorkbook sxssfWorkbook) {
                 try {
                     sxssfWorkbook.close();
-                } catch (IOException e) {
-                    throw Exceptions.handle(e);
+                } catch (IOException exception) {
+                    throw Exceptions.handle(exception);
                 }
             }
         }

--- a/src/main/java/sirius/web/templates/pdf/InlinedSvgElement.java
+++ b/src/main/java/sirius/web/templates/pdf/InlinedSvgElement.java
@@ -68,10 +68,10 @@ public class InlinedSvgElement implements ITextReplacedElement {
         graphics.dispose();
 
         PageBox page = renderingContext.getPage();
-        float x = (float) blockBox.getAbsX() + page.getMarginBorderPadding(renderingContext, CalculatedStyle.LEFT);
+        float x = (float) blockBox.getAbsX() + page.getMarginBorderPadding(renderingContext, CalculatedStyle.Edge.LEFT);
         float y = (float) (page.getBottom() - (blockBox.getAbsY() + cssHeight)) + page.getMarginBorderPadding(
                 renderingContext,
-                CalculatedStyle.BOTTOM);
+                CalculatedStyle.Edge.BOTTOM);
         x /= outputDevice.getDotsPerPoint();
         y /= outputDevice.getDotsPerPoint();
 

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -49,7 +49,7 @@ public class BarcodePdfReplaceHandler extends PdfReplaceHandler {
         FSImage fsImage = new ITextFSImage(com.lowagie.text.Image.getInstance(awtImage, Color.WHITE, true));
 
         if (cssWidth != -1 || cssHeight != -1) {
-            fsImage.scale(cssWidth, cssHeight);
+            return fsImage.scale(cssWidth, cssHeight);
         }
 
         return fsImage;

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -95,7 +95,7 @@ public abstract class PdfReplaceHandler implements Priorized {
             Tuple<Integer, Integer> newSize = computeResizeBox(cssWidth, cssHeight, image);
 
             if (newSize != null) {
-                image.scale(newSize.getFirst(), newSize.getSecond());
+                return image.scale(newSize.getFirst(), newSize.getSecond());
             }
         }
 

--- a/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
@@ -51,7 +51,7 @@ public class QrCodePdfReplaceHandler extends PdfReplaceHandler {
         FSImage fsImage = new ITextFSImage(Image.getInstance(MatrixToImageWriter.toBufferedImage(matrix), Color.WHITE));
 
         if (cssWidth != -1 || cssHeight != -1) {
-            fsImage.scale(cssWidth, cssHeight);
+            return fsImage.scale(cssWidth, cssHeight);
         }
 
         return fsImage;

--- a/src/test/kotlin/sirius/web/templates/pdf/handlers/PdfReplaceHandlerTest.kt
+++ b/src/test/kotlin/sirius/web/templates/pdf/handlers/PdfReplaceHandlerTest.kt
@@ -15,7 +15,6 @@ import org.xhtmlrenderer.pdf.ITextFSImage
 import sirius.kernel.SiriusExtension
 import kotlin.test.assertEquals
 
-@ExtendWith(SiriusExtension::class)
 class PdfReplaceHandlerTest {
 
     @Test


### PR DESCRIPTION
### Description
Fixes: SIRI-1036
Wait for https://github.com/scireum/sirius-parent/pull/45 and https://github.com/scireum/sirius-kernel/pull/542

**BREAKING CHANGES:**
- org.xhtmlrenderer.extend.FSImage#scale now operates immutable. Means you need to use the returned value. 

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1036](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1036)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
