### PR TITLE
Fix a potential XXE Vulnerability

### DIFF
--- a/src/main/java/sirius/pasta/noodle/macros/XmlProcessingMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/XmlProcessingMacro.java
@@ -18,6 +18,7 @@ import sirius.kernel.health.HandledException;
 import sirius.web.resources.Resource;
 
 import javax.annotation.Nullable;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -104,6 +105,7 @@ public abstract class XmlProcessingMacro extends BasicMacro {
     protected Document parseDocument(InputSource source, @Nullable String expectedRootElement) {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             Document document = factory.newDocumentBuilder().parse(source);
 
             if (Strings.isFilled(expectedRootElement) && !Strings.areEqual(expectedRootElement,

--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -27,6 +27,7 @@ import sirius.web.http.WebContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.xml.XMLConstants;
 import javax.xml.crypto.AlgorithmMethod;
 import javax.xml.crypto.KeySelector;
 import javax.xml.crypto.KeySelectorException;
@@ -256,6 +257,7 @@ public class SAMLHelper {
     private Document getResponseDocument(InputStream inputStream)
             throws SAXException, IOException, ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setNamespaceAware(true);
         return factory.newDocumentBuilder().parse(inputStream);
     }

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -22,6 +22,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.web.templates.pdf.handlers.PdfReplaceHandler;
 
 import javax.annotation.Nonnull;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -84,6 +85,7 @@ public class ImageReplacedElementFactory extends ITextReplacedElementFactory {
 
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+            documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 
             Document svgDocument = documentBuilder.newDocument();


### PR DESCRIPTION
### Description
Fix a potential XXE vulnerability via setting Feature Secure Processing
https://docs.oracle.com/javase/8/docs/technotes/guides/security/jaxp/jaxp.html#feature-for-secure-processing
Nicer and more current documentation:
https://docs.oracle.com/en/java/javase/23/security/java-api-xml-processing-jaxp-security-guide.html
In a nutshell, this prevents access to external entities and set limit while processing xml. As this feature is rarely required and the limits are reasonable high, we expect no problems. But testing the xml processing in products is recommended, after this change got included. 
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1037](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1037)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise --> https://github.com/scireum/sirius-kernel/pull/543

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
