### PR TITLE
Toast - Add some much needed spacing between toast message and close button

### DIFF
--- a/src/main/resources/default/assets/common/scripts/toast.js
+++ b/src/main/resources/default/assets/common/scripts/toast.js
@@ -18,7 +18,7 @@ window.sirius.toast = (function () {
                  data-toast-type="{{type}}">
                 {{{message}}}
                 {{#closable}}
-                    <div role="button" class="sci-icon-smaller sci-icon-close sci-cursor-pointer sci-toast-button-close sci-toast-button-close-js"></div>
+                    <div role="button" class="sci-icon-smaller sci-icon-close sci-ms-2 sci-cursor-pointer sci-toast-button-close sci-toast-button-close-js"></div>
                 {{/closable}}
             </div>`;
 


### PR DESCRIPTION
### Description

**Before:**

<img width="415" height="85" alt="grafik" src="https://github.com/user-attachments/assets/1a7ac887-cdc7-463a-b606-6ae8d13a043a" />

**After:**

<img width="444" height="86" alt="grafik" src="https://github.com/user-attachments/assets/30729075-5619-457b-8ff1-a28f570d11bc" />


### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12062](https://scireum.myjetbrains.com/youtrack/issue/OX-12062)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
