### PR TITLE
Add tunnel backpressure handling

### DIFF
--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -12,6 +12,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -25,6 +27,7 @@ import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.netty.request.NettyRequest;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Processor;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.ValueHolder;
@@ -51,6 +54,8 @@ import java.util.stream.Collectors;
  * Performs tunneling into a request by reading from another.
  */
 public class TunnelHandler implements AsyncHandler<String> {
+
+    private static final String BACKPRESSURE_HANDLER_NAME = "tunnelBackpressure";
 
     private static final Set<String> NON_TUNNELLED_HEADERS =
             Set.of(HttpHeaderNames.TRANSFER_ENCODING.toString().toLowerCase(),
@@ -88,6 +93,12 @@ public class TunnelHandler implements AsyncHandler<String> {
     private volatile int responseCode = HttpResponseStatus.OK.code();
     private volatile boolean contentLengthKnown;
 
+    @SuppressWarnings("java:S3077")
+    @Explain("Assigned by AsyncHttpClient connection callbacks (including pooled connections) and read from Netty "
+             + "event-loop callbacks that mirror client writability to the upstream channel; volatile provides the "
+             + "required cross-thread visibility.")
+    private volatile Channel upstreamChannel;
+
     private volatile boolean failed;
 
     TunnelHandler(Response response,
@@ -118,6 +129,15 @@ public class TunnelHandler implements AsyncHandler<String> {
     @Override
     public void onTcpConnectSuccess(InetSocketAddress remoteAddress, Channel connection) {
         this.timeToConnect = watch.elapsedMillis();
+        this.upstreamChannel = connection;
+    }
+
+    @Override
+    public void onConnectionPooled(Channel connection) {
+        // Pooled connections never trigger onTcpConnectSuccess, but we still need a reference
+        // to the upstream channel to apply back-pressure (toggling autoRead) once the response
+        // headers have been received.
+        this.upstreamChannel = connection;
     }
 
     @Override
@@ -172,6 +192,8 @@ public class TunnelHandler implements AsyncHandler<String> {
     @Override
     public State onHeadersReceived(HttpHeaders httpHeaders) throws Exception {
         CallContext.setCurrent(callContext);
+
+        installBackpressureBridge();
 
         if (webContext.responseCommitted) {
             if (WebServer.LOG.isFINE()) {
@@ -324,6 +346,86 @@ public class TunnelHandler implements AsyncHandler<String> {
         }
     }
 
+    /**
+     * Installs an inbound handler in the client-side pipeline which mirrors the writability of the client channel
+     * onto the upstream channel's {@code autoRead} flag.
+     * <p>
+     * This implements proper back-pressure based on Netty's write-buffer high/low watermarks: as soon as the
+     * outbound buffer of the slow client crosses the high watermark, reading from the upstream is paused; once it
+     * drops below the low watermark, reading is resumed.
+     */
+    @SuppressWarnings("resource")
+    @Explain("The clientChannel eventLoop gets managed by Netty. We must not close it here.")
+    private void installBackpressureBridge() {
+        Channel clientChannel = response.getChannelHandlerContext().channel();
+        clientChannel.eventLoop().execute(() -> {
+            if (clientChannel.pipeline().context(BACKPRESSURE_HANDLER_NAME) != null) {
+                // onHeadersReceived may be invoked more than once (e.g. for interim 1xx responses) -
+                // keep the bridge that was installed first.
+                return;
+            }
+            ChannelInboundHandlerAdapter bridge = new ChannelInboundHandlerAdapter() {
+                @Override
+                public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+                    mirrorWritabilityToUpstream(ctx.channel().isWritable());
+                    ctx.fireChannelWritabilityChanged();
+                }
+
+                @Override
+                public void handlerRemoved(ChannelHandlerContext ctx) {
+                    mirrorWritabilityToUpstream(true);
+                }
+            };
+            // The pipeline name "handler" is registered by WebServerInitializer for WebServerHandler.
+            if (clientChannel.pipeline().get("handler") != null) {
+                clientChannel.pipeline().addBefore("handler", BACKPRESSURE_HANDLER_NAME, bridge);
+            } else {
+                clientChannel.pipeline().addLast(BACKPRESSURE_HANDLER_NAME, bridge);
+            }
+            // channelWritabilityChanged only fires on transitions, so apply the current writability
+            // immediately to avoid missing an already-unwritable client at install time.
+            mirrorWritabilityToUpstream(clientChannel.isWritable());
+        });
+    }
+
+    @SuppressWarnings("resource")
+    @Explain("The clientChannel eventLoop gets managed by Netty.")
+    private void removeBackpressureBridge() {
+        Channel clientChannel = response.getChannelHandlerContext().channel();
+        clientChannel.eventLoop().execute(() -> {
+            if (clientChannel.pipeline().context(BACKPRESSURE_HANDLER_NAME) != null) {
+                // handlerRemoved restores the upstream autoRead flag.
+                clientChannel.pipeline().remove(BACKPRESSURE_HANDLER_NAME);
+            } else {
+                // Defensive fallback: if the handler was never actually added (e.g. the install
+                // lambda ran on an already closed pipeline), make sure upstream is not left paused.
+                mirrorWritabilityToUpstream(true);
+            }
+        });
+    }
+
+    /**
+     * Mirrors the given writability state onto the upstream channel's {@code autoRead} flag,
+     * making sure the mutation happens on the upstream channel's own event loop.
+     */
+    @SuppressWarnings("resource")
+    @Explain("The upstream eventLoop gets managed by Netty.")
+    private void mirrorWritabilityToUpstream(boolean writable) {
+        Channel up = upstreamChannel;
+        if (up == null || !up.isOpen()) {
+            return;
+        }
+        if (up.eventLoop().inEventLoop()) {
+            up.config().setAutoRead(writable);
+        } else {
+            up.eventLoop().execute(() -> {
+                if (up.isOpen()) {
+                    up.config().setAutoRead(writable);
+                }
+            });
+        }
+    }
+
     private void commitAndCompleteResponse(HttpResponseBodyPart bodyPart, ByteBuf data) {
         HttpResponse res = response.createFullResponse(HttpResponseStatus.valueOf(responseCode), true, data);
         HttpUtil.setContentLength(res, bodyPart.getBodyByteBuffer().remaining());
@@ -388,6 +490,8 @@ public class TunnelHandler implements AsyncHandler<String> {
 
     @Override
     public String onCompleted() throws Exception {
+        removeBackpressureBridge();
+
         if (completionHandler != null) {
             completionHandler.accept(this);
         }
@@ -467,6 +571,8 @@ public class TunnelHandler implements AsyncHandler<String> {
 
     @Override
     public void onThrowable(Throwable throwable) {
+        removeBackpressureBridge();
+
         CallContext.setCurrent(callContext);
 
         WebServer.LOG.WARN("Tunnel - ERROR %s for tunneling to '%s' performed at '%s'",

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -366,13 +366,13 @@ public class TunnelHandler implements AsyncHandler<String> {
             }
             ChannelInboundHandlerAdapter bridge = new ChannelInboundHandlerAdapter() {
                 @Override
-                public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-                    mirrorWritabilityToUpstream(ctx.channel().isWritable());
-                    ctx.fireChannelWritabilityChanged();
+                public void channelWritabilityChanged(ChannelHandlerContext context) throws Exception {
+                    mirrorWritabilityToUpstream(context.channel().isWritable());
+                    context.fireChannelWritabilityChanged();
                 }
 
                 @Override
-                public void handlerRemoved(ChannelHandlerContext ctx) {
+                public void handlerRemoved(ChannelHandlerContext context) {
                     mirrorWritabilityToUpstream(true);
                 }
             };
@@ -411,25 +411,25 @@ public class TunnelHandler implements AsyncHandler<String> {
     @SuppressWarnings("resource")
     @Explain("The upstream eventLoop gets managed by Netty.")
     private void mirrorWritabilityToUpstream(boolean writable) {
-        Channel up = upstreamChannel;
-        if (up == null || !up.isOpen()) {
+        Channel upstream = upstreamChannel;
+        if (upstream == null || !upstream.isOpen()) {
             return;
         }
-        if (up.eventLoop().inEventLoop()) {
-            up.config().setAutoRead(writable);
+        if (upstream.eventLoop().inEventLoop()) {
+            upstream.config().setAutoRead(writable);
         } else {
-            up.eventLoop().execute(() -> {
-                if (up.isOpen()) {
-                    up.config().setAutoRead(writable);
+            upstream.eventLoop().execute(() -> {
+                if (upstream.isOpen()) {
+                    upstream.config().setAutoRead(writable);
                 }
             });
         }
     }
 
     private void commitAndCompleteResponse(HttpResponseBodyPart bodyPart, ByteBuf data) {
-        HttpResponse res = response.createFullResponse(HttpResponseStatus.valueOf(responseCode), true, data);
-        HttpUtil.setContentLength(res, bodyPart.getBodyByteBuffer().remaining());
-        response.complete(response.commit(res));
+        HttpResponse fullResponse = response.createFullResponse(HttpResponseStatus.valueOf(responseCode), true, data);
+        HttpUtil.setContentLength(fullResponse, bodyPart.getBodyByteBuffer().remaining());
+        response.complete(response.commit(fullResponse));
     }
 
     private void completeResponse(HttpResponseBodyPart bodyPart) throws Exception {
@@ -509,10 +509,10 @@ public class TunnelHandler implements AsyncHandler<String> {
             WebServer.LOG.FINE("Tunnel - COMPLETE for %s", webContext.getRequestedURI());
         }
         if (!webContext.responseCommitted) {
-            HttpResponse res =
+            HttpResponse fullResponse =
                     response.createFullResponse(HttpResponseStatus.valueOf(responseCode), true, Unpooled.EMPTY_BUFFER);
-            HttpUtil.setContentLength(res, 0);
-            response.complete(response.commit(res));
+            HttpUtil.setContentLength(fullResponse, 0);
+            response.complete(response.commit(fullResponse));
         } else if (!webContext.responseCompleted) {
             ChannelFuture writeFuture =
                     response.getChannelHandlerContext().writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -168,6 +168,11 @@ public class TestController extends BasicController {
         webContext.respondWith().tunnel("http://localhost:9999/api/test/test_large");
     }
 
+    @Routed("/tunnel/streaming-payload")
+    public void tunnelStreamingPayload(WebContext webContext) {
+        webContext.respondWith().tunnel("http://localhost:9999/test/streaming-payload");
+    }
+
     @Routed("/tunnel/test_transform")
     public void tunnelTestTransform(WebContext webContext) {
         webContext.respondWith().tunnel("http://localhost:9999/api/test/test_large", buffer -> {

--- a/src/test/java/sirius/web/dispatch/TestDispatcher.java
+++ b/src/test/java/sirius/web/dispatch/TestDispatcher.java
@@ -10,6 +10,7 @@ package sirius.web.dispatch;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.kernel.di.std.Register;
+import sirius.web.http.ChunkedOutputStream;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
 
@@ -24,6 +25,16 @@ public class TestDispatcher implements WebDispatcher {
         return 100;
     }
 
+    /**
+     * Number of 18-byte chunks emitted by {@link #STREAMING_PAYLOAD_PATH}. Yields ~20 MiB per
+     * response, well above Netty's default high watermark (64 KiB) so that any test which slows
+     * down the consumer forces the tunnel's back-pressure bridge through multiple writability
+     * transitions.
+     */
+    public static final int STREAMING_PAYLOAD_CHUNKS = 1_200_000;
+    public static final int STREAMING_PAYLOAD_TOTAL_BYTES = STREAMING_PAYLOAD_CHUNKS * 18;
+    public static final String STREAMING_PAYLOAD_PATH = "/test/streaming-payload";
+
     @Override
     public DispatchDecision dispatch(WebContext ctx) throws Exception {
         if ("/large-blocking-calls".equalsIgnoreCase(ctx.getRequestedURI())) {
@@ -31,6 +42,22 @@ public class TestDispatcher implements WebDispatcher {
             OutputStream out = ctx.respondWith().outputStream(HttpResponseStatus.OK, "text/plain");
             for (int i = 0; i < 10000000; i++) {
                 out.write("THISISLARGECONTENT".getBytes(StandardCharsets.UTF_8));
+            }
+            out.close();
+            return DispatchDecision.DONE;
+        }
+        if (STREAMING_PAYLOAD_PATH.equalsIgnoreCase(ctx.getRequestedURI())) {
+            // Contention control makes the dispatcher block until each chunk has been written to
+            // the socket, which emulates what a real remote backend would see under TCP flow
+            // control. Without it, the dispatcher would dump the entire payload into its own Netty
+            // outbound buffer on the same JVM, masking any back-pressure applied on the tunnel
+            // side.
+            ChunkedOutputStream out = ctx.respondWith()
+                                         .outputStream(HttpResponseStatus.OK, "text/plain")
+                                         .enableContentionControl();
+            byte[] chunk = "THISISLARGECONTENT".getBytes(StandardCharsets.UTF_8);
+            for (int i = 0; i < STREAMING_PAYLOAD_CHUNKS; i++) {
+                out.write(chunk);
             }
             out.close();
             return DispatchDecision.DONE;

--- a/src/test/kotlin/sirius/web/http/TestChannelTracker.kt
+++ b/src/test/kotlin/sirius/web/http/TestChannelTracker.kt
@@ -1,0 +1,97 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http
+
+import io.netty.channel.Channel
+import io.netty.channel.ChannelHandler
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import sirius.kernel.Startable
+import sirius.kernel.di.Injector
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Test-only helper that tracks all server-side child channels accepted by the [WebServer] for the
+ * lifetime of the test JVM.
+ *
+ * The tracker works without any production-code change by attaching a [ChannelHandler] to the
+ * front of the listening (server) channel's pipeline. Netty dispatches every accepted child
+ * channel through the server channel's pipeline as a [channelRead] event (where `msg` is the new
+ * child [Channel]) before `ServerBootstrapAcceptor` takes over. By intercepting that event, the
+ * tracker learns about every new connection and registers a close listener to forget the channel
+ * when it terminates.
+ *
+ * Usage:
+ * ```
+ * TestChannelTracker.install()
+ * // ... perform requests ...
+ * val pending = TestChannelTracker.totalPendingOutboundBytes()
+ * ```
+ *
+ * [install] is idempotent; the handler is added only on the first call.
+ */
+internal object TestChannelTracker {
+
+    private const val HANDLER_NAME = "testChannelTracker"
+
+    private val active: MutableSet<Channel> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Installs the tracker on the [WebServer]'s listening channel if it has not been installed
+     * yet. Safe to call multiple times.
+     */
+    fun install() {
+        // WebServer is registered for its auto-registered interfaces (Startable, Stoppable, etc.),
+        // not for the class itself. Look it up via one of those interfaces.
+        val webServer = Injector.context().getParts(Startable::class.java)
+            .filterIsInstance<WebServer>()
+            .firstOrNull()
+            ?: error("WebServer part is not available")
+        val serverChannel = extractServerChannel(webServer)
+            ?: error("WebServer has not been bound yet - cannot install test channel tracker")
+
+        val pipeline = serverChannel.pipeline()
+        if (pipeline.get(HANDLER_NAME) != null) {
+            return
+        }
+        pipeline.addFirst(HANDLER_NAME, Tracker())
+    }
+
+    /**
+     * Returns a snapshot of the currently tracked child channels.
+     */
+    fun activeChannels(): Set<Channel> = active.toSet()
+
+    /**
+     * Returns the sum of [io.netty.channel.ChannelOutboundBuffer.totalPendingWriteBytes] across
+     * all currently tracked channels. Channels without an outbound buffer (e.g. already closed)
+     * are ignored.
+     */
+    fun totalPendingOutboundBytes(): Long = active.sumOf { channel ->
+        if (!channel.isOpen) 0L
+        else channel.unsafe().outboundBuffer()?.totalPendingWriteBytes() ?: 0L
+    }
+
+    private fun extractServerChannel(webServer: WebServer): Channel? {
+        val field = WebServer::class.java.getDeclaredField("channel")
+        field.isAccessible = true
+        return field.get(webServer) as Channel?
+    }
+
+    @ChannelHandler.Sharable
+    private class Tracker : ChannelInboundHandlerAdapter() {
+        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+            if (msg is Channel) {
+                active.add(msg)
+                msg.closeFuture().addListener { active.remove(msg) }
+            }
+            super.channelRead(ctx, msg)
+        }
+    }
+}

--- a/src/test/kotlin/sirius/web/http/TestChannelTracker.kt
+++ b/src/test/kotlin/sirius/web/http/TestChannelTracker.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * The tracker works without any production-code change by attaching a [ChannelHandler] to the
  * front of the listening (server) channel's pipeline. Netty dispatches every accepted child
- * channel through the server channel's pipeline as a [channelRead] event (where `msg` is the new
+ * channel through the server channel's pipeline as a [channelRead] event (where `message` is the new
  * child [Channel]) before `ServerBootstrapAcceptor` takes over. By intercepting that event, the
  * tracker learns about every new connection and registers a close listener to forget the channel
  * when it terminates.
@@ -86,12 +86,12 @@ internal object TestChannelTracker {
 
     @ChannelHandler.Sharable
     private class Tracker : ChannelInboundHandlerAdapter() {
-        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
-            if (msg is Channel) {
-                active.add(msg)
-                msg.closeFuture().addListener { active.remove(msg) }
+        override fun channelRead(context: ChannelHandlerContext, message: Any) {
+            if (message is Channel) {
+                active.add(message)
+                message.closeFuture().addListener { active.remove(message) }
             }
-            super.channelRead(ctx, msg)
+            super.channelRead(context, message)
         }
     }
 }

--- a/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
@@ -12,7 +12,8 @@ import io.netty.bootstrap.Bootstrap
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.ChannelInitializer
-import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.MultiThreadIoEventLoopGroup
+import io.netty.channel.nio.NioIoHandler
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.codec.http.*
@@ -76,7 +77,7 @@ class WebServerNightlyTest {
 
         val responses = ArrayList<HttpResponse>()
 
-        val workerGroup = NioEventLoopGroup()
+        val workerGroup = MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())
 
         try {
             val bootstrap = Bootstrap()

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -11,9 +11,23 @@
 package sirius.web.http
 
 
+import io.netty.bootstrap.Bootstrap
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.codec.http.DefaultFullHttpRequest
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpClientCodec
 import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpObjectAggregator
 import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
 import org.junit.jupiter.api.Test
+import sirius.web.dispatch.TestDispatcher
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -28,8 +42,11 @@ import sirius.kernel.health.Log
 import sirius.kernel.health.LogHelper
 import java.io.IOException
 import java.net.HttpURLConnection
+import java.net.Socket
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.util.Collections
+import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -319,6 +336,170 @@ class WebServerTest {
         val data = callAndRead(uri, null, expectedHeaders)
 
         assertEquals("{\"success\":true,\"error\":false,\"test\":true}", data)
+    }
+
+    /**
+     * Tunnels a streaming payload through the back-pressure bridge while the client deliberately
+     * reads slowly.
+     * <p>
+     * The payload exceeds Netty's default high watermark (64 KiB), which forces the bridge to
+     * toggle {@code autoRead} on the upstream channel. The test verifies that the full payload
+     * arrives intact, i.e. that back-pressure never deadlocks the tunnel and that
+     * {@code autoRead} is eventually restored.
+     */
+    @Test
+    fun `Large tunneled payload is delivered completely to a slow consumer`() {
+        val connection =
+            URI("http://localhost:9999/tunnel/streaming-payload").toURL().openConnection() as HttpURLConnection
+        connection.connect()
+
+        var totalBytes = 0
+        // Reads in 8 KiB blocks so the artificial per-iteration sleep still exercises the bridge
+        // across multiple writability transitions without inflating the test's wall-clock time.
+        val chunk = ByteArray(8 * 1024)
+        var read: Int
+        try {
+            connection.inputStream.use { input ->
+                while (input.read(chunk).also { read = it } > 0) {
+                    totalBytes += read
+                    Wait.millis(1)
+                }
+            }
+        } finally {
+            connection.disconnect()
+        }
+
+        assertEquals(TestDispatcher.STREAMING_PAYLOAD_TOTAL_BYTES, totalBytes)
+    }
+
+    /**
+     * Sends multiple HTTP/1.1 keep-alive requests over a single Netty channel and waits for each
+     * full response before sending the next request.
+     * <p>
+     * Each response tunnels a payload that exceeds Netty's high watermark.
+     * <p>
+     * This exercises the full lifecycle of the back-pressure bridge across connection reuse. If the
+     * bridge were not properly removed after a response, the next tunnel attempt would cause a
+     * {@code DuplicateChannelHandlerNameException} inside the server-side event loop. While Netty
+     * swallows that exception, the bridge would not be installed for subsequent requests, leaving
+     * them without any back-pressure protection and eventually leading to corrupt or incomplete
+     * responses under load.
+     */
+    @Test
+    fun `Sequential keep-alive tunnel requests do not leak the backpressure bridge`() {
+        val receivedLengths = Collections.synchronizedList(ArrayList<Int>())
+        val workerGroup = NioEventLoopGroup()
+
+        try {
+            val bootstrap = Bootstrap()
+            bootstrap.group(workerGroup)
+            bootstrap.channel(NioSocketChannel::class.java)
+            bootstrap.handler(object : ChannelInitializer<SocketChannel>() {
+                override fun initChannel(ch: SocketChannel) {
+                    ch.pipeline().addLast(HttpClientCodec())
+                    // Aggregator must hold the full streaming payload (~20 MiB) per response.
+                    ch.pipeline().addLast(HttpObjectAggregator(64 * 1024 * 1024))
+                    ch.pipeline().addLast(object : ChannelInboundHandlerAdapter() {
+                        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+                            if (msg is FullHttpResponse) {
+                                receivedLengths.add(msg.content().readableBytes())
+                                msg.release()
+                                if (receivedLengths.size >= 3) {
+                                    ctx.channel().close()
+                                }
+                            }
+                        }
+                    })
+                }
+            })
+
+            val channel = bootstrap.connect("localhost", 9999).sync().channel()
+            repeat(3) { requestIndex ->
+                val expectedResponses = requestIndex + 1
+                channel.writeAndFlush(
+                    DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.GET,
+                        "/tunnel/streaming-payload"
+                    )
+                ).sync()
+
+                val deadline = System.currentTimeMillis() + 15_000
+                while (receivedLengths.size < expectedResponses && System.currentTimeMillis() < deadline) {
+                    Wait.millis(10)
+                }
+                assertEquals(
+                    expectedResponses,
+                    receivedLengths.size,
+                    "Timed out waiting for response ${requestIndex + 1}"
+                )
+            }
+            channel.close()
+            assertTrue(channel.closeFuture().await(10, TimeUnit.SECONDS), "Timed out waiting for client channel close")
+        } finally {
+            workerGroup.shutdownGracefully()
+        }
+
+        assertEquals(3, receivedLengths.size, "Expected exactly 3 responses")
+        receivedLengths.forEach { length ->
+            assertEquals(TestDispatcher.STREAMING_PAYLOAD_TOTAL_BYTES, length)
+        }
+    }
+
+    /**
+     * Proves that the back-pressure bridge in [TunnelHandler] keeps the server-side outbound
+     * buffer bounded when a client stops reading.
+     * <p>
+     * A raw TCP socket sends a request for a ~20 MiB streaming tunnel response and then never
+     * reads anything. While the request is in flight, the test samples the pending bytes in
+     * every server-side child channel's outbound buffer via [TestChannelTracker].
+     * <p>
+     * Without back-pressure, every body part returned by the upstream HTTP client is immediately
+     * pushed into the client channel's {@link io.netty.channel.ChannelOutboundBuffer}. Since the
+     * stalled client never drains the socket, the buffer grows monotonically toward the full
+     * payload size. With back-pressure, once the client channel's buffer crosses the high
+     * watermark, upstream {@code autoRead} is flipped off and the pipeline stabilises near the
+     * high watermark plus a small amount of slack.
+     */
+    @Test
+    fun `Back-pressure keeps tunnel outbound buffering bounded for a stalled consumer`() {
+        // Measures the exact number of bytes currently queued in every server-side child
+        // channel's outbound buffer. The tracker attaches to the listening channel's pipeline and
+        // therefore covers all HTTP connections to the test WebServer without any modification of
+        // production code.
+        TestChannelTracker.install()
+
+        Socket("localhost", 9999).use { socket ->
+            socket.getOutputStream().apply {
+                write(
+                    ("GET /tunnel/streaming-payload HTTP/1.1\r\n" +
+                            "Host: localhost\r\n" +
+                            "Connection: close\r\n\r\n").toByteArray(StandardCharsets.US_ASCII)
+                )
+                flush()
+            }
+
+            // Sample long enough that, without back-pressure, the entire 20 MiB payload would have
+            // been handed to the client channel's outbound buffer on localhost.
+            var peak = 0L
+            val deadline = System.currentTimeMillis() + 5_000
+            while (System.currentTimeMillis() < deadline) {
+                peak = maxOf(peak, TestChannelTracker.totalPendingOutboundBytes())
+                Wait.millis(25)
+            }
+
+            // Back-pressure keeps the in-flight buffering at ~ high watermark (64 KiB) plus HTTP
+            // framing overhead. Without it, the delta climbs toward the full payload size
+            // (~20 MiB). The threshold is intentionally generous for CI jitter.
+            val threshold = 1L * 1024 * 1024
+            val payload = TestDispatcher.STREAMING_PAYLOAD_TOTAL_BYTES.toLong()
+            assertTrue(
+                peak < threshold,
+                "Peak pending outbound bytes across all server channels: $peak " +
+                        "(payload = $payload, threshold = $threshold). " +
+                        "This indicates the tunnel is not applying back-pressure to the upstream channel."
+            )
+        }
     }
 
     /**

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -397,17 +397,17 @@ class WebServerTest {
             bootstrap.group(workerGroup)
             bootstrap.channel(NioSocketChannel::class.java)
             bootstrap.handler(object : ChannelInitializer<SocketChannel>() {
-                override fun initChannel(ch: SocketChannel) {
-                    ch.pipeline().addLast(HttpClientCodec())
+                override fun initChannel(channel: SocketChannel) {
+                    channel.pipeline().addLast(HttpClientCodec())
                     // Aggregator must hold the full streaming payload (~20 MiB) per response.
-                    ch.pipeline().addLast(HttpObjectAggregator(64 * 1024 * 1024))
-                    ch.pipeline().addLast(object : ChannelInboundHandlerAdapter() {
-                        override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
-                            if (msg is FullHttpResponse) {
-                                receivedLengths.add(msg.content().readableBytes())
-                                msg.release()
+                    channel.pipeline().addLast(HttpObjectAggregator(64 * 1024 * 1024))
+                    channel.pipeline().addLast(object : ChannelInboundHandlerAdapter() {
+                        override fun channelRead(context: ChannelHandlerContext, message: Any) {
+                            if (message is FullHttpResponse) {
+                                receivedLengths.add(message.content().readableBytes())
+                                message.release()
                                 if (receivedLengths.size >= 3) {
-                                    ctx.channel().close()
+                                    context.channel().close()
                                 }
                             }
                         }
@@ -440,8 +440,10 @@ class WebServerTest {
             assertTrue(channel.closeFuture().await(10, TimeUnit.SECONDS), "Timed out waiting for client channel close")
         } finally {
             workerGroup.shutdownGracefully()
-            assertTrue(workerGroup.terminationFuture().await(10, TimeUnit.SECONDS),
-                       "Timed out waiting for client event loop shutdown")
+            assertTrue(
+                workerGroup.terminationFuture().await(10, TimeUnit.SECONDS),
+                "Timed out waiting for client event loop shutdown"
+            )
         }
 
         assertEquals(3, receivedLengths.size, "Expected exactly 3 responses")

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -588,7 +588,7 @@ class WebServerTest {
         url.setDoInput(true)
         url.setDoOutput(true)
         val output = url.outputStream
-        for (index in 1..1024) {
+        repeat(1024) {
             output.write(testByteArray)
         }
         output.close()
@@ -617,7 +617,7 @@ class WebServerTest {
 
         // Write some data and flush so that the server triggers a response
         val output = url.outputStream
-        for (index in 0..1024) {
+        repeat(1025) {
             output.write(testByteArray)
         }
         output.flush()
@@ -625,7 +625,7 @@ class WebServerTest {
         // Slow down to ensure that the response is created and sent
         // Still no IOException is expected, as the server will discard all data..
         Wait.millis(200)
-        for (index in 0..1024) {
+        repeat(1025) {
             output.write(testByteArray)
         }
 

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -15,13 +15,15 @@ import io.netty.bootstrap.Bootstrap
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.ChannelInitializer
-import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.MultiThreadIoEventLoopGroup
+import io.netty.channel.nio.NioIoHandler
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.codec.http.DefaultFullHttpRequest
 import io.netty.handler.codec.http.FullHttpResponse
 import io.netty.handler.codec.http.HttpClientCodec
 import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaderValues
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpObjectAggregator
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -388,7 +390,7 @@ class WebServerTest {
     @Test
     fun `Sequential keep-alive tunnel requests do not leak the backpressure bridge`() {
         val receivedLengths = Collections.synchronizedList(ArrayList<Int>())
-        val workerGroup = NioEventLoopGroup()
+        val workerGroup = MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())
 
         try {
             val bootstrap = Bootstrap()
@@ -438,6 +440,8 @@ class WebServerTest {
             assertTrue(channel.closeFuture().await(10, TimeUnit.SECONDS), "Timed out waiting for client channel close")
         } finally {
             workerGroup.shutdownGracefully()
+            assertTrue(workerGroup.terminationFuture().await(10, TimeUnit.SECONDS),
+                       "Timed out waiting for client event loop shutdown")
         }
 
         assertEquals(3, receivedLengths.size, "Expected exactly 3 responses")
@@ -591,7 +595,7 @@ class WebServerTest {
         val result = String(Streams.toByteArray(url.inputStream), StandardCharsets.UTF_8)
 
         assertEquals(result, (testByteArray.size * 1024).toString())
-        assertEquals(HttpHeaderNames.KEEP_ALIVE.toString(), url.getHeaderField(HttpHeaderNames.CONNECTION.toString()))
+        assertEquals(HttpHeaderValues.KEEP_ALIVE.toString(), url.getHeaderField(HttpHeaderNames.CONNECTION.toString()))
     }
 
     /**


### PR DESCRIPTION
### Description
Add tunnel backpressure handling: 
- to fix the problem that our tunnel handling uses too much memory when serving slowly reading clients from fast sources
- this is reached by mirroring the client writability to upstream channel autoRead
- also adds some regression tests for bounded buffering and keep-alive cleanup, note: "Back-pressure keeps tunnel outbound buffering bounded for a stalled consumer" actually proves that the backpressure feature is working. the other tests ensure general tunnel reading work (still) properly and internal backpressure-netty validity

### Additional Notes
- This PR fixes or works on following ticket(s): [SE-15103](https://scireum.myjetbrains.com/youtrack/issue/SE-15103)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
