### PR TITLE
Allow Controller to Handle Exceptions custom

### DIFF
--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -203,6 +203,11 @@ public class BasicController implements Controller {
     }
 
     @Override
+    public HandledException handleError(WebContext webContext, Throwable cause) {
+        return Exceptions.handle(ControllerDispatcher.LOG, cause);
+    }
+
+    @Override
     public void onError(WebContext webContext, @Nonnull HandledException error) {
         if (webContext.isResponseCommitted() || defaultRoute == null || error.getHint(Controller.HTTP_STATUS)
                                                                              .isNumeric()) {

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -225,7 +225,7 @@ public class BasicController implements Controller {
             WebServer.LOG.WARN("""
                                        Cannot send service error for: %s - %s
                                        A partially successful response has already been created and committed!
-                                                                              
+                                       
                                        %s
                                        """,
                                webContext.getRequest().uri(),

--- a/src/main/java/sirius/web/controller/Controller.java
+++ b/src/main/java/sirius/web/controller/Controller.java
@@ -70,6 +70,18 @@ public interface Controller {
     ExceptionHint MISSING_PERMISSION = new ExceptionHint("missingPermission");
 
     /**
+     * Handles the given error and returns a {@link HandledException} which can be output to the user.
+     * <p>
+     * Depending on the type of request, {@link #onError} or {@link #onApiError} will be invoked with the returned
+     * {@link HandledException}.
+     *
+     * @param webContext the context containing the request
+     * @param cause      the error which occurred
+     * @return a {@link HandledException} which can be output to the user
+     */
+    HandledException handleError(WebContext webContext, Throwable cause);
+
+    /**
      * In case processing a request via a method fails (throws an exception), this method will be called.
      * <p>
      * This provides a convenient way to render a "fallback" page like a list view, if a specialized details view

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -319,10 +319,10 @@ public class ControllerDispatcher implements WebDispatcher {
             } else {
                 route.getController().onError(webContext, handledException);
             }
-        } catch (Exception t) {
+        } catch (Exception exceptionDuringFailureHandling) {
             webContext.respondWith()
                       .error(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                             route.getController().handleError(webContext, t));
+                             route.getController().handleError(webContext, exceptionDuringFailureHandling));
         }
     }
 

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -57,7 +57,11 @@ public class ControllerDispatcher implements WebDispatcher {
     @ConfigValue("http.maintenanceRetryAfter")
     private static Duration maintenanceRetryAfter;
 
-    protected static final Log LOG = Log.get("controller");
+    /**
+     * Used to log general controller related activities.
+     */
+    public static final Log LOG = Log.get("controller");
+
     private static final String SYSTEM_MVC = "MVC";
 
     /**


### PR DESCRIPTION
### Description

Some controllers (e.g. frontend controllers) may not want to log exceptions to the system log or they want to enrich the exception before logging it, e.g. adding a generic error code so that later on, a more generic error message can be displayed to the user with the error code instead of showing the actual internal error message while still allowing connecting the show error to the internal error via the code (if provided by the user).

By default, the exception is simply handled via the common logic as was the case already. Because handled exceptions are ignored and returned as is when calling Exceptions#handle, we don't have to differentiate between those and unhandled exceptions in the BasicController.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14652](https://scireum.myjetbrains.com/youtrack/issue/SE-14652)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
