### PR TITLE
Remove JSONP callback wrapping for JSON responses

### DIFF
--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -1556,7 +1556,6 @@ public class Response {
      * By default, caching will be disabled. If the generated JSON is small enough, it will be transmitted in
      * one go. Otherwise, a chunked response will be sent.
      * <p>
-     * If a callback parameter is given in the request, the output will automatically be boxed into that function as JSONP.
      *
      * @return a structured output which will be sent as JSON response
      */
@@ -1570,15 +1569,14 @@ public class Response {
      * By default, caching will be disabled. If the generated JSON is small enough, it will be transmitted in
      * one go. Otherwise, a chunked response will be sent. The response will have the given {@link HttpResponseStatus}.
      * <p>
-     * If a callback parameter is given in the request, the output will automatically be boxed into that function as JSONP.
      *
      * @param status the {@link HttpResponseStatus} the response shall have.
      * @return a structured output which will be sent as JSON response
      */
     public JSONStructuredOutput json(HttpResponseStatus status) {
         String encoding = webContext.safeGet("encoding").first().asString(StandardCharsets.UTF_8.name());
-        String mimeType = MimeHelper.APPLICATION_JSON;
-        return new JSONStructuredOutput(outputStream(status, mimeType + ";charset=" + encoding), null, encoding);
+        return new JSONStructuredOutput(outputStream(status, MimeHelper.APPLICATION_JSON + ";charset=" + encoding),
+                                        encoding);
     }
 
     /**

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -1576,10 +1576,9 @@ public class Response {
      * @return a structured output which will be sent as JSON response
      */
     public JSONStructuredOutput json(HttpResponseStatus status) {
-        String callback = webContext.safeGet("callback").getString();
         String encoding = webContext.safeGet("encoding").first().asString(StandardCharsets.UTF_8.name());
-        String mimeType = Strings.isFilled(callback) ? "application/javascript" : MimeHelper.APPLICATION_JSON;
-        return new JSONStructuredOutput(outputStream(status, mimeType + ";charset=" + encoding), callback, encoding);
+        String mimeType = MimeHelper.APPLICATION_JSON;
+        return new JSONStructuredOutput(outputStream(status, mimeType + ";charset=" + encoding), null, encoding);
     }
 
     /**

--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -131,7 +131,7 @@ public class JSONCall {
      * @throws IOException in case of an IO error while sending the JSON document
      */
     public JSONStructuredOutput getOutput() throws IOException {
-        return new JSONStructuredOutput(outcall.postFromOutput(), null, StandardCharsets.UTF_8.name());
+        return new JSONStructuredOutput(outcall.postFromOutput(), StandardCharsets.UTF_8.name());
     }
 
     private void logRequest(String response) throws IOException {

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -37,7 +37,7 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
      * @param out      the destination for the generated output
      * @param encoding the character encoding to use
      */
-    public JSONStructuredOutput(OutputStream out, @Nullable String callback, String encoding) {
+    public JSONStructuredOutput(OutputStream out, String encoding) {
         try {
             writer = new OutputStreamWriter(out, encoding);
         } catch (UnsupportedEncodingException exception) {
@@ -50,7 +50,7 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
      *
      * @param destination the destination for the generated output
      */
-    public JSONStructuredOutput(Writer destination, @Nullable String callback) {
+    public JSONStructuredOutput(Writer destination) {
         this.writer = destination;
     }
 

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -30,18 +30,15 @@ import java.io.Writer;
 public class JSONStructuredOutput extends AbstractStructuredOutput {
 
     private final Writer writer;
-    private final String callback;
 
     /**
      * Generates a new output, writing to the given output stream.
      *
      * @param out      the destination for the generated output
-     * @param callback name of the callback function for JSONP requests
      * @param encoding the character encoding to use
      */
     public JSONStructuredOutput(OutputStream out, @Nullable String callback, String encoding) {
         try {
-            this.callback = callback;
             writer = new OutputStreamWriter(out, encoding);
         } catch (UnsupportedEncodingException exception) {
             throw Exceptions.handle(exception);
@@ -52,10 +49,8 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
      * Generates a new output, writing to the given writer.
      *
      * @param destination the destination for the generated output
-     * @param callback    name of the callback function for JSONP requests
      */
     public JSONStructuredOutput(Writer destination, @Nullable String callback) {
-        this.callback = callback;
         this.writer = destination;
     }
 
@@ -181,16 +176,7 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
 
     @Override
     public StructuredOutput beginResult() {
-        try {
-            if (Strings.isFilled(callback)) {
-                writer.write(callback);
-                writer.write("(");
-            }
-            beginObject("result");
-        } catch (IOException exception) {
-            throw handleOutputException(exception);
-        }
-
+        beginObject("result");
         return this;
     }
 
@@ -286,9 +272,6 @@ public class JSONStructuredOutput extends AbstractStructuredOutput {
     public void finalizeOutput() {
         try {
             super.endResult();
-            if (Strings.isFilled(callback)) {
-                writer.write(")");
-            }
             writer.close();
         } catch (IOException exception) {
             throw handleOutputException(exception);

--- a/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
+++ b/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
@@ -28,7 +28,7 @@ class JSONStructuredOutputTest {
     @Test
     void writeEmptyArray() {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, null, StandardCharsets.UTF_8.name());
+        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, StandardCharsets.UTF_8.name());
 
         out.beginArray("");
         out.endArray();
@@ -40,7 +40,7 @@ class JSONStructuredOutputTest {
     @Test
     void writeAmountsWithinJacksonObject() {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, null, StandardCharsets.UTF_8.name());
+        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, StandardCharsets.UTF_8.name());
 
         ObjectNode objectNodeWithAmount = Json.createObject();
         objectNodeWithAmount.putPOJO("amountDefault", Amount.of(1.234567));
@@ -57,7 +57,7 @@ class JSONStructuredOutputTest {
     @Test
     void writeJacksonArrayWithObjects() {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, null, StandardCharsets.UTF_8.name());
+        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, StandardCharsets.UTF_8.name());
 
         ArrayNode array = Json.createArray(List.of(new AnObject("a", 1), new AnObject("b", 2)));
         out.writeProperty(null, array);
@@ -70,7 +70,7 @@ class JSONStructuredOutputTest {
     @Test
     void writeJacksonPojoWithObject() {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, null, StandardCharsets.UTF_8.name());
+        JSONStructuredOutput out = new JSONStructuredOutput(byteArrayOutputStream, StandardCharsets.UTF_8.name());
 
         out.writeProperty(null, new POJONode(new AnObject("a", 1)));
         out.finalizeOutput();
@@ -79,21 +79,6 @@ class JSONStructuredOutputTest {
                      {"field1":"a","field2":1}""", byteArrayOutputStream.toString());
     }
 
-    private static class AnObject {
-        private final String field1;
-        private final int field2;
-
-        public AnObject(String field1, int field2) {
-            this.field1 = field1;
-            this.field2 = field2;
-        }
-
-        public String getField1() {
-            return field1;
-        }
-
-        public int getField2() {
-            return field2;
-        }
+    private record AnObject(String field1, int field2) {
     }
 }

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -522,6 +522,25 @@ class WebServerTest {
         assertEquals("Hello_World", Json.parseObject(data).get("test").asText())
     }
 
+    @ParameterizedTest
+    @CsvSource(
+        "foo",
+        "fooBar",
+        "alert('xss')",
+        "alert('xss')//",
+        "alert('xss')/*",
+        "callback%29%3Balert%28%27xss%27%29%3B%2F%2F",
+        "constructor%5B%27prototype%27%5D%5B%27isAdmin%27%5D%3Dtrue"
+    )
+    fun `JSON responses ignore JSONP callback parameters`(callback: String) {
+        val uri = "/test/json?test=Hello_World&callback=$callback"
+        val expectedHeaders = mapOf("content-type" to "application/json;charset=UTF-8")
+
+        val data = callAndRead(uri, null, expectedHeaders)
+
+        assertEquals("""{"success":true,"error":false,"test":"Hello_World"}""", data)
+    }
+
     @Test
     fun `Invoke test-json-param testing built in JSON handling`() {
 

--- a/src/test/kotlin/sirius/web/service/JsonOutputTest.kt
+++ b/src/test/kotlin/sirius/web/service/JsonOutputTest.kt
@@ -23,7 +23,7 @@ class JsonOutputTest {
     @Test
     fun `json output uses attributes`() {
         val outputStream = ByteArrayOutputStream()
-        val jsonOutput = JSONStructuredOutput(outputStream, null, "UTF8");
+        val jsonOutput = JSONStructuredOutput(outputStream, "UTF8");
         jsonOutput.beginResult("test")
         jsonOutput.beginObject("1", Attribute.set("a", "b"))
         jsonOutput.endObject()

--- a/src/test/kotlin/sirius/web/util/CaptchaControllerTest.kt
+++ b/src/test/kotlin/sirius/web/util/CaptchaControllerTest.kt
@@ -32,7 +32,7 @@ class CaptchaControllerTest {
     fun `challenge serialization uses the legacy widget contract`() {
         val challenge = captchaController.createCaptchaChallenge(CAPTCHA_SECRET)
         val outputStream = ByteArrayOutputStream()
-        val jsonOutput = JSONStructuredOutput(outputStream, null, StandardCharsets.UTF_8.name())
+        val jsonOutput = JSONStructuredOutput(outputStream, StandardCharsets.UTF_8.name())
 
         jsonOutput.beginResult()
         captchaController.writeCaptchaChallenge(jsonOutput, challenge)


### PR DESCRIPTION
> [!CAUTION]
> __Breaking changes:__
>
> - `JSONStructuredOutput` no longer accepts a `callback` parameter: Callers need to adjust accordingly!
> - If an HTTP `callback` URL-parameter is provided, Sirius will no longer respond with a JSONP/`application/javascript` response

### Description

- Disabled JSONP callback wrapping for JSON responses, so callback parameters are ignored and responses remain plain application/json.
- Added a regression test covering benign and malicious callback values on an existing JSON endpoint.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1210](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1210)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
