### PR TITLE
SIRI-1044 Introduce a setting for SameSite on unsecure http

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1312,20 +1312,6 @@ public class WebContext implements SubContext {
     }
 
     /**
-     * Sets a cookie value to be sent back to the client
-     * <p>
-     * The generated cookie will be a session cookie and vanish once the user agent is closed
-     *
-     * @param name  the cookie to create
-     * @param value the contents of the cookie
-     * @deprecated Use {@link #setHTTPSessionCookie(String, String)} instead.
-     */
-    @Deprecated(since = "2023/08/08", forRemoval = true)
-    public void setSessionCookie(String name, String value) {
-        setCookie(name, value, Long.MIN_VALUE, sessionCookieSameSite, sessionCookieSecurity);
-    }
-
-    /**
      * Sets a http only cookie value to be sent back to the client.
      * <p>
      * The generated cookie will be a session cookie and vanish once the user agent is closed. Also, this cookie

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -330,6 +330,12 @@ public class WebContext implements SubContext {
     private static CookieHeaderNames.SameSite sessionCookieSameSite;
 
     /**
+     * The same site attribute of the Session Cookie for unsecure (i.e. http without SSL) connections
+     */
+    @ConfigValue("http.sessionCookie.sameSiteUnsecure")
+    private static CookieHeaderNames.SameSite sessionCookieSameSiteUnsecure;
+
+    /**
      * The same site attribute of the Session Cookie
      */
     @ConfigValue("http.sessionCookie.secure")
@@ -900,7 +906,7 @@ public class WebContext implements SubContext {
         setCookie(getSessionPinCookieName(),
                   givenSessionPin,
                   SESSION_PIN_COOKIE_TTL,
-                  sessionCookieSameSite,
+                  determineSessionCookieSameSite(),
                   sessionCookieSecurity);
     }
 
@@ -1335,7 +1341,7 @@ public class WebContext implements SubContext {
      * @param maxAgeSeconds contains the max age of this cookie in seconds
      */
     public void setHTTPCookie(String name, String value, long maxAgeSeconds) {
-        setCookie(name, value, maxAgeSeconds, sessionCookieSameSite, sessionCookieSecurity);
+        setCookie(name, value, maxAgeSeconds, determineSessionCookieSameSite(), sessionCookieSecurity);
     }
 
     /**
@@ -1460,7 +1466,11 @@ public class WebContext implements SubContext {
         if (ttl == 0) {
             setHTTPSessionCookie(sessionCookieName, protection + ":" + value);
         } else {
-            setCookie(sessionCookieName, protection + ":" + value, ttl, sessionCookieSameSite, sessionCookieSecurity);
+            setCookie(sessionCookieName,
+                      protection + ":" + value,
+                      ttl,
+                      determineSessionCookieSameSite(),
+                      sessionCookieSecurity);
         }
     }
 
@@ -1469,6 +1479,14 @@ public class WebContext implements SubContext {
             return sessionCookieTTL;
         }
         return defaultSessionCookieTTL.getSeconds();
+    }
+
+    private CookieHeaderNames.SameSite determineSessionCookieSameSite() {
+        if (isSSL()) {
+            return sessionCookieSameSite;
+        }
+
+        return sessionCookieSameSiteUnsecure;
     }
 
     /**

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -156,6 +156,10 @@ http {
         # Possible values are: Lax, Strict, None (see: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05)
         sameSite = "Lax"
 
+        # Determines the SameSite attribute of the session cookie for unsecure connections.
+        # Possible values are: Lax, Strict, None (see: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05)
+        sameSiteUnsecure = "Lax"
+
         # Determines whether the session cookie should be marked secure.
         # You probably want this, especially if you do not expect unsecure http connections without SSL.
         # Possible values are: ALWAYS_SECURE, NEVER, IF_SSL


### PR DESCRIPTION
### Description
A customer requires `SameSite=None`, which modern browsers no longer support without also setting `Secure`. Unfortunately, this customer still uses http without SSL for some internal services, which forbids the `Secure` attribute.

This introduces a separate setting for configuring the `SameSite` attribute for unsecure connections.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1044](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1044)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
