### PR TITLE
Permits to prevent responses from being crawled by search engines

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -444,6 +444,18 @@ public class Response {
                && ((WebServerHandler) channelHandlerContext.handler()).shouldKeepAlive();
     }
 
+    /**
+     * Prevents the response from being crawled by search engines.
+     * <p>
+     * There is no guarantee that search engines respect that, but big players like Google, Bing etc. do.
+     *
+     * @return the response itself for fluent method calls
+     */
+    public Response preventSearchEngineIndexing() {
+        addHeader("X-Robots-Tag", "noindex, nofollow");
+        return this;
+    }
+
     /*
      * Completes the response and closes the underlying channel if necessary
      */


### PR DESCRIPTION
### Description

There is no guarantee that search engines respect that, but big players like Google, Bing etc. do.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1049](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1049)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
