### PR TITLE
Forms - Adapts `confirm-link-js`-EventListener to be able to use inputs from external forms via form id to be passed via webContext

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -41,8 +41,9 @@ sirius.ready(function () {
             try {
                 _confirmForm.setAttribute('action', _node.getAttribute('href'));
 
-                if (_node.hasAttribute('data-sci-submit-form')) {
-                    const _form = document.getElementById(_node.getAttribute("data-sci-submit-form"));
+                if (_node.dataset.sciSubmitFormId) {
+                    [..._confirmForm.children].forEach(child => child.name !== "CSRFToken" && _confirmForm.removeChild(child));
+                    const _form = document.getElementById(_node.dataset.sciSubmitFormId);
                     const userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
                     userIdInputs.forEach(input => _confirmForm.appendChild(input));
                 }

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -46,7 +46,13 @@ sirius.ready(function () {
                     const _form = document.getElementById(_node.dataset.sciSubmitFormId);
                     if (_form != null) {
                         const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
-                        _userIdInputs.forEach(_input => _confirmForm.appendChild(_input));
+                        _userIdInputs.forEach(_input => {
+                            const _inputHidden = document.createElement('input');
+                            _inputHidden.type = 'hidden';
+                            _inputHidden.name = _input.name;
+                            _inputHidden.value = _input.value;
+                            _confirmForm.appendChild(_inputHidden);
+                        });
                     }
                 }
 

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -42,10 +42,10 @@ sirius.ready(function () {
                 _confirmForm.setAttribute('action', _node.getAttribute('href'));
 
                 if (_node.dataset.sciSubmitFormId) {
-                    [..._confirmForm.children].forEach(child => child.name !== "CSRFToken" && _confirmForm.removeChild(child));
+                    [..._confirmForm.children].forEach(_child => _child.name !== "CSRFToken" && _confirmForm.removeChild(_child));
                     const _form = document.getElementById(_node.dataset.sciSubmitFormId);
-                    const userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
-                    userIdInputs.forEach(input => _confirmForm.appendChild(input));
+                    const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
+                    _userIdInputs.forEach(_input => _confirmForm.appendChild(_input));
                 }
 
                 _modalElement.tabIndex = -1;

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -44,8 +44,10 @@ sirius.ready(function () {
                 if (_node.dataset.sciSubmitFormId) {
                     [..._confirmForm.children].forEach(_child => _child.name !== "CSRFToken" && _confirmForm.removeChild(_child));
                     const _form = document.getElementById(_node.dataset.sciSubmitFormId);
-                    const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
-                    _userIdInputs.forEach(_input => _confirmForm.appendChild(_input));
+                    if (_form.children != null) {
+                        const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
+                        _userIdInputs.forEach(_input => _confirmForm.appendChild(_input));
+                    }
                 }
 
                 _modalElement.tabIndex = -1;

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -41,6 +41,12 @@ sirius.ready(function () {
             try {
                 _confirmForm.setAttribute('action', _node.getAttribute('href'));
 
+                if (_node.hasAttribute('data-sci-submit-form')) {
+                    const _form = document.getElementById(_node.getAttribute("data-sci-submit-form"));
+                    const userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
+                    userIdInputs.forEach(input => _confirmForm.appendChild(input));
+                }
+
                 _modalElement.tabIndex = -1;
                 _modalElement.addEventListener('shown.bs.modal', () => {
                     const _cancelButton = _modalElement.querySelector('.btn-cancel-js');

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -44,7 +44,7 @@ sirius.ready(function () {
                 if (_node.dataset.sciSubmitFormId) {
                     [..._confirmForm.children].forEach(_child => _child.name !== "CSRFToken" && _confirmForm.removeChild(_child));
                     const _form = document.getElementById(_node.dataset.sciSubmitFormId);
-                    if (_form.children != null) {
+                    if (_form != null) {
                         const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
                         _userIdInputs.forEach(_input => _confirmForm.appendChild(_input));
                     }


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11940](https://scireum.myjetbrains.com/youtrack/issue/OX-11940)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
