### PR TITLE
SIRI-1060:  Mail OAuth

### DIFF
--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -25,6 +25,7 @@ public class SMTPConfiguration {
     private SMTPProtocol protocol;
     private String user;
     private String password;
+    private String oauthTokenName;
     private String mailSender;
     private String mailSenderName;
     private boolean useSenderAndEnvelopeFrom;
@@ -42,6 +43,9 @@ public class SMTPConfiguration {
 
     @ConfigValue("mail.smtp.password")
     private static String smtpPassword;
+
+    @ConfigValue("mail.smtp.oauthTokenName")
+    private static String smtpOAuthTokenName;
 
     @ConfigValue("mail.smtp.sender")
     private static String smtpSender;
@@ -97,6 +101,11 @@ public class SMTPConfiguration {
         return this;
     }
 
+    public SMTPConfiguration setOAuthTokenName(String oauthTokenName) {
+        this.oauthTokenName = oauthTokenName;
+        return this;
+    }
+
     public SMTPConfiguration setMailSender(String mailSender) {
         this.mailSender = mailSender;
         return this;
@@ -134,6 +143,7 @@ public class SMTPConfiguration {
                                 .setProtocol(asSMTPProtocol(Sirius.getSettings().get("mail.smtp.protocol")))
                                 .setUser(smtpUser)
                                 .setPassword(smtpPassword)
+                                .setOAuthTokenName(smtpOAuthTokenName)
                                 .setMailSender(smtpSender)
                                 .setMailSenderName(smtpSenderName)
                                 .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom)
@@ -163,6 +173,7 @@ public class SMTPConfiguration {
                                 .setProtocol(asSMTPProtocol(settings.get("mail.protocol")))
                                 .setUser(settings.get("mail.user").getString())
                                 .setPassword(settings.get("mail.password").getString())
+                                .setOAuthTokenName(settings.get("mail.oauthTokenName").getString())
                                 .setMailSender(settings.get("mail.sender").getString())
                                 .setMailSenderName(settings.get("mail.senderName").getString())
                                 .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean())
@@ -258,6 +269,15 @@ public class SMTPConfiguration {
      */
     public String getMailPassword() {
         return password;
+    }
+
+    /**
+     * Returns the name of the OAuth token used to authenticate against the mail server.
+     *
+     * @return the name of the OAuth token used for authentication
+     */
+    public String getOAuthTokenName() {
+        return oauthTokenName;
     }
 
     /**

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -34,6 +34,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Exceptions;
 import sirius.web.security.UserContext;
+import sirius.web.security.oauth.OAuthTokenProviderUtils;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -75,6 +76,8 @@ class SendMailTask implements Runnable {
     private static final String MAIL_FROM = "mail.from";
 
     private static final String AUTH = "auth";
+    private static final String AUTH_MECHANISMS = "auth.mechanisms";
+    private static final String AUTH_MECHANISM_XOAUTH2 = "XOAUTH2";
     private static final String HOST = "host";
     private static final String STARTTLS_ENABLE = "starttls.enable";
     private static final String CHECKSERVERIDENTITY = "ssl.checkserveridentity";
@@ -101,6 +104,9 @@ class SendMailTask implements Runnable {
 
     @Part
     private static Mails mails;
+
+    @Part
+    private static OAuthTokenProviderUtils oauthTokenProviderUtils;
 
     @ConfigValue("mail.smtp.dkim.keyFile")
     private static String dkimKeyFile;
@@ -390,6 +396,13 @@ class SendMailTask implements Runnable {
     }
 
     private Session setupAuthSession(SMTPConfiguration config, Properties props, String protocolPropPrefix) {
+        if (Strings.isFilled(config.getOAuthTokenName())) {
+            props.setProperty(MAIL_USER, config.getMailUser());
+            props.setProperty(protocolPropPrefix + AUTH, Boolean.TRUE.toString());
+            props.setProperty(protocolPropPrefix + AUTH_MECHANISMS, AUTH_MECHANISM_XOAUTH2);
+            return Session.getInstance(props, new OAuthMailAuthenticator(config));
+        }
+
         if (Strings.isFilled(config.getMailPassword())) {
             props.setProperty(MAIL_USER, config.getMailUser());
             props.setProperty(protocolPropPrefix + AUTH, Boolean.TRUE.toString());
@@ -525,6 +538,41 @@ class SendMailTask implements Runnable {
         @Override
         protected PasswordAuthentication getPasswordAuthentication() {
             return new PasswordAuthentication(config.getMailUser(), config.getMailPassword());
+        }
+    }
+
+    /**
+     * Authenticates the mail session using an OAuth2 access token.
+     */
+    private static class OAuthMailAuthenticator extends Authenticator {
+
+        private final SMTPConfiguration config;
+        private final String accessToken;
+
+        private OAuthMailAuthenticator(SMTPConfiguration config) {
+            this.config = config;
+            this.accessToken = fetchRequiredAccessToken(config);
+        }
+
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            return new PasswordAuthentication(config.getMailUser(), accessToken);
+        }
+
+        /**
+         * Fetches the access token for the configured OAuth token name.
+         *
+         * @param config the SMTP configuration to use
+         * @return the access token to use for authentication
+         */
+        private static String fetchRequiredAccessToken(SMTPConfiguration config) {
+            return oauthTokenProviderUtils.fetchValidTokenForCurrentScope(config.getOAuthTokenName())
+                                          .orElseThrow(() -> Exceptions.handle()
+                                                                       .to(Mails.LOG)
+                                                                       .withSystemErrorMessage(
+                                                                               "No valid OAuth token found for '%s'",
+                                                                               config.getOAuthTokenName())
+                                                                       .handle());
         }
     }
 

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -395,6 +395,16 @@ class SendMailTask implements Runnable {
         return setupAuthSession(config, props, protocolPropPrefix);
     }
 
+    /**
+     * Sets the properties depending on the configuration and returns a corresponding session.
+     * <p>
+     * OAuth2 is prioritized over a simple username/password authentication which is prioritized over no authentication.
+     *
+     * @param config             the SMTP configuration to use
+     * @param props              the properties to set for the session
+     * @param protocolPropPrefix the prefix to use for the protocol properties (e.g. "mail.smtp.")
+     * @return the session to use for sending mails
+     */
     private Session setupAuthSession(SMTPConfiguration config, Properties props, String protocolPropPrefix) {
         if (Strings.isFilled(config.getOAuthTokenName())) {
             props.setProperty(MAIL_USER, config.getMailUser());

--- a/src/main/java/sirius/web/security/oauth/OAuthTokenProvider.java
+++ b/src/main/java/sirius/web/security/oauth/OAuthTokenProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.security.oauth;
+
+import sirius.kernel.di.std.AutoRegister;
+
+import java.util.Optional;
+
+/**
+ * Provides implementation specific access to OAuth tokens.
+ */
+@AutoRegister
+public interface OAuthTokenProvider {
+
+    /**
+     * Fetches the token identified by the given name, scoped to the current context but not tied to a specific user.
+     *
+     * @param tokenName the name of the token to fetch
+     * @return an optional containing the token if available, or empty if none is found
+     */
+    Optional<String> fetchValidTokenForCurrentScope(String tokenName);
+}

--- a/src/main/java/sirius/web/security/oauth/OAuthTokenProviderUtils.java
+++ b/src/main/java/sirius/web/security/oauth/OAuthTokenProviderUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.security.oauth;
+
+import sirius.kernel.di.std.Parts;
+import sirius.kernel.di.std.Register;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Provides utility methods to work with OAuth tokens and services.
+ */
+@Register(classes = OAuthTokenProviderUtils.class)
+public class OAuthTokenProviderUtils {
+
+    @Parts(OAuthTokenProvider.class)
+    private Collection<OAuthTokenProvider> providers;
+
+    /**
+     * Fetches a valid OAuth token for the current scope and the specified token name.
+     *
+     * @param tokenName the name of the token to fetch
+     * @return an optional containing the valid access token if available, or empty if none is found
+     */
+    public Optional<String> fetchValidTokenForCurrentScope(String tokenName) {
+        return providers.stream()
+                        .map(provider -> provider.fetchValidTokenForCurrentScope(tokenName))
+                        .flatMap(Optional::stream)
+                        .findFirst();
+    }
+}

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -569,6 +569,10 @@ mail {
         # Password used to authenticate at the SMTP server
         password = ""
 
+        # Name of the OAuth2 token used to fetch the correlating access token to authenticate at the SMTP server.
+        # If set, the configured password is ignored.
+        oauthTokenName = ""
+
         # Default address used as "From:" if no other address is given
         sender = ""
 

--- a/src/main/resources/scope-conf/mail.conf
+++ b/src/main/resources/scope-conf/mail.conf
@@ -12,6 +12,10 @@ mail {
     # Password used to authenticate at the SMTP server
     password = ""
 
+    # Name of the OAuth2 token used to fetch the correlating access token to authenticate at the SMTP server.
+    # If set, the configured password is ignored.
+    oauthTokenName = ""
+
     # Default address used as "From:" if no other address is given
     sender = ""
 


### PR DESCRIPTION
### Description

Provides a mechanism to declare an OAuth token by referencing it via a "name" when sending mails.

The tokens themselves must be provided via a custom implementation of `OAuthTokenProvider`.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1060](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1060)
- This PR is related to PR: #1546

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
