### PR TITLE
Tycho - Ensure only relevant clicks toggle the checkbox more safely

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/selectableTable.js.pasta
@@ -1,7 +1,7 @@
 sirius.ready(function () {
     // FireFox Fix: If a checkbox has been checked and someone refreshes the page, that checkbox is still checked
     // without triggering a change event. Therefore, we are manually clearing all checkboxes on page load.
-    window.addEventListener('pageshow',function (){
+    window.addEventListener('pageshow', function () {
         document.querySelectorAll('.select-table-row-checkbox-js:checked').forEach(function (_checkbox) {
             _checkbox.checked = false;
             toggleRowSelection(_checkbox);
@@ -30,13 +30,13 @@ sirius.ready(function () {
                 changeSelectAllCheckboxState(_table);
             });
 
+            const skippedTargetTypes = ['input', 'a', 'i', 'button'];
             const _row = _checkbox.closest('tr');
             // Handle clicks on the row for convenience
             _row.addEventListener('click', function (event) {
-                if (event.target.tagName.toLowerCase() !== 'input' &&
-                    event.target.tagName.toLowerCase() !== 'a' &&
-                    event.target.tagName.toLowerCase() !== 'i' &&
-                    event.target.tagName.toLowerCase() !== 'button') {
+                const targetType = event.target.tagName.toLowerCase();
+                const targetParentType = event.target.parentElement?.tagName?.toLowerCase();
+                if (!skippedTargetTypes.includes(targetType) && !skippedTargetTypes.includes(targetParentType)) {
                     _checkbox.checked = !_checkbox.checked;
                     _checkbox.dispatchEvent(new Event('change'));
                 }

--- a/src/main/resources/default/taglib/t/additionalActions.html.pasta
+++ b/src/main/resources/default/taglib/t/additionalActions.html.pasta
@@ -18,8 +18,7 @@
                 style="z-index: 3; position: relative"
                 data-bs-toggle="dropdown"
                 aria-haspopup="true"
-                aria-expanded="false"
-                onclick="event.stopPropagation()">
+                aria-expanded="false">
             <i:if test="isFilled(label)">
                 <span class="@labelClass pe-2">@label</span>
             </i:if>


### PR DESCRIPTION
### Description

The previous solution of preventing the click propagation of the additional actions toggle caused its dropdown not closing properly when clicking on a similar toggle in another table row.

**Before/Problem:**

![grafik](https://github.com/user-attachments/assets/fb2e5172-dc2f-43e4-a846-482910d4fbf7)

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1114](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1114)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
