### PR TITLE
Sidebar Overlay - Use sirius font for overlay title when enabled

### DIFF
--- a/src/main/resources/default/assets/common/templates/sidebar-overlay.html.mustache
+++ b/src/main/resources/default/assets/common/templates/sidebar-overlay.html.mustache
@@ -4,7 +4,7 @@
             <div class="sci-m-2 sci-d-flex">
                 <span class="{{icon}} sci-icon-small"></span>
             </div>
-            <div class="sci-w-100 sci-text sci-bold">{{title}}</div>
+            <div class="sci-w-100 sci-text sci-font sci-bold">{{title}}</div>
             <div class="sci-m-2 sci-d-flex">
                 <a class="sci-cursor-pointer sci-sidebar-overlay-close-js sci-icon-close-text-soft sci-icon-small"></a>
             </div>


### PR DESCRIPTION
### Description

Otherwise we get an ugly default font and its harder for customers to override the used font

**Before:**

![grafik](https://github.com/user-attachments/assets/24d69ce0-d8e7-405c-a3b3-92ce8cee2fe3)

**After:**

![grafik](https://github.com/user-attachments/assets/22a61313-7bce-476b-8f5d-4cf77c41e051)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11901](https://scireum.myjetbrains.com/youtrack/issue/OX-11901)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
