### PR TITLE
Fixes setting wrong receiver mail address.

### DIFF
--- a/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
+++ b/src/main/java/sirius/web/mails/MicrosoftGraphApiMail.java
@@ -63,7 +63,7 @@ public class MicrosoftGraphApiMail {
         MicrosoftGraphApiMail microsoftGraphApiMail =
                 create().withOAuthTokenName(mail.getSmtpConfiguration().getOAuthTokenName())
                         .withEndpoint(endpoint)
-                        .withReceiverEmailAddress(mail.getReceiverName())
+                        .withReceiverEmailAddress(mail.getReceiverEmail())
                         .withSubject(mail.getSubject())
                         .withSaveToSentItems(saveToSentItems);
 


### PR DESCRIPTION
### Description

This didn't emerge during development because when no name is set, the mail address is also the name :/

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14716](https://scireum.myjetbrains.com/youtrack/issue/SE-14716)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
