### PR TITLE
File Explorer - Fixes checkbox behaviour when using the back function of the browser

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
@@ -1,11 +1,13 @@
 sirius.ready(function () {
     // FireFox Fix: If a checkbox has been checked and someone refreshes the page, that checkbox is still checked
     // without triggering a change event. Therefore, we are manually clearing all checkboxes on page load.
-    document.querySelectorAll('.select-table-row-checkbox-js:checked').forEach(function (_checkbox) {
-        _checkbox.checked = false;
-    });
-    document.querySelectorAll('.select-all-visible-table-rows-checkbox-js:checked').forEach(function (_selectAllCheckbox) {
-        _selectAllCheckbox.checked = false;
+    window.addEventListener('pageshow',function (){
+        document.querySelectorAll('.select-table-row-checkbox-js:checked').forEach(function (_checkbox) {
+            _checkbox.checked = false;
+        });
+        document.querySelectorAll('.select-all-visible-table-rows-checkbox-js:checked').forEach(function (_selectAllCheckbox) {
+            _selectAllCheckbox.checked = false;
+        });
     });
 
     document.querySelectorAll('.select-all-visible-table-rows-checkbox-js').forEach(function (_selectAllCheckbox) {


### PR DESCRIPTION
### Description
Before:
![image](https://github.com/user-attachments/assets/649f59dd-6bb6-4f4e-883a-67b806cd9df2)

After:
![image](https://github.com/user-attachments/assets/3ed1572e-dea5-43ac-8044-943435a5a6a0)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11700](https://scireum.myjetbrains.com/youtrack/issue/OX-11700)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2094

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
