### PR TITLE
Tycho - Prevent extremely long title from breaking the layout

### DIFF
--- a/src/main/resources/default/assets/tycho/styles/page.scss
+++ b/src/main/resources/default/assets/tycho/styles/page.scss
@@ -109,7 +109,8 @@ nav.navbar {
     font-size: 2rem;
     font-weight: lighter;
     margin-bottom: 0px;
-    overflow-x: clip;
-    overflow-y: inherit;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 }

--- a/src/main/resources/default/taglib/t/pageHeader.html.pasta
+++ b/src/main/resources/default/taglib/t/pageHeader.html.pasta
@@ -20,7 +20,7 @@
                 <i class="fa-solid fa-bars"></i>
             </a>
             <i:if test="isFilled(title)">
-                <h1 class="legend me-auto text-ellipsis text-nowrap">@title</h1>
+                <h1 class="legend me-auto overflow-hidden text-ellipsis">@title</h1>
                 <i:else>
                     <i:local name="markupTitle" value="@renderToString('title')"/>
                     <i:if test="isFilled(markupTitle)">


### PR DESCRIPTION
### Description

Restricts page title to two lines. The previous CSS already tried to apply an ellipsis but did not work.

Ellipsis on a single line is a little restrictive on mobile devices, so we utilize webkit box with line clamping. Seems to be supported by all modern browsers.

**Before:**

![grafik](https://github.com/user-attachments/assets/e66066e0-eb15-4e11-802c-0beb48a5d764)

**After:**

![grafik](https://github.com/user-attachments/assets/feea8f9b-4462-422a-9c6c-43e4837d2f87)

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1091](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1091)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
