### PR TITLE
SIRI-1060: OAuth Error Handling

### DIFF
--- a/src/main/java/sirius/web/security/oauth/OAuth.java
+++ b/src/main/java/sirius/web/security/oauth/OAuth.java
@@ -140,4 +140,14 @@ public class OAuth {
      * @see #GRANT_TYPE
      */
     public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+
+    /**
+     * Contains the error code returned by the OAuth server in case of an error.
+     */
+    public static final String ERROR = "error";
+
+    /**
+     * Contains the error description returned by the OAuth server in case of an error.
+     */
+    public static final String ERROR_DESCRIPTION = "error_description";
 }

--- a/src/main/resources/web_de.properties
+++ b/src/main/resources/web_de.properties
@@ -20,6 +20,7 @@ MailService.invalidReceiver = Die Empfänger-Adresse ${address} ist ungültig.
 MailService.invalidReplyTo = Die Reply-To-Adresse ${address} is ungültig.
 MailService.invalidSender = Die Absender-Adresse ${address} ist ungültig.
 Model.next = Weiter
+OAuthAuthentication.error.errorResponse = Fehlerhafte Antwort vom OAuth-Server: ${error}: ${errorDescription}
 Page.noResults = keine Ergebnisse
 Page.range = ${first} – ${last}[ von ${total}]
 Pagination.next = Weiter


### PR DESCRIPTION
### Description

Otherwise, error would be ignored and requiring a JSON or web-context parameter would fail later on would throw an exception that is rather useless besides indicating that something went wrong.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1060](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1060)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1549

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
