### PR TITLE
SAML: Parsing of X509Certificate (OX-12034)

### DIFF
--- a/src/main/java/sirius/web/security/SAMLHelper.java
+++ b/src/main/java/sirius/web/security/SAMLHelper.java
@@ -55,6 +55,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Provides a helper to generate SAML 2 requests and to process responses.
@@ -338,8 +339,14 @@ public class SAMLHelper {
 
             for (XMLStructure xmlStructure : keyInfo.getContent()) {
                 if (xmlStructure instanceof X509Data x509Data && !x509Data.getContent().isEmpty()) {
-                    X509Certificate x509Certificate = (X509Certificate) x509Data.getContent().getFirst();
-                    return new X509CertificateResult(x509Certificate);
+                    Optional<X509Certificate> optionalCertificate = x509Data.getContent()
+                                                                            .stream()
+                                                                            .filter(X509Certificate.class::isInstance)
+                                                                            .map(X509Certificate.class::cast)
+                                                                            .findFirst();
+                    if (optionalCertificate.isPresent()) {
+                        return new X509CertificateResult(optionalCertificate.get());
+                    }
                 }
             }
 


### PR DESCRIPTION
### Description

Previously, we expected the X509Certificate to be the first child of the X509Data structure. For Google SAML, this assumption is wrong as the X509Certificate is the second entry only, leading to an illegal cast. Therefore, we now inspect all children and process the first X509Certificate child.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12034](https://scireum.myjetbrains.com/youtrack/issue/OX-12034)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
