### PR TITLE
Support JSON Calls that return an Array

### DIFF
--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -8,6 +8,7 @@
 
 package sirius.web.services;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import sirius.kernel.commons.Json;
@@ -147,6 +148,20 @@ public class JSONCall {
      * @throws IOException in case of an IO error while receiving the result
      */
     public ObjectNode getInput() throws IOException {
+        return Json.parseObject(executeCall());
+    }
+
+    /**
+     * Executes the call and returns the input expecting a JSON array as result.
+     *
+     * @return the result of the call as an array
+     * @throws IOException in case of an IO error during the call
+     */
+    public ArrayNode getInputArray() throws IOException {
+        return Json.parseArray(executeCall());
+    }
+
+    private String executeCall() throws IOException {
         String body =
                 Streams.readToString(new InputStreamReader(outcall.getResponse().body(), outcall.getContentEncoding()));
         logRequest(body);
@@ -154,7 +169,7 @@ public class JSONCall {
         String contentType = outcall.getHeaderField("content-type");
         if (!outcall.isErroneous() || (contentType != null && contentType.toLowerCase()
                                                                          .contains(MimeHelper.APPLICATION_JSON))) {
-            return Json.parseObject(body);
+            return body;
         }
         throw new IOException(Strings.apply("A non-OK response (%s) was received as a result of an HTTP call",
                                             outcall.getResponse().statusCode()));

--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -161,6 +161,16 @@ public class JSONCall {
         return Json.parseArray(executeCall());
     }
 
+    /**
+     * Executes the call and returns the input as a plain text string.
+     * <p>
+     * An {@link IOException} is thrown in case of an issue with the connection or if the response isn't JSON. Note,
+     * that non-OK responses (e.g. HTTP status 404) are accepted as long as the content type is JSON to support APIs
+     * that return proper error messages in JSON format.
+     *
+     * @return the result of the call as a plain text string
+     * @throws IOException in case of an IO error during the call
+     */
     private String executeCall() throws IOException {
         String body =
                 Streams.readToString(new InputStreamReader(outcall.getResponse().body(), outcall.getContentEncoding()));


### PR DESCRIPTION
### Description

There are known APIs that return a JSON array instead of an Object.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14587](https://scireum.myjetbrains.com/youtrack/issue/SE-14587)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
