### PR TITLE
Ignore closed channel exceptions occurring during PDF generation

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -38,11 +38,11 @@ import sirius.web.security.MaintenanceInfo;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
 import sirius.web.services.Format;
+import sirius.web.templates.ClosedChannelHelper;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -291,8 +291,7 @@ public class ControllerDispatcher implements WebDispatcher {
         try {
             // We never want to log or handle exceptions which are caused by the user which
             // closed the browser / socket mid-processing...
-            if ((cause instanceof ClosedChannelException || cause.getCause() instanceof ClosedChannelException)
-                && webContext.isResponseCommitted()) {
+            if (ClosedChannelHelper.tryDetectClosedChannelException(cause) && webContext.isResponseCommitted()) {
                 Exceptions.ignore(cause);
                 return;
             }

--- a/src/main/java/sirius/web/services/ServiceCall.java
+++ b/src/main/java/sirius/web/services/ServiceCall.java
@@ -16,8 +16,8 @@ import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.xml.StructuredOutput;
 import sirius.web.http.WebContext;
+import sirius.web.templates.ClosedChannelHelper;
 
-import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
 import java.util.List;
 
@@ -140,7 +140,7 @@ public abstract class ServiceCall {
             StructuredOutput output = createOutput();
             serv.call(this, output);
         } catch (Exception exception) {
-            if (exception instanceof ClosedChannelException || exception.getCause() instanceof ClosedChannelException) {
+            if (ClosedChannelHelper.tryDetectClosedChannelException(exception)) {
                 // If the user unexpectedly closes the connection, we do not need to log an error...
                 Exceptions.ignore(exception);
                 return;

--- a/src/main/java/sirius/web/templates/ClosedChannelHelper.java
+++ b/src/main/java/sirius/web/templates/ClosedChannelHelper.java
@@ -1,0 +1,48 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.templates;
+
+import com.lowagie.text.ExceptionConverter;
+import org.asynchttpclient.exception.ChannelClosedException;
+
+import java.nio.channels.ClosedChannelException;
+
+/**
+ * Helps to detect closed channel exceptions in complex exception chains.
+ */
+public class ClosedChannelHelper {
+
+    private ClosedChannelHelper() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Detects if the given exception or any of its causes is a closed channel exception.
+     * <p>
+     * This is useful for handling cases where a channel was closed unexpectedly, such as when a client
+     * disconnects or a network error occurs.
+     * <p>
+     * It also handles the async http client variant and the openpdf exception wrapping.
+     *
+     * @param throwable the exception to check
+     * @return <tt>true</tt> if the exception or any of its causes is a closed channel exception.
+     */
+    public static boolean tryDetectClosedChannelException(Throwable throwable) {
+        if (throwable instanceof ClosedChannelException || throwable instanceof ChannelClosedException) {
+            return true;
+        }
+        if (throwable instanceof ExceptionConverter exceptionConverter && exceptionConverter.getException() != null) {
+            return tryDetectClosedChannelException(exceptionConverter.getException());
+        }
+        if (throwable.getCause() != null) {
+            return tryDetectClosedChannelException(throwable.getCause());
+        }
+        return false;
+    }
+}

--- a/src/main/java/sirius/web/templates/Generator.java
+++ b/src/main/java/sirius/web/templates/Generator.java
@@ -8,9 +8,7 @@
 
 package sirius.web.templates;
 
-import com.lowagie.text.ExceptionConverter;
 import jakarta.activation.DataSource;
-import org.asynchttpclient.exception.ChannelClosedException;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Explain;
@@ -34,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
@@ -174,25 +171,8 @@ public class Generator {
         try {
             try {
                 invokeContentHandler(out);
-            } catch (ExceptionConverter exceptionConverter) {
-                // We need to unwrap exceptions created by iText here...
-                if (exceptionConverter.getException() instanceof ChannelClosedException
-                    || exceptionConverter.getException() instanceof ClosedChannelException
-                    || exceptionConverter.getException().getCause() instanceof ClosedChannelException) {
-                    // A ChannelClosedException, we know, that the underlying socket was closed "aka browser was closed"
-                    // There is no need to jam the logs up with such messages, as there is no way of avoiding this...
-                    Exceptions.ignore(exceptionConverter.getException());
-                } else {
-                    throw Exceptions.handle()
-                                    .error(exceptionConverter.getException())
-                                    .to(Templates.LOG)
-                                    .withSystemErrorMessage("Error applying template '%s': %s (%s)",
-                                                            Strings.isEmpty(templateName) ? templateCode : templateName)
-                                    .handle();
-                }
             } catch (Exception exception) {
-                if (exception instanceof ClosedChannelException
-                    || exception.getCause() instanceof ClosedChannelException) {
+                if (ClosedChannelHelper.tryDetectClosedChannelException(exception)) {
                     // A ClosedChannelException, we know, that the underlying socket was closed "aka browser was closed"
                     // There is no need to jam the logs up with such messages, as there is no way of avoiding this...
                     Exceptions.ignore(exception);


### PR DESCRIPTION
### Description

This new recursive logic is necessary as openpdf/iText does some shady stuff by converting all checked exceptions in its code to unchecked ExceptionConverter exceptions (which don't follow the getCause-syntax ...). We want to ignore these as we don't want to have a log full of error messages just because users closed the browser tab during the PDF creation process.

```stacktrace
sirius.kernel.health.HandledException:
Ein Fehler ist aufgetreten: Error applying template '/templates/pig/datasheet/datasheet.pdf.pasta': ExceptionConverter: java.nio.channels.ClosedChannelException (org.xhtmlrenderer.util.XRRuntimeException)

Caused by: org.xhtmlrenderer.util.XRRuntimeException:
ExceptionConverter: java.nio.channels.ClosedChannelException


Caused by: com.lowagie.text.DocumentException:
ExceptionConverter: java.nio.channels.ClosedChannelException


Caused by: com.lowagie.text.ExceptionConverter:
ExceptionConverter: java.nio.channels.ClosedChannelException
```

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1038](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1038)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
