### PR TITLE
Design System: Fix the class names with decimal point

### DIFF
--- a/src/main/java/sirius/web/sass/Parser.java
+++ b/src/main/java/sirius/web/sass/Parser.java
@@ -117,8 +117,8 @@ public class Parser {
             if (super.isIdentifierChar(current)) {
                 return true;
             }
-            // CSS selectors can contain "-", "." or "#" as long as it is not the last character of the token
-            return (current.is('-') || current.is('.') || current.is('#')) && !input.next().isWhitespace();
+            // CSS selectors can contain "-", ".", "#", or "\" as long as it is not the last character of the token
+            return current.is('-', '.', '#', '\\') && !input.next().isWhitespace();
         }
 
         @Override

--- a/src/main/resources/assets/design-system/grid.scss
+++ b/src/main/resources/assets/design-system/grid.scss
@@ -6,9 +6,9 @@
   display: flex;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin-right: -var(--sci-grid-gap);
-  margin-left: -var(--sci-grid-gap);
-  margin-bottom: -var(--sci-grid-gap);
+  margin-right: calc(-1 * var(--sci-grid-gap));
+  margin-left: calc(-1 * var(--sci-grid-gap));
+  margin-bottom: calc(-1 * var(--sci-grid-gap));
 }
 
 .sci-grid-auto, .sci-grid-5, .sci-grid-4, .sci-grid-3, .sci-grid-2, .sci-grid-1,
@@ -20,9 +20,9 @@
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   align-items: stretch;
-  margin-left: -var(--sci-grid-gap);
-  margin-right: -var(--sci-grid-gap);
-  margin-bottom: -var(--sci-grid-gap);
+  margin-left: calc(-1 * var(--sci-grid-gap));
+  margin-right: calc(-1 * var(--sci-grid-gap));
+  margin-bottom: calc(-1 * var(--sci-grid-gap));
 
   .sci-grid-cell {
     position: relative;

--- a/src/main/resources/assets/design-system/margin-padding.scss
+++ b/src/main/resources/assets/design-system/margin-padding.scss
@@ -7,7 +7,7 @@
   --sci-margin-4: calc(4 * var(--sci-margin-1)); // Default: 32px / 2rem
 }
 
-.sci-m-0.5 {
+.sci-m-0\.5 {
   margin: var(--sci-margin-0_5);
 }
 
@@ -15,7 +15,7 @@
   margin: var(--sci-margin-1);
 }
 
-.sci-m-1.5 {
+.sci-m-1\.5 {
   margin: var(--sci-margin-1_5);
 }
 
@@ -31,7 +31,7 @@
   margin: var(--sci-margin-4);
 }
 
-.sci-mt-0.5 {
+.sci-mt-0\.5 {
   margin-top: var(--sci-margin-0_5);
 }
 
@@ -39,7 +39,7 @@
   margin-top: var(--sci-margin-1);
 }
 
-.sci-mt-1.5 {
+.sci-mt-1\.5 {
   margin-top: var(--sci-margin-1_5);
 }
 
@@ -55,7 +55,7 @@
   margin-top: var(--sci-margin-4);
 }
 
-.sci-mr-0.5, .sci-me-0.5 {
+.sci-mr-0.5, .sci-me-0\.5 {
   margin-right: var(--sci-margin-0_5);
 }
 
@@ -63,7 +63,7 @@
   margin-right: var(--sci-margin-1);
 }
 
-.sci-mr-1.5, .sci-me-1.5 {
+.sci-mr-1.5, .sci-me-1\.5 {
   margin-right: var(--sci-margin-1_5);
 }
 
@@ -79,7 +79,7 @@
   margin-right: var(--sci-margin-4);
 }
 
-.sci-mb-0.5 {
+.sci-mb-0\.5 {
   margin-bottom: var(--sci-margin-0_5);
 }
 
@@ -87,7 +87,7 @@
   margin-bottom: var(--sci-margin-1);
 }
 
-.sci-mb-1.5 {
+.sci-mb-1\.5 {
   margin-bottom: var(--sci-margin-1_5);
 }
 
@@ -103,7 +103,7 @@
   margin-bottom: var(--sci-margin-4);
 }
 
-.sci-ml-0.5, .sci-ms-0.5 {
+.sci-ml-0.5, .sci-ms-0\.5 {
   margin-left: var(--sci-margin-0_5);
 }
 
@@ -111,7 +111,7 @@
   margin-left: var(--sci-margin-1);
 }
 
-.sci-ml-1.5, .sci-ms-1.5 {
+.sci-ml-1.5, .sci-ms-1\.5 {
   margin-left: var(--sci-margin-1_5);
 }
 
@@ -127,7 +127,7 @@
   margin-left: var(--sci-margin-4);
 }
 
-.sci-p-0.5 {
+.sci-p-0\.5 {
   padding: var(--sci-margin-0_5);
 }
 
@@ -135,7 +135,7 @@
   padding: var(--sci-margin-1);
 }
 
-.sci-p-1.5 {
+.sci-p-1\.5 {
   padding: var(--sci-margin-1_5);
 }
 
@@ -151,7 +151,7 @@
   padding: var(--sci-margin-4);
 }
 
-.sci-pt-0.5 {
+.sci-pt-0\.5 {
   padding-top: var(--sci-margin-0_5);
 }
 
@@ -159,7 +159,7 @@
   padding-top: var(--sci-margin-1);
 }
 
-.sci-pt-1.5 {
+.sci-pt-1\.5 {
   padding-top: var(--sci-margin-1_5);
 }
 
@@ -175,7 +175,7 @@
   padding-top: var(--sci-margin-4);
 }
 
-.sci-pr-0.5, .sci-pe-0.5 {
+.sci-pr-0.5, .sci-pe-0\.5 {
   padding-right: var(--sci-margin-0_5);
 }
 
@@ -183,7 +183,7 @@
   padding-right: var(--sci-margin-1);
 }
 
-.sci-pr-1.5, .sci-pe-1.5 {
+.sci-pr-1.5, .sci-pe-1\.5 {
   padding-right: var(--sci-margin-1_5);
 }
 
@@ -199,7 +199,7 @@
   padding-right: var(--sci-margin-4);
 }
 
-.sci-pb-0.5 {
+.sci-pb-0\.5 {
   padding-bottom: var(--sci-margin-0_5);
 }
 
@@ -207,7 +207,7 @@
   padding-bottom: var(--sci-margin-1);
 }
 
-.sci-pb-1.5 {
+.sci-pb-1\.5 {
   padding-bottom: var(--sci-margin-1_5);
 }
 
@@ -223,7 +223,7 @@
   padding-bottom: var(--sci-margin-4);
 }
 
-.sci-pl-0.5, .sci-ps-0.5 {
+.sci-pl-0.5, .sci-ps-0\.5 {
   padding-left: var(--sci-margin-0_5);
 }
 
@@ -231,7 +231,7 @@
   padding-left: var(--sci-margin-1);
 }
 
-.sci-pl-1.5, .sci-ps-1.5 {
+.sci-pl-1.5, .sci-ps-1\.5 {
   padding-left: var(--sci-margin-1_5);
 }
 
@@ -247,7 +247,7 @@
   padding-left: var(--sci-margin-4);
 }
 
-.sci-gap-0.5 {
+.sci-gap-0\.5 {
   gap: var(--sci-margin-0_5);
 }
 
@@ -255,7 +255,7 @@
   gap: var(--sci-margin-1);
 }
 
-.sci-gap-1.5 {
+.sci-gap-1\.5 {
   gap: var(--sci-margin-1_5);
 }
 
@@ -271,7 +271,7 @@
   gap: var(--sci-margin-4);
 }
 
-.sci-column-gap-0.5 {
+.sci-column-gap-0\.5 {
   column-gap: var(--sci-margin-0_5);
 }
 
@@ -279,7 +279,7 @@
   column-gap: var(--sci-margin-1);
 }
 
-.sci-column-gap-1.5 {
+.sci-column-gap-1\.5 {
   column-gap: var(--sci-margin-1_5);
 }
 
@@ -295,7 +295,7 @@
   column-gap: var(--sci-margin-4);
 }
 
-.sci-row-gap-0.5 {
+.sci-row-gap-0\.5 {
   row-gap: var(--sci-margin-0_5);
 }
 
@@ -303,7 +303,7 @@
   row-gap: var(--sci-margin-1);
 }
 
-.sci-row-gap-1.5 {
+.sci-row-gap-1\.5 {
   row-gap: var(--sci-margin-1_5);
 }
 

--- a/src/main/resources/assets/design-system/margin-padding.scss
+++ b/src/main/resources/assets/design-system/margin-padding.scss
@@ -55,7 +55,7 @@
   margin-top: var(--sci-margin-4);
 }
 
-.sci-mr-0.5, .sci-me-0\.5 {
+.sci-mr-0\.5, .sci-me-0\.5 {
   margin-right: var(--sci-margin-0_5);
 }
 
@@ -63,7 +63,7 @@
   margin-right: var(--sci-margin-1);
 }
 
-.sci-mr-1.5, .sci-me-1\.5 {
+.sci-mr-1\.5, .sci-me-1\.5 {
   margin-right: var(--sci-margin-1_5);
 }
 
@@ -103,7 +103,7 @@
   margin-bottom: var(--sci-margin-4);
 }
 
-.sci-ml-0.5, .sci-ms-0\.5 {
+.sci-ml-0\.5, .sci-ms-0\.5 {
   margin-left: var(--sci-margin-0_5);
 }
 
@@ -111,7 +111,7 @@
   margin-left: var(--sci-margin-1);
 }
 
-.sci-ml-1.5, .sci-ms-1\.5 {
+.sci-ml-1\.5, .sci-ms-1\.5 {
   margin-left: var(--sci-margin-1_5);
 }
 
@@ -175,7 +175,7 @@
   padding-top: var(--sci-margin-4);
 }
 
-.sci-pr-0.5, .sci-pe-0\.5 {
+.sci-pr-0\.5, .sci-pe-0\.5 {
   padding-right: var(--sci-margin-0_5);
 }
 
@@ -183,7 +183,7 @@
   padding-right: var(--sci-margin-1);
 }
 
-.sci-pr-1.5, .sci-pe-1\.5 {
+.sci-pr-1\.5, .sci-pe-1\.5 {
   padding-right: var(--sci-margin-1_5);
 }
 
@@ -223,7 +223,7 @@
   padding-bottom: var(--sci-margin-4);
 }
 
-.sci-pl-0.5, .sci-ps-0\.5 {
+.sci-pl-0\.5, .sci-ps-0\.5 {
   padding-left: var(--sci-margin-0_5);
 }
 
@@ -231,7 +231,7 @@
   padding-left: var(--sci-margin-1);
 }
 
-.sci-pl-1.5, .sci-ps-1\.5 {
+.sci-pl-1\.5, .sci-ps-1\.5 {
   padding-left: var(--sci-margin-1_5);
 }
 

--- a/src/main/resources/assets/design-system/misc.scss
+++ b/src/main/resources/assets/design-system/misc.scss
@@ -153,7 +153,7 @@
   border-right: 0 !important;
 }
 
-.sci-border-solid-0.5 {
+.sci-border-solid-0\.5 {
   border-width: var(--sci-border-width-0_5);
   border-style: solid;
 }
@@ -168,7 +168,7 @@
   border-style: solid;
 }
 
-.sci-border-top-solid-0.5 {
+.sci-border-top-solid-0\.5 {
   border-top-width: var(--sci-border-width-0_5);
   border-top-style: solid;
 }
@@ -183,7 +183,7 @@
   border-top-style: solid;
 }
 
-.sci-border-bottom-solid-0.5 {
+.sci-border-bottom-solid-0\.5 {
   border-bottom-width: var(--sci-border-width-0_5);
   border-bottom-style: solid;
 }
@@ -198,7 +198,7 @@
   border-bottom-style: solid;
 }
 
-.sci-border-left-solid-0.5 {
+.sci-border-left-solid-0\.5 {
   border-left-width: var(--sci-border-width-0_5);
   border-left-style: solid;
 }
@@ -213,7 +213,7 @@
   border-left-style: solid;
 }
 
-.sci-border-right-solid-0.5 {
+.sci-border-right-solid-0\.5 {
   border-right-width: var(--sci-border-width-0_5);
   border-right-style: solid;
 }


### PR DESCRIPTION
### Description
In class names like `sci-m-0.5` the period needs to be escaped, this adds support to the SASS parser and fixes all class names.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13735](https://scireum.myjetbrains.com/youtrack/issue/SE-13735)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
