### PR TITLE
Sets the success flag outside the SMTP logic 

### DIFF
--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -178,8 +178,8 @@ class SendMailTask implements Runnable {
                                 mail.text,
                                 mail.html,
                                 mail.type);
-            } catch (Exception e) {
-                Exceptions.handle(Mails.LOG, e);
+            } catch (Exception exception) {
+                Exceptions.handle(Mails.LOG, exception);
             }
         }
     }
@@ -213,7 +213,7 @@ class SendMailTask implements Runnable {
             }
 
             success = true;
-        } catch (Exception e) {
+        } catch (Exception exception) {
             if (mail.remainingAttempts.decrementAndGet() > 0) {
                 Mails.LOG.WARN(
                         "RESCHEDULING sending mail from: '%s' to '%s' with subject: '%s' (Remaining attempts: %s)",
@@ -232,13 +232,13 @@ class SendMailTask implements Runnable {
             Exceptions.handle()
                       .withSystemErrorMessage(
                               "Invalid mail configuration: %s (Host: %s, Port: %s, User: %s, Password used: %s)",
-                              e.getMessage(),
+                              exception.getMessage(),
                               config.getMailHost(),
                               config.getMailPort(),
                               config.getMailUser(),
                               Strings.isFilled(config.getMailPassword()))
                       .to(Mails.LOG)
-                      .error(e)
+                      .error(exception)
                       .handle();
         }
 
@@ -254,14 +254,14 @@ class SendMailTask implements Runnable {
 
             transport.sendMessage(msg, msg.getAllRecipients());
             messageId = msg.getMessageID();
-        } catch (Exception e) {
+        } catch (Exception exception) {
             throw Exceptions.handle()
                             .withSystemErrorMessage("Cannot send mail to %s from %s with subject '%s': %s (%s)",
                                                     mail.receiverEmail,
                                                     mail.senderEmail,
                                                     mail.subject)
                             .to(Mails.LOG)
-                            .error(e)
+                            .error(exception)
                             .handle();
         }
     }
@@ -336,8 +336,12 @@ class SendMailTask implements Runnable {
             dkimSigner.setLengthParam(true);
             dkimSigner.setCopyHeaderFields(false);
             return new DkimMessage(message, dkimSigner);
-        } catch (Exception e) {
-            Exceptions.handle().to(Mails.LOG).error(e).withNLSKey("Skipping DKIM signing due to: %s (%s)").handle();
+        } catch (Exception exception) {
+            Exceptions.handle()
+                      .to(Mails.LOG)
+                      .error(exception)
+                      .withNLSKey("Skipping DKIM signing due to: %s (%s)")
+                      .handle();
         }
 
         return message;
@@ -598,17 +602,17 @@ class SendMailTask implements Runnable {
                               null;
             transport.connect(config.getMailHost(), config.getMailUser(), password);
             return transport;
-        } catch (Exception e) {
+        } catch (Exception exception) {
             throw Exceptions.handle()
                             .withSystemErrorMessage(
                                     "Invalid mail configuration: %s (Host: %s, Port: %s, User: %s, Password used: %s)",
-                                    e.getMessage(),
+                                    exception.getMessage(),
                                     config.getMailHost(),
                                     config.getMailPort(),
                                     config.getMailUser(),
                                     Strings.isFilled(config.getMailPassword()))
                             .to(Mails.LOG)
-                            .error(e)
+                            .error(exception)
                             .handle();
         }
     }

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -211,6 +211,8 @@ class SendMailTask implements Runnable {
                     sendMailViaTransport(session, transport);
                 }
             }
+
+            success = true;
         } catch (Exception e) {
             if (mail.remainingAttempts.decrementAndGet() > 0) {
                 Mails.LOG.WARN(
@@ -252,7 +254,6 @@ class SendMailTask implements Runnable {
 
             transport.sendMessage(msg, msg.getAllRecipients());
             messageId = msg.getMessageID();
-            success = true;
         } catch (Exception e) {
             throw Exceptions.handle()
                             .withSystemErrorMessage("Cannot send mail to %s from %s with subject '%s': %s (%s)",


### PR DESCRIPTION
### Description

…to also set it for mails sent via Microsoft Graph API.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1060](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1060)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
