### PR TITLE
BREAKING: Fixes and adjusts all 3 OAuth helper methods.

### DIFF
--- a/src/main/java/sirius/web/security/oauth/OAuthAuthentication.java
+++ b/src/main/java/sirius/web/security/oauth/OAuthAuthentication.java
@@ -24,7 +24,8 @@ import java.nio.charset.StandardCharsets;
 public class OAuthAuthentication {
 
     /**
-     * Creates an authorization URL that requests user consent for the specified OAuth scopes.
+     * Creates a URL that requests authorization by user consent for the specified OAuth scopes using the authorization
+     * code flow.
      * <p>
      * The URL can be used to redirect the user to the OAuth provider's authorization endpoint, where they can grant
      * access to the requested scopes.
@@ -65,11 +66,11 @@ public class OAuthAuthentication {
      * @return the received tokens containing access and refresh tokens, as well as their types and expiration dates
      * @throws IOException if an error occurs while making the HTTP request to the OAuth server
      */
-    public ReceivedTokens requestAccess(String endpoint,
-                                        String clientId,
-                                        String clientSecret,
-                                        String authorizationCode,
-                                        String redirectUri) throws IOException {
+    public ReceivedTokens requestAccessTokenViaAuthorizationCode(String endpoint,
+                                                                 String clientId,
+                                                                 String clientSecret,
+                                                                 String authorizationCode,
+                                                                 String redirectUri) throws IOException {
         JSONCall call = JSONCall.to(URI.create(endpoint));
 
         call.getOutcall()
@@ -95,8 +96,10 @@ public class OAuthAuthentication {
      * @return the received tokens containing the new access token, its type, and expiration date
      * @throws IOException if an error occurs while making the HTTP request to the OAuth server
      */
-    public ReceivedTokens requestRefresh(String endpoint, String clientId, String clientSecret, String refreshToken)
-            throws IOException {
+    public ReceivedTokens requestAccessTokenViaRefreshToken(String endpoint,
+                                                            String clientId,
+                                                            String clientSecret,
+                                                            String refreshToken) throws IOException {
         JSONCall call = JSONCall.to(URI.create(endpoint));
 
         call.getOutcall()


### PR DESCRIPTION
### Description

- This now more closely follows the OAuth standard as grant type should not be present for the auth code request.
- "sharedSecret" should be named "clientSecret"
- redirectUrl is a REQUIRED parameter according to the RFC

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1060](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1060)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1547

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
