### PR TITLE
Sets cache headers for non cached redirect URLs

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -822,7 +822,8 @@ public class Response {
     private void performRedirect(String url, HttpResponseStatus status) {
         if (cacheSeconds == null || cacheSeconds == 0) {
             userMessagesCache.cacheUserMessages(webContext);
-        } else {
+        }
+        if (cacheSeconds != null) {
             setDateAndCacheHeaders(System.currentTimeMillis(), cacheSeconds, isPrivate);
         }
 


### PR DESCRIPTION
### Description

When creating a response marked as not cached (cacheSeconds = 0), no cache headers were added to the response.
With this change, `cache-control: no-cache, max-age=0` will be added to the response headers.
Of course this header is suppressed when no caching time is present.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11230](https://scireum.myjetbrains.com/youtrack/issue/OX-11230)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
