### PR TITLE
Only allows accessing files in base directory and below from LocalPathResolver

### DIFF
--- a/src/main/java/sirius/web/resources/LocalPathResolver.java
+++ b/src/main/java/sirius/web/resources/LocalPathResolver.java
@@ -15,7 +15,7 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 
 import java.io.File;
-import java.net.MalformedURLException;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -53,13 +53,12 @@ public class LocalPathResolver implements Resolver {
             return null;
         }
         File file = new File(baseDir, (scopeId + resource).replace("/", File.separator));
-        if (file.exists()) {
-            try {
+        try {
+            if (file.exists() && file.getCanonicalPath().startsWith(baseDir.getCanonicalPath())) {
                 return Resource.dynamicResource(scopeId, resource, file.toURI().toURL());
-            } catch (MalformedURLException e) {
-                Exceptions.handle(e);
-                return null;
             }
+        } catch (IOException e) {
+            Exceptions.handle(e);
         }
         return null;
     }


### PR DESCRIPTION
### Description
The asset dispatcher uses resolver to access resources. The one called LocalPathResolver allows accessing local file system files in a configured directory (if that directory exists). This PR prevents the resolver from providing access to files from other directories than base directory and its subdirectories  

### Additional Notes
- This PR fixes or works on following ticket(s): [SIRI-1125](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1125)

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
