### PR TITLE
OAuth Mail Config Fixes

### DIFF
--- a/src/main/java/sirius/web/mails/MicrosoftGraphApiConfiguration.java
+++ b/src/main/java/sirius/web/mails/MicrosoftGraphApiConfiguration.java
@@ -1,0 +1,19 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.mails;
+
+/**
+ * Represents the configuration for sending mails via the Microsoft Graph API.
+ *
+ * @param enabled         indicates whether sending mails via the Microsoft Graph API is enabled
+ * @param endpoint        the endpoint URL for the Microsoft Graph API (may contain a "${user}" placeholder")
+ * @param saveToSentItems indicates whether sent mails should be saved to the "Sent Items" folder
+ */
+public record MicrosoftGraphApiConfiguration(boolean enabled, String endpoint, boolean saveToSentItems) {
+}

--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -32,6 +32,10 @@ public class SMTPConfiguration {
     private String trustedServers;
     private boolean checkServerIdentity;
 
+    private String microsoftGraphApiEndpoint;
+    private boolean microsoftGraphApiEnabled;
+    private boolean microsoftGraphApiSaveToSentItems;
+
     @ConfigValue("mail.smtp.host")
     private static String smtpHost;
 
@@ -61,6 +65,15 @@ public class SMTPConfiguration {
 
     @ConfigValue("mail.smtp.checkServerIdentity")
     private static boolean smtpCheckServerIdentity;
+
+    @ConfigValue("mail.microsoftGraphApi.endpoint")
+    private static String systemMicrosoftGraphApiEndpoint;
+
+    @ConfigValue("mail.microsoftGraphApi.enabled")
+    private static boolean systemMicrosoftGraphApiEnabled;
+
+    @ConfigValue("mail.microsoftGraphApi.saveToSentItems")
+    private static boolean systemMicrosoftGraphApiSaveToSentItems;
 
     private SMTPConfiguration() {
     }
@@ -131,6 +144,21 @@ public class SMTPConfiguration {
         return this;
     }
 
+    public SMTPConfiguration setMicrosoftGraphApiEndpoint(String microsoftGraphApiEndpoint) {
+        this.microsoftGraphApiEndpoint = microsoftGraphApiEndpoint;
+        return this;
+    }
+
+    public SMTPConfiguration setMicrosoftGraphApiEnabled(boolean microsoftGraphApiEnabled) {
+        this.microsoftGraphApiEnabled = microsoftGraphApiEnabled;
+        return this;
+    }
+
+    public SMTPConfiguration setMicrosoftGraphApiSaveToSentItems(boolean microsoftGraphApiSaveToSentItems) {
+        this.microsoftGraphApiSaveToSentItems = microsoftGraphApiSaveToSentItems;
+        return this;
+    }
+
     /**
      * Creates a new configuration based on the config files.
      *
@@ -148,7 +176,10 @@ public class SMTPConfiguration {
                                 .setMailSenderName(smtpSenderName)
                                 .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom)
                                 .setTrustedServers(smtpTrustedServers)
-                                .setCheckServerIdentity(smtpCheckServerIdentity);
+                                .setCheckServerIdentity(smtpCheckServerIdentity)
+                                .setMicrosoftGraphApiEndpoint(systemMicrosoftGraphApiEndpoint)
+                                .setMicrosoftGraphApiEnabled(systemMicrosoftGraphApiEnabled)
+                                .setMicrosoftGraphApiSaveToSentItems(systemMicrosoftGraphApiSaveToSentItems);
     }
 
     /**
@@ -178,7 +209,12 @@ public class SMTPConfiguration {
                                 .setMailSenderName(settings.get("mail.senderName").getString())
                                 .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean())
                                 .setTrustedServers(settings.get("mail.trustedServers").getString())
-                                .setCheckServerIdentity(settings.get("mail.checkServerIdentity").asBoolean());
+                                .setCheckServerIdentity(settings.get("mail.checkServerIdentity").asBoolean())
+                                .setMicrosoftGraphApiEndpoint(settings.get("mail.microsoftGraphApi.endpoint")
+                                                                      .getString())
+                                .setMicrosoftGraphApiEnabled(settings.get("mail.microsoftGraphApi.enabled").asBoolean())
+                                .setMicrosoftGraphApiSaveToSentItems(settings.get(
+                                        "mail.microsoftGraphApi.saveToSentItems").asBoolean());
     }
 
     /**
@@ -309,6 +345,18 @@ public class SMTPConfiguration {
      */
     public boolean isUseSenderAndEnvelopeFrom() {
         return useSenderAndEnvelopeFrom;
+    }
+
+    public String getMicrosoftGraphApiEndpoint() {
+        return microsoftGraphApiEndpoint;
+    }
+
+    public boolean isMicrosoftGraphApiEnabled() {
+        return microsoftGraphApiEnabled;
+    }
+
+    public boolean isMicrosoftGraphApiSaveToSentItems() {
+        return microsoftGraphApiSaveToSentItems;
     }
 
     private static SMTPProtocol asSMTPProtocol(Value setting) {

--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -32,9 +32,7 @@ public class SMTPConfiguration {
     private String trustedServers;
     private boolean checkServerIdentity;
 
-    private String microsoftGraphApiEndpoint;
-    private boolean microsoftGraphApiEnabled;
-    private boolean microsoftGraphApiSaveToSentItems;
+    private MicrosoftGraphApiConfiguration microsoftGraphApiConfiguration;
 
     @ConfigValue("mail.smtp.host")
     private static String smtpHost;
@@ -144,18 +142,8 @@ public class SMTPConfiguration {
         return this;
     }
 
-    public SMTPConfiguration setMicrosoftGraphApiEndpoint(String microsoftGraphApiEndpoint) {
-        this.microsoftGraphApiEndpoint = microsoftGraphApiEndpoint;
-        return this;
-    }
-
-    public SMTPConfiguration setMicrosoftGraphApiEnabled(boolean microsoftGraphApiEnabled) {
-        this.microsoftGraphApiEnabled = microsoftGraphApiEnabled;
-        return this;
-    }
-
-    public SMTPConfiguration setMicrosoftGraphApiSaveToSentItems(boolean microsoftGraphApiSaveToSentItems) {
-        this.microsoftGraphApiSaveToSentItems = microsoftGraphApiSaveToSentItems;
+    public SMTPConfiguration setMicrosoftGraphApiConfiguration(MicrosoftGraphApiConfiguration microsoftGraphApiConfiguration) {
+        this.microsoftGraphApiConfiguration = microsoftGraphApiConfiguration;
         return this;
     }
 
@@ -165,6 +153,11 @@ public class SMTPConfiguration {
      * @return a new configuration based on the config files.
      */
     public static SMTPConfiguration fromConfig() {
+        MicrosoftGraphApiConfiguration microsoftGraphApiConfig = new MicrosoftGraphApiConfiguration(
+                systemMicrosoftGraphApiEnabled,
+                systemMicrosoftGraphApiEndpoint,
+                systemMicrosoftGraphApiSaveToSentItems);
+
         return SMTPConfiguration.create()
                                 .setHost(smtpHost)
                                 .setPort(smtpPort)
@@ -177,9 +170,7 @@ public class SMTPConfiguration {
                                 .setUseSenderAndEnvelopeFrom(smtpUseEnvelopeFrom)
                                 .setTrustedServers(smtpTrustedServers)
                                 .setCheckServerIdentity(smtpCheckServerIdentity)
-                                .setMicrosoftGraphApiEndpoint(systemMicrosoftGraphApiEndpoint)
-                                .setMicrosoftGraphApiEnabled(systemMicrosoftGraphApiEnabled)
-                                .setMicrosoftGraphApiSaveToSentItems(systemMicrosoftGraphApiSaveToSentItems);
+                                .setMicrosoftGraphApiConfiguration(microsoftGraphApiConfig);
     }
 
     /**
@@ -198,6 +189,11 @@ public class SMTPConfiguration {
      * @return a new configuration based on the given settings.
      */
     public static SMTPConfiguration fromSettings(Settings settings) {
+        MicrosoftGraphApiConfiguration microsoftGraphApiConfig =
+                new MicrosoftGraphApiConfiguration(settings.get("mail.microsoftGraphApi.enabled").asBoolean(),
+                                                   settings.get("mail.microsoftGraphApi.endpoint").getString(),
+                                                   settings.get("mail.microsoftGraphApi.saveToSentItems").asBoolean());
+
         return SMTPConfiguration.create()
                                 .setHost(settings.get("mail.host").getString())
                                 .setPort(settings.get("mail.port").getString())
@@ -210,11 +206,7 @@ public class SMTPConfiguration {
                                 .setUseSenderAndEnvelopeFrom(settings.get("mail.useEnvelopeFrom").asBoolean())
                                 .setTrustedServers(settings.get("mail.trustedServers").getString())
                                 .setCheckServerIdentity(settings.get("mail.checkServerIdentity").asBoolean())
-                                .setMicrosoftGraphApiEndpoint(settings.get("mail.microsoftGraphApi.endpoint")
-                                                                      .getString())
-                                .setMicrosoftGraphApiEnabled(settings.get("mail.microsoftGraphApi.enabled").asBoolean())
-                                .setMicrosoftGraphApiSaveToSentItems(settings.get(
-                                        "mail.microsoftGraphApi.saveToSentItems").asBoolean());
+                                .setMicrosoftGraphApiConfiguration(microsoftGraphApiConfig);
     }
 
     /**
@@ -347,16 +339,8 @@ public class SMTPConfiguration {
         return useSenderAndEnvelopeFrom;
     }
 
-    public String getMicrosoftGraphApiEndpoint() {
-        return microsoftGraphApiEndpoint;
-    }
-
-    public boolean isMicrosoftGraphApiEnabled() {
-        return microsoftGraphApiEnabled;
-    }
-
-    public boolean isMicrosoftGraphApiSaveToSentItems() {
-        return microsoftGraphApiSaveToSentItems;
+    public MicrosoftGraphApiConfiguration getMicrosoftGraphApiConfiguration() {
+        return microsoftGraphApiConfiguration;
     }
 
     private static SMTPProtocol asSMTPProtocol(Value setting) {

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -33,11 +33,13 @@ import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.nls.Formatter;
 import sirius.web.security.UserContext;
 import sirius.web.security.oauth.OAuthTokenProviderUtils;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -203,8 +205,10 @@ class SendMailTask implements Runnable {
         try {
             Mails.LOG.FINE("Sending eMail: " + mail.subject + " to: " + mail.receiverEmail);
 
-            if (MicrosoftGraphApiMail.isEnabled()) {
-                MicrosoftGraphApiMail.createFromMail(mail).send();
+            if (config.isMicrosoftGraphApiEnabled()) {
+                MicrosoftGraphApiMail.createFromMail(mail,
+                                                     createMicrosoftGraphApiEndpoint(),
+                                                     config.isMicrosoftGraphApiSaveToSentItems()).send();
             } else {
                 Session session = getMailSession(config);
                 try (Transport transport = getSMTPTransport(session, config)) {
@@ -246,6 +250,22 @@ class SendMailTask implements Runnable {
         tasks.forgetSynchronizer(mail.internalMessageId);
         logSentMail();
         mails.collectMailSendMetric(mailSendTime.elapsedMillis());
+    }
+
+    /**
+     * Creates the endpoint to use for sending mails via the Microsoft Graph API.
+     * <p>
+     * The sender email (that is used as part of the endpoint) is the first filled one,
+     * either {@link MailSender#getSenderEmail()}, {@link SMTPConfiguration#getMailSender()} or
+     * {@link SMTPConfiguration#getDefaultSender()}.
+     *
+     * @return the endpoint to use for sending mails via the Microsoft Graph API
+     */
+    private URI createMicrosoftGraphApiEndpoint() {
+        String effectiveSenderMail = Strings.firstFilled(mail.senderEmail, technicalSender);
+        return URI.create(Formatter.create(config.getMicrosoftGraphApiEndpoint())
+                                   .set("user", effectiveSenderMail)
+                                   .format());
     }
 
     private void sendMailViaTransport(Session session, Transport transport) {

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -205,10 +205,11 @@ class SendMailTask implements Runnable {
         try {
             Mails.LOG.FINE("Sending eMail: " + mail.subject + " to: " + mail.receiverEmail);
 
-            if (config.isMicrosoftGraphApiEnabled()) {
+            if (config.getMicrosoftGraphApiConfiguration().enabled()) {
                 MicrosoftGraphApiMail.createFromMail(mail,
                                                      createMicrosoftGraphApiEndpoint(),
-                                                     config.isMicrosoftGraphApiSaveToSentItems()).send();
+                                                     config.getMicrosoftGraphApiConfiguration().saveToSentItems())
+                                     .send();
             } else {
                 Session session = getMailSession(config);
                 try (Transport transport = getSMTPTransport(session, config)) {
@@ -263,7 +264,7 @@ class SendMailTask implements Runnable {
      */
     private URI createMicrosoftGraphApiEndpoint() {
         String effectiveSenderMail = Strings.firstFilled(mail.senderEmail, technicalSender);
-        return URI.create(Formatter.create(config.getMicrosoftGraphApiEndpoint())
+        return URI.create(Formatter.create(config.getMicrosoftGraphApiConfiguration().endpoint())
                                    .set("user", effectiveSenderMail)
                                    .format());
     }

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -609,7 +609,6 @@ mail {
     }
 
     # Contains the configuration used to send mails via the Microsoft Graph API.
-    # Note: Settings may be overridden by scope settings of the same name.
     microsoftGraphApi {
         # The endpoint used to send mails via the Microsoft Graph API. The placeholder ${user} is replaced with the
         # sender user's email address.

--- a/src/main/resources/scope-conf/mail.conf
+++ b/src/main/resources/scope-conf/mail.conf
@@ -43,17 +43,16 @@ mail {
     # Whether the mail server requires early authentication
     useTransportAuthentication = false
 
-    # Overrides settings concerning the Microsoft Graph API.
-    # If left commented out, the settings are determinde by the system configuration.
-    #microsoftGraphApi {
-    #    # The endpoint used to send mails via the Microsoft Graph API. The placeholder ${user} is replaced with the
-    #    # sender user's email address.
-    #    endpoint = "https://graph.microsoft.com/v1.0/users/${user}/sendMail"
-    #
-    #    # Whether to use the Microsoft Graph API to send mails.
-    #    enabled = false
-    #
-    #    # Whether mails sent via the Microsoft Graph API should be saved to the sent items folder at Microsoft.
-    #    saveToSentItems = true
-    #}
+    # Settings for the Microsoft Graph API which is used to send mails via Microsoft 365 instead of using SMTP.
+    microsoftGraphApi {
+        # The endpoint used to send mails via the Microsoft Graph API. The placeholder ${user} is replaced with the
+        # sender user's email address.
+        endpoint = "https://graph.microsoft.com/v1.0/users/${user}/sendMail"
+
+        # Whether to use the Microsoft Graph API to send mails.
+        enabled = false
+
+        # Whether mails sent via the Microsoft Graph API should be saved to the sent items folder at Microsoft.
+        saveToSentItems = true
+    }
 }


### PR DESCRIPTION
### Description

We must set the Microsoft Graph API settings as part of the SMTPConfiguration (altough that name doesn't match) to have a single point of truth: Do we use the system settings or the scope settings?

Also, the mail sender address has no single point of truth, its either in the MailSender object, the SMTPConfiguration, or in the default system settings...

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14716](https://scireum.myjetbrains.com/youtrack/issue/SE-14716)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1557

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
