### PR TITLE
Allow to provide a schema download next to the sample response of an API

### DIFF
--- a/src/main/resources/default/templates/system/api.html.pasta
+++ b/src/main/resources/default/templates/system/api.html.pasta
@@ -131,7 +131,9 @@
                                             </td>
 
                                             <i:else>
-                                                <td><i:raw>@expandMessage(smartTranslate(request.description()))</i:raw></td>
+                                                <td>
+                                                    <i:raw>@expandMessage(smartTranslate(request.description()))</i:raw>
+                                                </td>
                                             </i:else>
                                         </i:if>
                                     </tr>
@@ -177,6 +179,17 @@
                                                        items="@toList(responseContent.examples())">
                                                     <pre class="prettyprint p-2">@example.value()</pre>
                                                 </i:for>
+                                                <i:local name="schemaUrl" value="@responseContent.schema().ref()"/>
+                                                <i:local name="schemaFileName"
+                                                         value="@Strings.firstFilled(responseContent.schema().name(), responseContent.schema().ref())"/>
+                                                <i:if test="@isFilled(schemaUrl)">
+                                                    <a href="@schemaUrl"
+                                                       download="@schemaFileName"
+                                                       class="btn btn-primary">
+                                                        <i class="fa-solid fa-file-download me-1"></i>
+                                                        Download Schema
+                                                    </a>
+                                                </i:if>
                                             </td>
 
                                             <i:else>


### PR DESCRIPTION
### Description

This way a JSON-schema or XSD can be provided to further document an API response.

We use the `@Schema` sub annotation of the swagger `@ApiResponse` annotation for this. A `ref` has to be filled with the downloadable asset URI of the schema. The `name` field can be used to provide an optimized download name for the schema file.

**Example:**

![grafik](https://github.com/user-attachments/assets/e48c56d6-042e-4698-a1c4-b3f4b9d7b243)

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11872](https://scireum.myjetbrains.com/youtrack/issue/OX-11872)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
