### PR TITLE
prevent scrolling to the fake-element inserted for copy-buttons

### DIFF
--- a/src/main/resources/default/assets/common/core.js.pasta
+++ b/src/main/resources/default/assets/common/core.js.pasta
@@ -917,7 +917,7 @@ sirius.copyToClipboard = function (textToCopy, _element) {
     _fakeElement.setAttribute('readonly', '');
     _fakeElement.value = textToCopy;
     document.body.appendChild(_fakeElement);
-    _fakeElement.focus();
+    _fakeElement.focus({preventScroll: true});
 
     var range = document.createRange();
     range.selectNodeContents(_fakeElement);


### PR DESCRIPTION
### Description
<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
The logic for copying values via copy-button is quiet weird, but "the-way-to-go" for all browsers and all cases (http, https).

in some rare cases (where scrollPaddingTop is set) the top-scroll value does not fit to the real scroll-position. So vie preventScroll we ask the browser to not scroll on focus. Is also not supported by all browsers, but does not break the functionality

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
