### PR TITLE
update sirius-kernel, use new common.Urls-methods, allow them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>dev-45.1.3</sirius.kernel>
+        <sirius.kernel>dev-46.3.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
+++ b/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
@@ -16,6 +16,7 @@ import sirius.kernel.commons.Files;
 import sirius.kernel.commons.Hasher;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
+import sirius.kernel.commons.Urls;
 import sirius.kernel.commons.Value;
 import sirius.kernel.commons.Values;
 import sirius.kernel.commons.Wait;
@@ -73,6 +74,7 @@ public class SiriusClassAliasProvider implements ClassAliasProvider {
         consumer.accept("WebContext", WebContext.class);
         consumer.accept("Injector", Injector.class);
         consumer.accept("Strings", Strings.class);
+        consumer.accept("Urls", Urls.class);
         consumer.accept("Files", Files.class);
         consumer.accept("Hasher", Hasher.class);
         consumer.accept("Amount", Amount.class);

--- a/src/main/java/sirius/pasta/noodle/macros/UrlEncodeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/UrlEncodeMacro.java
@@ -8,9 +8,9 @@
 
 package sirius.pasta.noodle.macros;
 
-import sirius.kernel.tokenizer.Position;
-import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Urls;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.tokenizer.Position;
 import sirius.pasta.noodle.Environment;
 import sirius.pasta.noodle.compiler.CompilationContext;
 import sirius.pasta.noodle.compiler.ir.Node;
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
- * Represents <tt>urlEncode(String)</tt> which is a call to {@link Strings#urlEncode(String)}.
+ * Represents <tt>urlEncode(String)</tt> which is a call to {@link Urls#encode(String)}.
  */
 @Register
 @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
@@ -39,7 +39,7 @@ public class UrlEncodeMacro extends BasicMacro {
 
     @Override
     public Object invoke(Environment environment, Object[] args) {
-        return Strings.urlEncode((String) args[0]);
+        return Urls.encode((String) args[0]);
     }
 
     @Nonnull

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -39,6 +39,7 @@ import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.commons.MultiMap;
 import sirius.kernel.commons.Processor;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Urls;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
@@ -950,7 +951,7 @@ public class Response {
      */
     protected void setContentDisposition(String name, boolean download) {
         String cleanName = name.replaceAll("[^A-Za-z0-9\\-_.]", "_");
-        String utf8Name = Strings.urlEncode(name.replace(" ", "_"));
+        String utf8Name = Urls.encode(name.replace(" ", "_"));
         addHeaderIfNotExists("Content-Disposition",
                              (download ? "attachment;" : "inline;")
                              + "filename=\""

--- a/src/main/java/sirius/web/security/OTPVerifier.java
+++ b/src/main/java/sirius/web/security/OTPVerifier.java
@@ -10,6 +10,7 @@ package sirius.web.security;
 
 import com.google.common.io.BaseEncoding;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Urls;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
@@ -81,7 +82,7 @@ public class OTPVerifier {
      */
     @Nonnull
     public String getAsAuthURL(String account, String secret) {
-        return "otpauth://totp/" + account.replace(" ", "_") + "?secret=" + Strings.urlEncode(secret);
+        return "otpauth://totp/" + account.replace(" ", "_") + "?secret=" + Urls.encode(secret);
     }
 
     /**

--- a/src/main/java/sirius/web/util/LinkBuilder.java
+++ b/src/main/java/sirius/web/util/LinkBuilder.java
@@ -9,12 +9,13 @@
 package sirius.web.util;
 
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Urls;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Helperclass to build links containing query strings.
+ * Helper class to build links containing query strings.
  */
 public class LinkBuilder {
 
@@ -24,7 +25,7 @@ public class LinkBuilder {
     /**
      * Creates a new builder based on the initial URL.
      * <p>
-     * This can be either a fully qualified URL like <tt>https://somehost.com</tt> or an URI like <tt>/some/uri</tt>
+     * This can be either a fully qualified URL like <tt><a href="https://somehost.com">...</a></tt> or an URI like <tt>/some/uri</tt>
      * or even one with a query string already like <tt>/test?some=parameter</tt>.
      *
      * @param uriOrLink the base url to extend. This value can be empty but must not be <tt>null</tt>
@@ -40,7 +41,7 @@ public class LinkBuilder {
      * This will <b>NOT</b> url encode the given value but it will properly extend the URL by ? or &amp; to append
      * the given parameter to the query string.
      *
-     * @param name  the name of the paramete to add
+     * @param name  the name of the parameter to add
      * @param value the value to add (without any further processing)
      * @return the builder itself for fluent method calls
      */
@@ -62,10 +63,10 @@ public class LinkBuilder {
     /**
      * Adds a name/value pair to the link as given.
      * <p>
-     * This the given value will be url encoded using {@link Strings#urlEncode(String)}. A <tt>null</tt>
+     * This the given value will be url encoded using {@link Urls#encode(String)}. A <tt>null</tt>
      * value will be replaced with "". If a non-string object is given, <tt>toString()</tt> will be called upon it.
      *
-     * @param name  the name of the paramete to add
+     * @param name  the name of the parameter to add
      * @param value the value to add (without any further processing)
      * @return the builder itself for fluent method calls
      */
@@ -73,7 +74,7 @@ public class LinkBuilder {
         if (Strings.isEmpty(value)) {
             return appendRaw(name, "");
         } else {
-            return appendRaw(name, Strings.urlEncode(value.toString()));
+            return appendRaw(name, Urls.encode(value.toString()));
         }
     }
 
@@ -83,13 +84,13 @@ public class LinkBuilder {
      * <p>
      * Just like {@link #append(String, Object)} this will escape the given value.
      *
-     * @param name  the name of the paramete to add
+     * @param name  the name of the parameter to add
      * @param value the value to add (without any further processing)
      * @return the builder itself for fluent method calls
      */
     public LinkBuilder appendIfFilled(@Nonnull String name, @Nullable Object value) {
         if (Strings.isFilled(value)) {
-            appendRaw(name, Strings.urlEncode(value.toString()));
+            appendRaw(name, Urls.encode(value.toString()));
         }
 
         return this;

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -452,6 +452,7 @@ scripting {
             "sirius.kernel.commons.Amount.*" = true
             "sirius.kernel.commons.Strings.*" = true
             "sirius.kernel.commons.StringCleanup.*" = true
+            "sirius.kernel.commons.Urls.*" = true
             "sirius.kernel.settings.ExtendedSettings.getExtension" = true
             "sirius.kernel.settings.Settings.get" = true
             "sirius.kernel.settings.Settings.getSettings" = true

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -28,6 +28,7 @@ import sirius.kernel.async.Promise;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Urls;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.health.Exceptions;
@@ -508,7 +509,7 @@ public class TestRequest extends WebContext implements HttpRequest {
     }
 
     private String generateQueryStringParam(String key, Object value) {
-        return Strings.urlEncode(key) + "=" + Strings.urlEncode(NLS.toMachineString(value));
+        return Urls.encode(key) + "=" + Urls.encode(NLS.toMachineString(value));
     }
 
     protected InputStream getResourceAsStream(String resource) {


### PR DESCRIPTION
### Description
- update sirius-kernel
- allow Urls-methods in NoodleSandbox
- add shortHand
- use new methods to fix breaking deprecations

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
full changelog of kernel: https://github.com/scireum/sirius-kernel/compare/dev-45.1.3...dev-46.3.0
### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14614](https://scireum.myjetbrains.com/youtrack/issue/SE-14614)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
