### PR TITLE
Adds sci-preloader-small

### DIFF
--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -296,9 +296,12 @@
 }
 
 .sci-preloader {
+  --preloader-size: calc(3 * var(--sci-base-unit)); /* Default size */
+  --preloader-border-width: calc(0.2 * var(--sci-base-unit)); /* Default border width */
+
   position: relative;
-  height: calc(3 * var(--sci-base-unit));
-  width: calc(3 * var(--sci-base-unit));
+  height: var(--preloader-size);
+  width: var(--preloader-size);
 }
 
 .sci-preloader::before {
@@ -307,15 +310,21 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: calc(3 * var(--sci-base-unit));
-  height: calc(3 * var(--sci-base-unit));
-  margin-top: calc(-1.5 * var(--sci-base-unit));
-  margin-left: calc(-1.5 * var(--sci-base-unit));
+  width: var(--preloader-size);
+  height: var(--preloader-size);
+  margin-top: calc(-1 * var(--preloader-size) / 2);
+  margin-left: calc(-1 * var(--preloader-size) / 2);
   border-radius: 50%;
-  border-top: calc(0.2 * var(--sci-base-unit)) solid $sirius-gray;
-  border-right: calc(0.2 * var(--sci-base-unit)) solid transparent;
+  border-top: var(--preloader-border-width) solid $sirius-gray;
+  border-right: var(--preloader-border-width) solid transparent;
   animation: sciPreloader 1s linear infinite;
 }
+
+.sci-preloader-small {
+  --preloader-size: calc(2 * var(--sci-base-unit));
+  --preloader-border-width: calc(0.15 * var(--sci-base-unit));
+}
+
 
 @keyframes sciPreloader {
   to {

--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -297,7 +297,7 @@
 
 .sci-preloader {
   --preloader-size: calc(3 * var(--sci-base-unit)); /* Default size */
-  --preloader-border-width: calc(0.2 * var(--sci-base-unit)); /* Default border width */
+  --preloader-border-width: calc(var(--preloader-size) * (0.2 / 3));
 
   position: relative;
   height: var(--preloader-size);
@@ -321,9 +321,10 @@
 }
 
 .sci-preloader-small {
-  --preloader-size: calc(2 * var(--sci-base-unit));
-  --preloader-border-width: calc(0.15 * var(--sci-base-unit));
+  --preloader-size: calc(2 * var(--sci-base-unit)); /* Smaller size */
+  /* No need to redefine --preloader-border-width; it adjusts automatically */
 }
+
 
 @keyframes sciPreloader {
   to {

--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -325,7 +325,6 @@
   --preloader-border-width: calc(0.15 * var(--sci-base-unit));
 }
 
-
 @keyframes sciPreloader {
   to {
     transform: rotate(360deg);


### PR DESCRIPTION
A sightly smaller version of the preloader which can be used in tighter spaces
![Bildschirmfoto 2024-12-09 um 16 30 10](https://github.com/user-attachments/assets/8fe354eb-db3b-4132-b497-c3f425c621c5)


### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11681](https://scireum.myjetbrains.com/youtrack/issue/OX-11681)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

