### PR TITLE
Mail OAuth2: Support Microsoft Graph API

### DIFF
--- a/src/main/java/sirius/web/mails/MailSender.java
+++ b/src/main/java/sirius/web/mails/MailSender.java
@@ -647,4 +647,48 @@ public class MailSender {
     public String getLanguage() {
         return language;
     }
+
+    public String getSenderEmail() {
+        return senderEmail;
+    }
+
+    public String getSenderName() {
+        return senderName;
+    }
+
+    public String getReceiverEmail() {
+        return receiverEmail;
+    }
+
+    public String getReceiverName() {
+        return receiverName;
+    }
+
+    public String getReplyToEmail() {
+        return replyToEmail;
+    }
+
+    public String getReplyToName() {
+        return replyToName;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getHtml() {
+        return html;
+    }
+
+    public List<DataSource> getAttachments() {
+        return Collections.unmodifiableList(attachments);
+    }
+
+    public SMTPConfiguration getSmtpConfiguration() {
+        return smtpConfiguration;
+    }
 }

--- a/src/main/java/sirius/web/mails/MailSender.java
+++ b/src/main/java/sirius/web/mails/MailSender.java
@@ -23,7 +23,9 @@ import sirius.kernel.nls.NLS;
 import sirius.web.http.MimeHelper;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
+import sirius.web.security.ScopeInfo;
 import sirius.web.security.UserContext;
+import sirius.web.security.UserInfo;
 import sirius.web.templates.Generator;
 import sirius.web.templates.Templates;
 
@@ -522,11 +524,17 @@ public class MailSender {
                            subject);
         } else {
             SendMailTask task = new SendMailTask(this, smtpConfiguration);
+            ScopeInfo currentScope = UserContext.getCurrentScope();
+            UserInfo currentUser = UserContext.getCurrentUser();
             tasks.executor("email")
                  .minInterval(internalMessageId,
                               Duration.ofSeconds((MAX_SEND_ATTEMPTS - remainingAttempts.get())
                                                  * RESEND_WAIT_INTERVAL_SECONDS))
-                 .fork(task);
+                 .fork(() -> {
+                     UserContext.get().setCurrentScope(currentScope);
+                     UserContext.get().setCurrentUser(currentUser);
+                     task.run();
+                 });
         }
     }
 

--- a/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
+++ b/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
@@ -62,6 +62,32 @@ public class MicrosoftGraphApiMail {
     }
 
     /**
+     * Creates a new instance of {@link MicrosoftGraphApiMail} based on the provided {@link MailSender}.
+     * <p>
+     * Note, that the HTML body is preferred over the plain text body as only a single body type can be defined.
+     *
+     * @param mail the {@link MailSender} containing the data and configuration for the mail to be sent
+     * @return a new instance of {@link MicrosoftGraphApiMail} configured with the details from the {@link MailSender}
+     */
+    public static MicrosoftGraphApiMail createFromMail(MailSender mail) {
+        MicrosoftGraphApiMail microsoftGraphApiMail =
+                create().withOAuthTokenName(mail.getSmtpConfiguration().getOAuthTokenName())
+                        .withUser(mail.getSenderEmail())
+                        .withReceiverEmailAddress(mail.getReceiverName())
+                        .withSubject(mail.getSubject());
+
+        if (Strings.isFilled(mail.getHtml())) {
+            microsoftGraphApiMail.withHtmlBody(mail.getHtml());
+        } else {
+            microsoftGraphApiMail.withTextBody(mail.getText());
+        }
+
+        mail.getAttachments().forEach(microsoftGraphApiMail::addAttachment);
+
+        return microsoftGraphApiMail;
+    }
+
+    /**
      * Creates a new instance of {@link MicrosoftGraphApiMail}.
      *
      * @return a new instance of {@link MicrosoftGraphApiMail}

--- a/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
+++ b/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
@@ -194,7 +194,7 @@ public class MicrosoftGraphApiMail {
         call.getOutcall().withOAuth(this::fetchValidAccessToken, this::refreshAccessToken);
         addPayload(call.getOutput());
 
-        // Note: Invoke method to tigger JSON logging as just getting the response code skips it.
+        // Note: Invoke method to trigger JSON logging as just getting the response code skips it.
         call.getInput();
 
         int responseCode = call.getOutcall().getResponseCode();
@@ -217,7 +217,7 @@ public class MicrosoftGraphApiMail {
             throw new IllegalStateException("Subject for Microsoft Graph API mail is not set.");
         }
         if (Strings.isEmpty(receiverMailAddress)) {
-            throw new IllegalStateException("Receiver mail address for Microsoft API Graph mail is not set.");
+            throw new IllegalStateException("Receiver mail address for Microsoft Graph API mail is not set.");
         }
         if (Strings.isEmpty(oauthTokenName)) {
             throw new IllegalStateException("OAuth token name for Microsoft Graph API mail is not set.");

--- a/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
+++ b/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
@@ -1,0 +1,366 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.mails;
+
+import jakarta.activation.DataSource;
+import sirius.kernel.Sirius;
+import sirius.kernel.commons.Json;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.Log;
+import sirius.kernel.nls.Formatter;
+import sirius.web.security.UserContext;
+import sirius.web.security.oauth.OAuth;
+import sirius.web.security.oauth.OAuthTokenProviderUtils;
+import sirius.web.services.JSONCall;
+import sirius.web.services.JSONStructuredOutput;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Represents a mail to be sent via the Microsoft Graph API.
+ * <p>
+ * Instead of using the standard SMTP protocol, the Microsoft Graph API (using HTTP POST requests containing a JSON
+ * body) is used to send emails as SMTP is considered legacy and only available for certain Microsoft plans.
+ */
+public class MicrosoftGraphApiMail {
+
+    @Part
+    private static OAuthTokenProviderUtils oauthTokenProviderUtils;
+
+    private static final Log LOG = Log.get("microsoft-graph-api-mail");
+
+    private URI endpoint;
+    private String subject;
+    private String receiverMailAddress;
+    private String oauthTokenName;
+
+    private String bodyContent;
+    private String bodyType;
+
+    private final List<Attachment> attachments = new ArrayList<>();
+
+    /**
+     * Returns whether the Microsoft Graph API Mail service is enabled.
+     *
+     * @return <tt>true</tt> if the service is enabled, <tt>false</tt> otherwise
+     */
+    public static boolean isEnabled() {
+        return getSetting("enabled").asBoolean();
+    }
+
+    /**
+     * Creates a new instance of {@link MicrosoftGraphApiMail}.
+     *
+     * @return a new instance of {@link MicrosoftGraphApiMail}
+     */
+    public static MicrosoftGraphApiMail create() {
+        return new MicrosoftGraphApiMail();
+    }
+
+    /**
+     * Sets the name of the OAuth token to be used for authentication.
+     * <p>
+     * The access token itself will then be fetched via the {@link OAuthTokenProviderUtils} using the given name.
+     *
+     * @param oauthTokenName the name of the OAuth token to be used for authentication
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     */
+    public MicrosoftGraphApiMail withOAuthTokenName(String oauthTokenName) {
+        this.oauthTokenName = oauthTokenName;
+        return this;
+    }
+
+    /**
+     * Sets the endpoint for the Microsoft Graph API Mail service based on the user.
+     *
+     * @param user the user for whom the mail is being sent
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     */
+    public MicrosoftGraphApiMail withUser(String user) {
+        this.endpoint = createEndpoint(user);
+        return this;
+    }
+
+    /**
+     * Sets the subject of the mail to be sent.
+     *
+     * @param subject the subject of the mail
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     */
+    public MicrosoftGraphApiMail withSubject(String subject) {
+        this.subject = subject;
+        return this;
+    }
+
+    /**
+     * Sets the email address of the receiver.
+     *
+     * @param receiverMailAddress the email address of the receiver
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     */
+    public MicrosoftGraphApiMail withReceiverEmailAddress(String receiverMailAddress) {
+        this.receiverMailAddress = receiverMailAddress;
+        return this;
+    }
+
+    /**
+     * Sets the body of the mail to be sent as HTML.
+     * <p>
+     * Note, that only one type of body (HTML or plain text) can be defined for a single mail. If an HTML body is set,
+     * Microsoft Graph API will create a plain text counterpart automatically based on the HTML content.
+     *
+     * @param body the HTML content of the mail body
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     */
+    public MicrosoftGraphApiMail withHtmlBody(String body) {
+        this.bodyContent = body;
+        this.bodyType = "html";
+        return this;
+    }
+
+    /**
+     * Sets the body of the mail to be sent as plain text.
+     *
+     * @param body the plain text content of the mail body
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     * @see #withHtmlBody(String) for details concerning how Microsoft Graph API handles the body content
+     */
+    public MicrosoftGraphApiMail withTextBody(String body) {
+        this.bodyContent = body;
+        this.bodyType = "text";
+        return this;
+    }
+
+    /**
+     * Adds an attachment to the mail being sent.
+     *
+     * @param dataSource the data source representing the attachment to be added
+     * @return the current instance of {@link MicrosoftGraphApiMail} for method chaining
+     */
+    public MicrosoftGraphApiMail addAttachment(DataSource dataSource) {
+        this.attachments.add(Attachment.fromDataSource(dataSource));
+        return this;
+    }
+
+    /**
+     * Sends the mail using the Microsoft Graph API.
+     *
+     * @throws IOException if an error occurs while sending the mail or processing the response
+     * @implNote Microsoft Graph API responses with just a HTTP status code and no body content. Thus, the JSON call
+     * requires allowing an empty response body
+     */
+    public void send() throws IOException {
+        assertValidConfiguration();
+
+        JSONCall call = JSONCall.to(endpoint).withAllowEmptyResponseBody(true);
+        call.getOutcall().withOAuth(this::fetchValidAccessToken, this::refreshAccessToken);
+        addPayload(call.getOutput());
+
+        int responseCode = call.getOutcall().getResponseCode();
+        logCall(call, responseCode);
+        assertSuccessfulCall(responseCode);
+    }
+
+    private static Value getSetting(String key) {
+        Value value = UserContext.getSettings().getSettings("mail.microsoftGraphApi").get(key);
+        if (value.isFilled()) {
+            return value;
+        }
+        return Sirius.getSettings().getSettings("mail.microsoftGraphApi").get(key);
+    }
+
+    private void assertValidConfiguration() {
+        if (Strings.isEmpty(endpoint)) {
+            throw new IllegalStateException("Endpoint for Microsoft Graph API mail is not set.");
+        }
+        if (Strings.isEmpty(subject)) {
+            throw new IllegalStateException("Subject for Microsoft Graph API mail is not set.");
+        }
+        if (Strings.isEmpty(receiverMailAddress)) {
+            throw new IllegalStateException("Receiver mail address for Microsoft API Graph mail is not set.");
+        }
+        if (Strings.isEmpty(oauthTokenName)) {
+            throw new IllegalStateException("OAuth token name for Microsoft Graph API mail is not set.");
+        }
+        if (Strings.isEmpty(bodyContent) || Strings.isEmpty(bodyType)) {
+            throw new IllegalStateException("Body for Microsoft Graph API mail is not set.");
+        }
+    }
+
+    private String fetchValidAccessToken() {
+        String token = oauthTokenProviderUtils.fetchValidTokenForCurrentScope(oauthTokenName).orElseThrow(() -> {
+            return Exceptions.handle()
+                             .withSystemErrorMessage(
+                                     "No valid access token found for Microsoft Graph API with name '%s'.",
+                                     oauthTokenName)
+                             .handle();
+        });
+
+        return OAuth.TOKEN_TYPE_BEARER + " " + token;
+    }
+
+    private void refreshAccessToken() {
+        // No-op: The access token is refreshed automatically by the access token provider.
+    }
+
+    private void addPayload(JSONStructuredOutput output) {
+        output.beginResult();
+        {
+            output.beginObject("message");
+            {
+                addSubject(output);
+                addBody(output);
+                addRecipient(output);
+                addAttachments(output);
+            }
+            output.endObject();
+
+            output.property("saveToSentItems", getSetting("saveToSentItems").asBoolean());
+        }
+        output.endResult();
+    }
+
+    private void addSubject(JSONStructuredOutput output) {
+        output.property("subject", subject);
+    }
+
+    private void addBody(JSONStructuredOutput output) {
+        output.beginObject("body");
+        {
+            output.property("contentType", bodyType);
+            output.property("content", bodyContent);
+        }
+        output.endObject();
+    }
+
+    private void addRecipient(JSONStructuredOutput output) {
+        output.beginArray("toRecipients");
+        {
+            output.beginObject("");
+            {
+                output.beginObject("emailAddress");
+                {
+                    output.property("address", receiverMailAddress);
+                }
+                output.endObject();
+            }
+            output.endObject();
+        }
+        output.endArray();
+    }
+
+    private void addAttachments(JSONStructuredOutput output) {
+        if (attachments.isEmpty()) {
+            return;
+        }
+
+        output.beginArray("attachments");
+        {
+            for (Attachment attachment : attachments) {
+                output.beginObject("");
+                {
+                    output.property("@odata.type", "#microsoft.graph.fileAttachment");
+                    output.property("name", attachment.filename());
+                    output.property("contentType", attachment.contentType());
+                    output.property("contentBytes", attachment.base64Content());
+                }
+                output.endObject();
+            }
+        }
+        output.endArray();
+    }
+
+    /**
+     * Logs the details of the call to the Microsoft Graph API, including the endpoint, request body, and response code
+     * if fine logging is enabled.
+     *
+     * @param call         the {@link JSONCall} representing the call to the Microsoft Graph API
+     * @param responseCode the response code received from the Microsoft Graph API
+     * @throws IOException if an error occurs while logging the call details
+     */
+    private void logCall(JSONCall call, int responseCode) throws IOException {
+        if (LOG.isFINE()) {
+            LOG.FINE("""
+                             ---------- call ----------
+                             Endpoint: %s
+                             
+                             %s
+                             
+                             ---------- response ----------
+                             Response Code: %s
+                             """,
+                     call.getOutcall().getRequest().uri(),
+                     Json.writePretty(Json.parseObject(call.getOutput().toString())),
+                     responseCode);
+        }
+    }
+
+    /**
+     * Asserts that the call to the Microsoft Graph API was successful by checking that the response code is 202.
+     *
+     * @param responseCode the response code received from the Microsoft Graph API
+     * @implNote Microsoft Graph API does not send a body in the response, thus only the response code can be checked.
+     */
+    private void assertSuccessfulCall(int responseCode) {
+        if (responseCode != 202) {
+            throw Exceptions.handle()
+                            .withSystemErrorMessage(
+                                    "Failed to send mail with subject '%s' via Microsoft Graph API. HTTP status: %s",
+                                    subject,
+                                    responseCode)
+                            .handle();
+        }
+    }
+
+    private URI createEndpoint(String user) {
+        return URI.create(Formatter.create(getSetting("endpoint").asString()).set("user", user).format());
+    }
+
+    /**
+     * Represents an attachment to be included in a Microsoft Graph API mail.
+     *
+     * @param filename      the name of the attachment file
+     * @param contentType   the MIME type of the attachment
+     * @param base64Content the base64 encoded content of the attachment
+     */
+    public record Attachment(String filename, String contentType, String base64Content) {
+
+        /**
+         * Creates an attachment from a {@link DataSource}.
+         *
+         * @param dataSource the data source representing the attachment
+         * @return a new instance of {@link Attachment} containing the data from the data source
+         */
+        public static Attachment fromDataSource(DataSource dataSource) {
+            return new Attachment(dataSource.getName(), dataSource.getContentType(), readAndEncodeContent(dataSource));
+        }
+
+        /**
+         * Reads the content of the given {@link DataSource} and encodes it as a Base64 string.
+         *
+         * @param dataSource the data source to read the content from
+         * @return the Base64 encoded content of the data source
+         */
+        private static String readAndEncodeContent(DataSource dataSource) {
+            try (var inputStream = dataSource.getInputStream()) {
+                byte[] bytes = inputStream.readAllBytes();
+                return Base64.getEncoder().encodeToString(bytes);
+            } catch (IOException exception) {
+                throw Exceptions.handle(exception);
+            }
+        }
+    }
+}

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -557,16 +557,14 @@ class SendMailTask implements Runnable {
     private static class OAuthMailAuthenticator extends Authenticator {
 
         private final SMTPConfiguration config;
-        private final String accessToken;
 
         private OAuthMailAuthenticator(SMTPConfiguration config) {
             this.config = config;
-            this.accessToken = fetchRequiredAccessToken(config);
         }
 
         @Override
         protected PasswordAuthentication getPasswordAuthentication() {
-            return new PasswordAuthentication(config.getMailUser(), accessToken);
+            return new PasswordAuthentication(config.getMailUser(), fetchRequiredAccessToken(config));
         }
 
         /**

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -202,9 +202,14 @@ class SendMailTask implements Runnable {
         Watch mailSendTime = Watch.start();
         try {
             Mails.LOG.FINE("Sending eMail: " + mail.subject + " to: " + mail.receiverEmail);
-            Session session = getMailSession(config);
-            try (Transport transport = getSMTPTransport(session, config)) {
-                sendMailViaTransport(session, transport);
+
+            if (MicrosoftGraphApiMail.isEnabled()) {
+                MicrosoftGraphApiMail.createFromMail(mail).send();
+            } else {
+                Session session = getMailSession(config);
+                try (Transport transport = getSMTPTransport(session, config)) {
+                    sendMailViaTransport(session, transport);
+                }
             }
         } catch (Exception e) {
             if (mail.remainingAttempts.decrementAndGet() > 0) {

--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -138,11 +138,11 @@ public class JSONCall {
             debugLogger.FINE(Formatter.create("""
                                                       ---------- call ----------
                                                       ${httpMethod} ${url} [
-                                                                                   
+                                                      
                                                       ${callBody}]
                                                       ---------- response ----------
                                                       HTTP-Response-Code: ${responseCode}
-                                                                                   
+                                                      
                                                       ${response}
                                                       ---------- end ----------
                                                       """)

--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -34,6 +34,7 @@ public class JSONCall {
     private Outcall outcall;
     private Log debugLogger = Log.get("json");
     private BooleanSupplier isDebugLogActive = () -> true;
+    private boolean allowEmptyResponseBody;
 
     /*
      * Use .to(URL) to generate an instance.
@@ -95,6 +96,20 @@ public class JSONCall {
     }
 
     /**
+     * Sets whether an empty response body is allowed.
+     * <p>
+     * If set to <tt>true</tt>, invoking {@link #getInput()} or {@link #getInputArray()} will return an empty JSON
+     * object or array respectively if the response body is empty.
+     *
+     * @param allowEmptyResponseBody whether an empty response body is allowed
+     * @return the JSON call itself for fluent method calls
+     */
+    public JSONCall withAllowEmptyResponseBody(boolean allowEmptyResponseBody) {
+        this.allowEmptyResponseBody = allowEmptyResponseBody;
+        return this;
+    }
+
+    /**
      * Adds a custom header field to the call
      *
      * @param name  name of the field
@@ -148,7 +163,8 @@ public class JSONCall {
      * @throws IOException in case of an IO error during the call
      */
     public ObjectNode getInput() throws IOException {
-        return Json.parseObject(executeCall());
+        String response = executeCall();
+        return allowEmptyResponseBody && Strings.isEmpty(response) ? Json.createObject() : Json.parseObject(response);
     }
 
     /**
@@ -158,7 +174,8 @@ public class JSONCall {
      * @throws IOException in case of an IO error during the call
      */
     public ArrayNode getInputArray() throws IOException {
-        return Json.parseArray(executeCall());
+        String response = executeCall();
+        return allowEmptyResponseBody && Strings.isEmpty(response) ? Json.createArray() : Json.parseArray(response);
     }
 
     /**

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -235,11 +235,11 @@ http {
         ephemeralDHKeySize = 2048
 
         # Only enable TLS protocols as SSLv3 is insecure (POODLE)
-        protocols = [ "TLSv1", "TLSv1.1", "TLSv1.2" ]
+        protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
 
         # The cipher selection of Java 8 seems quite reasonable
         # so we don't need to overwrite this
-        ciphers = [ ]
+        ciphers = []
     }
 
     # Lists all public APIs of the system.
@@ -689,17 +689,17 @@ security {
 
     # Defines a list of all known permissions for reporting reasons
     permissions {
-        flag-logged-in : "Determines if an authorized user is present"
-        permission-system-console : "Required to use the console"
-        permission-system-timing : "Required to use the Microtiming UI"
-        permission-system-api : "Required to view public APIs provided by the system"
-        permission-system-health-api : "Required to view the documentation of the health API"
-        permission-system-state : "Required to view the system state"
-        permission-system-load : "Required to view the system load"
-        permission-system-tags : "Required to view all known Tagliatelle Tags"
-        permission-system-tags-state : "Required to view the state of Tagliatelle"
-        permission-babelfish : "Required to view and export loaded translations"
-        permission-view-scope-default-config : "Required to view the default config of scopes"
+        flag-logged-in: "Determines if an authorized user is present"
+        permission-system-console: "Required to use the console"
+        permission-system-timing: "Required to use the Microtiming UI"
+        permission-system-api: "Required to view public APIs provided by the system"
+        permission-system-health-api: "Required to view the documentation of the health API"
+        permission-system-state: "Required to view the system state"
+        permission-system-load: "Required to view the system load"
+        permission-system-tags: "Required to view all known Tagliatelle Tags"
+        permission-system-tags-state: "Required to view the state of Tagliatelle"
+        permission-babelfish: "Required to view and export loaded translations"
+        permission-view-scope-default-config: "Required to view the default config of scopes"
     }
 
     # Declares profiles. Profiles are meta permissions which represent a set of permissions. Once a user is
@@ -714,12 +714,12 @@ security {
     # WARNING: When the name is a complex expression you will NOT be warned about wrong priorities in the profiles!
     # You need to check the priorities in these cases yourself!
     profiles {
-    #    template {
-    #        priority : 100
-    #        condition : "!some-permission"
-    #        "permission1" : true,
-    #        "permission2" : false
-    #    }
+        #    template {
+        #        priority : 100
+        #        condition : "!some-permission"
+        #        "permission1" : true,
+        #        "permission2" : false
+        #    }
     }
 
 }

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -608,6 +608,19 @@ mail {
         }
     }
 
+    # Contains the configuration used to send mails via the Microsoft Graph API.
+    # Note: Settings may be overridden by scope settings of the same name.
+    microsoftGraphApi {
+        # The endpoint used to send mails via the Microsoft Graph API. The placeholder ${user} is replaced with the
+        # sender user's email address.
+        endpoint = "https://graph.microsoft.com/v1.0/users/${user}/sendMail"
+
+        # Whether to use the Microsoft Graph API to send mails.
+        enabled = false
+
+        # Whether mails sent via the Microsoft Graph API should be saved to the sent items folder at Microsoft.
+        saveToSentItems = true
+    }
 }
 
 async.executor {

--- a/src/main/resources/scope-conf/mail.conf
+++ b/src/main/resources/scope-conf/mail.conf
@@ -42,4 +42,18 @@ mail {
 
     # Whether the mail server requires early authentication
     useTransportAuthentication = false
+
+    # Overrides settings concerning the Microsoft Graph API.
+    # If left commented out, the settings are determinde by the system configuration.
+    #microsoftGraphApi {
+    #    # The endpoint used to send mails via the Microsoft Graph API. The placeholder ${user} is replaced with the
+    #    # sender user's email address.
+    #    endpoint = "https://graph.microsoft.com/v1.0/users/${user}/sendMail"
+    #
+    #    # Whether to use the Microsoft Graph API to send mails.
+    #    enabled = false
+    #
+    #    # Whether mails sent via the Microsoft Graph API should be saved to the sent items folder at Microsoft.
+    #    saveToSentItems = true
+    #}
 }

--- a/src/test/java/sirius/web/mails/MailsMock.java
+++ b/src/test/java/sirius/web/mails/MailsMock.java
@@ -8,7 +8,6 @@
 
 package sirius.web.mails;
 
-import jakarta.activation.DataSource;
 import sirius.kernel.di.Replace;
 import sirius.kernel.di.std.Register;
 
@@ -41,38 +40,6 @@ public class MailsMock extends Mails {
 
         public SMTPConfiguration getEffectiveConfig() {
             return effectiveConfig;
-        }
-
-        public String getSenderEmail() {
-            return senderEmail;
-        }
-
-        public String getSenderName() {
-            return senderName;
-        }
-
-        public String getReceiverEmail() {
-            return receiverEmail;
-        }
-
-        public String getReceiverName() {
-            return receiverName;
-        }
-
-        public String getSubject() {
-            return subject;
-        }
-
-        public String getText() {
-            return text;
-        }
-
-        public String getHtml() {
-            return html;
-        }
-
-        public List<DataSource> getAttachments() {
-            return attachments;
         }
 
         public String getBounceToken() {


### PR DESCRIPTION
### Description

Microsoft unterstützt OAuth in SMTP nur für bestimmte Legacy Systeme. Stattdessen soll die proprietäre Microsoft Graph API verwendet werden, die Mails per HTTP weiterleitet.

Caveat:

Viele Einstellungen in den Mail Settings sind bei Nutzung der API eigentlich nicht mehr nötig, wir prüfen aber auf deren Existenz (teilweise in den Produkten selbst hinsichtlich ob die Konfig aus den UserSettings oder System Settings genutzt werden soll). Das sollte sinnvoll aufgedröselt werden, ist aber gar nicht so trivial. Hier gibt es auch Sonderfälle wie in `sirius.web.mails.SendMailTask#setupSender`, wo die in dem MailSender hinterlegte `senderEmail` ignoriert wird und nur die Einstellung aus der Config oder aus den System Settings zieht, was eher wie ein Bug statt Feature aussieht.

Eine sinnvollere Lösung hinsichtlich der Konfig überlege ich mir noch.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1060](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1060)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
