### PR TITLE
File Explorer - Changes the back function to clear the checkboxes of 'bg-sirius-blue-faint' and fixes behaviour of "more action"-button

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
@@ -4,6 +4,7 @@ sirius.ready(function () {
     window.addEventListener('pageshow',function (){
         document.querySelectorAll('.select-table-row-checkbox-js:checked').forEach(function (_checkbox) {
             _checkbox.checked = false;
+            toggleRowSelection(_checkbox);
         });
         document.querySelectorAll('.select-all-visible-table-rows-checkbox-js:checked').forEach(function (_selectAllCheckbox) {
             _selectAllCheckbox.checked = false;

--- a/src/main/resources/default/taglib/t/additionalActions.html.pasta
+++ b/src/main/resources/default/taglib/t/additionalActions.html.pasta
@@ -18,7 +18,8 @@
                 style="z-index: 3; position: relative"
                 data-bs-toggle="dropdown"
                 aria-haspopup="true"
-                aria-expanded="false">
+                aria-expanded="false"
+                onclick="event.stopPropagation()">
             <i:if test="isFilled(label)">
                 <span class="@labelClass pe-2">@label</span>
             </i:if>


### PR DESCRIPTION
### Description
Before:
![image](https://github.com/user-attachments/assets/387c7fe7-a430-4b9d-82da-4e7f6ced75d9)
![image](https://github.com/user-attachments/assets/8e5b1fcb-7e68-4640-a642-6bb3173e3360)

After:
![image](https://github.com/user-attachments/assets/b43f84d4-0d41-48eb-9184-873d5f8460c7)
![image](https://github.com/user-attachments/assets/be6cdda8-a3f2-482a-b12b-daf2252f9e7e)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11700](https://scireum.myjetbrains.com/youtrack/issue/OX-11700)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1503

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
