### PR TITLE
BREAKING: Checks for CSRF token for All POST Requests by default

### DIFF
--- a/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
+++ b/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
@@ -26,6 +26,7 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.nls.Formatter;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.Page;
+import sirius.web.http.CSRFHelper;
 import sirius.web.http.WebContext;
 import sirius.web.security.UserContext;
 
@@ -81,5 +82,6 @@ public class SiriusClassAliasProvider implements ClassAliasProvider {
         consumer.accept("Context", Context.class);
         consumer.accept("Wait", Wait.class);
         consumer.accept("Watch", Watch.class);
+        consumer.accept("CSRFHelper", CSRFHelper.class);
     }
 }

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -265,6 +265,11 @@ public class BasicController implements Controller {
         out.endResult();
     }
 
+    @Override
+    public boolean isSkipCsrfValidation() {
+        return false;
+    }
+
     private StructuredOutput createStructuredOutput(WebContext webContext,
                                                     Format format,
                                                     HttpResponseStatus status,

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -248,11 +248,6 @@ public class BasicController implements Controller {
         out.endResult();
     }
 
-    @Override
-    public boolean isSkipCsrfValidation() {
-        return false;
-    }
-
     private StructuredOutput createStructuredOutput(WebContext webContext,
                                                     Format format,
                                                     HttpResponseStatus status,

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -111,23 +111,6 @@ public class BasicController implements Controller {
     }
 
     /**
-     * Throws an error which yields an HTTP 405 (Method Not Allowed) status if the request method isn't a POST.
-     * <p>
-     * Note that this doesn't enforce CSRF tokens.
-     *
-     * @see WebContext#isUnsafePOST()
-     * @see WebContext#ensureSafePOST()
-     */
-    protected void enforceMethodPost(WebContext webContext) {
-        if (!webContext.isUnsafePOST()) {
-            throw Exceptions.createHandled()
-                            .withDirectMessage("A POST request is expected.")
-                            .hint(HTTP_STATUS, HttpResponseStatus.METHOD_NOT_ALLOWED.code())
-                            .handle();
-        }
-    }
-
-    /**
      * Asserts that the given object is non-null.
      * <p>
      * Throws an appropriate error if the object is <tt>null</tt>.

--- a/src/main/java/sirius/web/controller/Controller.java
+++ b/src/main/java/sirius/web/controller/Controller.java
@@ -113,5 +113,7 @@ public interface Controller {
      *
      * @return <tt>true</tt> if the CSRF token validation should be skipped, <tt>false</tt> otherwise
      */
-    boolean isSkipCsrfValidation();
+    default boolean isSkipCsrfValidation() {
+        return false;
+    }
 }

--- a/src/main/java/sirius/web/controller/Controller.java
+++ b/src/main/java/sirius/web/controller/Controller.java
@@ -107,4 +107,11 @@ public interface Controller {
      * @param format     the expected response format
      */
     void onApiError(WebContext webContext, HandledException error, Format format);
+
+    /**
+     * Determines if the CSRF token validation should be skipped for all routes handled by this controller.
+     *
+     * @return <tt>true</tt> if the CSRF token validation should be skipped, <tt>false</tt> otherwise
+     */
+    boolean isSkipCsrfValidation();
 }

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -11,7 +11,6 @@ package sirius.web.controller;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Promise;
 import sirius.kernel.async.TaskContext;
@@ -66,6 +65,9 @@ public class ControllerDispatcher implements WebDispatcher {
 
     @ConfigValue("http.skipCSRFTokens")
     private static boolean skipCsrfTokens;
+
+    @ConfigValue("http.csrfExemptions")
+    private static Set<String> csrfExemptions;
 
     /**
      * Used to log general controller related activities.
@@ -505,6 +507,6 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private boolean isExemptFromCsrfValidation(Route route) {
-        return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getUri());
+        return csrfExemptions.contains(route.getUri());
     }
 }

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -11,6 +11,7 @@ package sirius.web.controller;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Promise;
 import sirius.kernel.async.TaskContext;
@@ -29,6 +30,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.xml.StructuredOutput;
+import sirius.web.http.CSRFHelper;
 import sirius.web.http.Firewall;
 import sirius.web.http.InputStreamHandler;
 import sirius.web.http.Limited;
@@ -62,10 +64,19 @@ public class ControllerDispatcher implements WebDispatcher {
     @ConfigValue("http.maintenanceRetryAfter")
     private static Duration maintenanceRetryAfter;
 
+    @ConfigValue("http.skipCSRFTokens")
+    private static boolean skipCsrfTokens;
+
     /**
      * Used to log general controller related activities.
      */
     public static final Log LOG = Log.get("controller");
+
+    /**
+     * HTTP methods that require CSRF token validation unless explicitly skipped.
+     */
+    public static final Set<HttpMethod> CSRF_VALIDATED_METHODS =
+            Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE);
 
     private static final String SYSTEM_MVC = "MVC";
 
@@ -83,6 +94,9 @@ public class ControllerDispatcher implements WebDispatcher {
 
     @Part
     private Tasks tasks;
+
+    @Part
+    private CSRFHelper csrfHelper;
 
     @Part
     @Nullable
@@ -175,6 +189,8 @@ public class ControllerDispatcher implements WebDispatcher {
                           .error(HttpResponseStatus.SERVICE_UNAVAILABLE);
                 return;
             }
+
+            validateCsrfTokenUnlessSkipped(webContext, route);
 
             // Inject WebContext as first parameter...
             params.addFirst(webContext);
@@ -468,5 +484,27 @@ public class ControllerDispatcher implements WebDispatcher {
                      exception.getClass().getName());
             return null;
         }
+    }
+
+    private void validateCsrfTokenUnlessSkipped(WebContext webContext, Route route) {
+        if (!skipCsrfTokens
+            && !route.isSkipCsrfValidation()
+            && isCsrfValidatedMethod(webContext)
+            && !isExemptFromCsrfValidation(route)
+            && !csrfHelper.hasValidCsrfToken(webContext)) {
+            throw Exceptions.createHandled()
+                            .hint(Controller.HTTP_STATUS, HttpResponseStatus.FORBIDDEN.code())
+                            .withNLSKey("WebContext.invalidCSRFToken")
+                            .handle();
+        }
+    }
+
+    private boolean isCsrfValidatedMethod(WebContext webContext) {
+        return CSRF_VALIDATED_METHODS.contains(webContext.getRequest().method());
+    }
+
+    private static boolean isExemptFromCsrfValidation(Route route) {
+        return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute())
+               || UserContext.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute());
     }
 }

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -486,6 +486,8 @@ public class ControllerDispatcher implements WebDispatcher {
         }
     }
 
+    @SuppressWarnings("java:S1067")
+    @Explain("The check is complex, but that is the nature of having multiple skip options and call cases.")
     private void validateCsrfTokenUnlessSkipped(WebContext webContext, Route route) {
         if (!skipCsrfTokens
             && !route.isSkipCsrfValidation()
@@ -503,8 +505,11 @@ public class ControllerDispatcher implements WebDispatcher {
         return CSRF_VALIDATED_METHODS.contains(webContext.getRequest().method());
     }
 
-    private static boolean isExemptFromCsrfValidation(Route route) {
+    private boolean isExemptFromCsrfValidation(Route route) {
         return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute())
-               || UserContext.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute());
+               || UserContext.getCurrentScope()
+                             .getSettings()
+                             .getStringList("http.csrfExemptions")
+                             .contains(route.getRawRoute());
     }
 }

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -118,7 +118,7 @@ public class ControllerDispatcher implements WebDispatcher {
     @Explain("We actually can use object identity here as this is a marker object.")
     public Callback<WebContext> preparePreDispatch(WebContext webContext) {
         String uri = determineEffectiveURI(webContext);
-        for (final Route route : getRoutes()) {
+        for (Route route : getRoutes()) {
             final List<Object> parameters = shouldExecute(webContext, uri, route, true);
             if (parameters != Route.NO_MATCH && route.matchesHttpMethod(webContext)) {
                 InputStreamHandler handler = new InputStreamHandler();
@@ -219,7 +219,7 @@ public class ControllerDispatcher implements WebDispatcher {
         String uri = determineEffectiveURI(webContext);
         List<Route> routesWithDifferentMethod = new ArrayList<>();
 
-        for (final Route route : getRoutes()) {
+        for (Route route : getRoutes()) {
             final List<Object> parameters = shouldExecute(webContext, uri, route, false);
             if (parameters != Route.NO_MATCH && route.matchesHttpMethod(webContext)) {
                 preparePerformRoute(webContext, route, parameters, null);
@@ -443,7 +443,7 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private void compileController(PriorityCollector<Route> collector, Controller controller) {
-        for (final Method method : controller.getClass().getMethods()) {
+        for (Method method : controller.getClass().getMethods()) {
             if (method.isAnnotationPresent(Routed.class)) {
                 Routed routed = method.getAnnotation(Routed.class);
                 Route route = compileMethod(routed, controller, method);

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -161,6 +161,7 @@ public class ControllerDispatcher implements WebDispatcher {
                                      Route route,
                                      List<Object> params,
                                      InputStreamHandler inputStreamHandler) {
+        webContext.setAttribute(ATTRIBUTE_MATCHED_ROUTE, route.getUri());
 
         Optional<HandledException> optionalException = webContext.checkParameterReadability();
         if (optionalException.isPresent()) {
@@ -283,8 +284,6 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private void executeRoute(WebContext webContext, Route route, List<Object> params) throws Exception {
-        webContext.setAttribute(ATTRIBUTE_MATCHED_ROUTE, route.getUri());
-
         if (route.getApiResponseFormat() != null && route.getApiResponseFormat() != Format.RAW) {
             executeApiCall(webContext, route, params);
         } else {

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -506,10 +506,6 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private boolean isExemptFromCsrfValidation(Route route) {
-        return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute())
-               || UserContext.getCurrentScope()
-                             .getSettings()
-                             .getStringList("http.csrfExemptions")
-                             .contains(route.getRawRoute());
+        return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute());
     }
 }

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -506,6 +506,6 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private boolean isExemptFromCsrfValidation(Route route) {
-        return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getRawRoute());
+        return Sirius.getSettings().getStringList("http.csrfExemptions").contains(route.getUri());
     }
 }

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -72,6 +72,8 @@ public class Route {
     private Set<String> permissions = null;
     private String subScope;
     private boolean deprecated;
+    private boolean skipCsrfValidation;
+    private String rawRoute;
 
     /**
      * Compiles a method defined by a {@link Controller}
@@ -89,6 +91,8 @@ public class Route {
         result.preDispatchable = routed.preDispatchable();
         result.permissions = Permissions.computePermissionsFromAnnotations(method);
         result.deprecated = method.isAnnotationPresent(Deprecated.class);
+        result.skipCsrfValidation = controller.isSkipCsrfValidation() || routed.skipCsrfValidation();
+        result.rawRoute = routed.value();
 
         result.httpMethods.addAll(Arrays.stream(routed.methods())
                                         .map(sirius.web.controller.HttpMethod::toHttpMethod)
@@ -467,6 +471,15 @@ public class Route {
     }
 
     /**
+     * Determines if the CSRF token validation for this route.
+     *
+     * @return <tt>true</tt> if CSRF validation is skipped, <tt>false</tt> otherwise
+     */
+    public boolean isSkipCsrfValidation() {
+        return skipCsrfValidation;
+    }
+
+    /**
      * Returns a string representation of the internal matching pattern, to detect routes which match the same URLs.
      *
      * @return a string representation of the internal matching pattern
@@ -481,6 +494,15 @@ public class Route {
 
     public String getUri() {
         return uri;
+    }
+
+    /**
+     * Returns the raw route string as it is defined in the {@link Routed} annotation, e.g. <tt>/system/api/:1</tt>.
+     *
+     * @return the raw route string as it is defined in the {@link Routed} annotation
+     */
+    public String getRawRoute() {
+        return rawRoute;
     }
 
     /**

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -73,7 +73,6 @@ public class Route {
     private String subScope;
     private boolean deprecated;
     private boolean skipCsrfValidation;
-    private String rawRoute;
 
     /**
      * Compiles a method defined by a {@link Controller}
@@ -92,7 +91,6 @@ public class Route {
         result.permissions = Permissions.computePermissionsFromAnnotations(method);
         result.deprecated = method.isAnnotationPresent(Deprecated.class);
         result.skipCsrfValidation = controller.isSkipCsrfValidation() || routed.skipCsrfValidation();
-        result.rawRoute = routed.value();
 
         result.httpMethods.addAll(Arrays.stream(routed.methods())
                                         .map(sirius.web.controller.HttpMethod::toHttpMethod)
@@ -494,15 +492,6 @@ public class Route {
 
     public String getUri() {
         return uri;
-    }
-
-    /**
-     * Returns the raw route string as it is defined in the {@link Routed} annotation, e.g. <tt>/system/api/:1</tt>.
-     *
-     * @return the raw route string as it is defined in the {@link Routed} annotation
-     */
-    public String getRawRoute() {
-        return rawRoute;
     }
 
     /**

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -471,7 +471,7 @@ public class Route {
     }
 
     /**
-     * Determines if the CSRF token validation for this route.
+     * Determines if CSRF token validation is skipped for this route.
      *
      * @return <tt>true</tt> if CSRF validation is skipped, <tt>false</tt> otherwise
      */

--- a/src/main/java/sirius/web/controller/Routed.java
+++ b/src/main/java/sirius/web/controller/Routed.java
@@ -113,4 +113,15 @@ public @interface Routed {
                                     HttpMethod.OPTIONS,
                                     HttpMethod.PATCH,
                                     HttpMethod.TRACE};
+
+    /**
+     * Determines if the CSRF token validation should be skipped for this route.
+     * <p>
+     * By default, the dispatcher validates the CSRF token for all {@link ControllerDispatcher#CSRF_VALIDATED_METHODS}
+     * requests before invoking the route. Set this to <tt>true</tt> to opt out.
+     *
+     * @return <tt>true</tt> if CSRF validation is skipped for this route, <tt>false</tt> otherwise
+     * @see Controller#isSkipCsrfValidation() for skipping CSRF validation for all routes of a specific controller
+     */
+    boolean skipCsrfValidation() default false;
 }

--- a/src/main/java/sirius/web/controller/Routed.java
+++ b/src/main/java/sirius/web/controller/Routed.java
@@ -96,8 +96,7 @@ public @interface Routed {
      * @return <tt>true</tt> if the method is used to create a JSON response for an AJAX call, <tt>false</tt> otherwise
      * @deprecated Use {@link InternalService} or {@link PublicService}
      */
-    @Deprecated(since = "2021/07/01")
-    boolean jsonCall() default false;
+    @Deprecated(since = "2021/07/01") boolean jsonCall() default false;
 
     /**
      * Determines the HTTP methods supported by the route. By default, all methods are supported.

--- a/src/main/java/sirius/web/health/console/ConsoleController.java
+++ b/src/main/java/sirius/web/health/console/ConsoleController.java
@@ -17,6 +17,7 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.console.Command;
 import sirius.web.controller.BasicController;
+import sirius.web.controller.HttpMethod;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebContext;
 import sirius.web.security.Permission;
@@ -58,7 +59,7 @@ public class ConsoleController extends BasicController {
      * @param out        the output to write the command result to
      * @throws Exception in case of an error when handling a command
      */
-    @Routed("/system/console/api")
+    @Routed(value = "/system/console/api", methods = HttpMethod.POST)
     @Permission(PERMISSION_SYSTEM_CONSOLE)
     @InternalService
     public void consoleApi(WebContext webContext, JSONStructuredOutput out) throws Exception {

--- a/src/main/java/sirius/web/http/CSRFHelper.java
+++ b/src/main/java/sirius/web/http/CSRFHelper.java
@@ -68,11 +68,6 @@ public class CSRFHelper {
         return webContext.getSessionValue(CSRF_TOKEN).asString();
     }
 
-    private boolean isCSRFTokenOutdated(long lastCSRFRecompute) {
-        return Duration.between(Instant.ofEpochMilli(lastCSRFRecompute), Instant.now()).compareTo(csrfTokenLifetime)
-               > 0;
-    }
-
     /**
      * Forces an explicit re-computation of the CSRF token.
      *
@@ -96,6 +91,11 @@ public class CSRFHelper {
         String lastSessionToken = webContext.getSessionValue(PREVIOUS_CSRF_TOKEN).asString();
 
         return Strings.isFilled(requestToken) && isValidRequestToken(requestToken, sessionToken, lastSessionToken);
+    }
+
+    private boolean isCSRFTokenOutdated(long lastCSRFRecompute) {
+        Duration timeSinceLastRecompute = Duration.between(Instant.ofEpochMilli(lastCSRFRecompute), Instant.now());
+        return timeSinceLastRecompute.compareTo(csrfTokenLifetime) > 0;
     }
 
     private boolean isValidRequestToken(String requestToken, String sessionToken, String lastSessionToken) {

--- a/src/main/java/sirius/web/http/CSRFHelper.java
+++ b/src/main/java/sirius/web/http/CSRFHelper.java
@@ -8,6 +8,7 @@
 
 package sirius.web.http;
 
+import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Register;
@@ -81,5 +82,23 @@ public class CSRFHelper {
         webContext.setSessionValue(PREVIOUS_CSRF_TOKEN, webContext.getSessionValue(CSRF_TOKEN).asString());
         webContext.setSessionValue(CSRF_TOKEN, UUID.randomUUID().toString());
         webContext.setSessionValue(LAST_CSRF_RECOMPUTE, Value.of(Instant.now().toEpochMilli()).asString());
+    }
+
+    /**
+     * Determines if the given request contains a valid CSRF token.
+     *
+     * @param webContext the request to check
+     * @return <tt>true</tt> if the request contains a valid CSRF token, <tt>false</tt> otherwise
+     */
+    public boolean hasValidCsrfToken(WebContext webContext) {
+        String requestToken = webContext.get(CSRF_TOKEN).asString();
+        String sessionToken = webContext.getSessionValue(CSRF_TOKEN).asString();
+        String lastSessionToken = webContext.getSessionValue(PREVIOUS_CSRF_TOKEN).asString();
+
+        return Strings.isFilled(requestToken) && isValidRequestToken(requestToken, sessionToken, lastSessionToken);
+    }
+
+    private boolean isValidRequestToken(String requestToken, String sessionToken, String lastSessionToken) {
+        return Strings.areEqual(requestToken, sessionToken) || Strings.areEqual(requestToken, lastSessionToken);
     }
 }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1684,25 +1684,22 @@ public class WebContext implements SubContext {
     }
 
     /**
-     * Determines if the current request is a POST request without checking for a valid CSRF-token.
-     * <p>
-     * A POST request signal the server to alter its state, knowing that side effects will occur.
+     * Determines if the current request should be treated as a POST request.
      *
-     * @return <tt>true</tt> if the method of the current request is POST, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if the method of the current request is POST and that fact isn't hidden, <tt>false</tt> otherwise
      */
-    public boolean isUnsafePOST() {
+    public boolean isPostRequest() {
         return HttpMethod.POST.equals(request.method()) && !hidePost;
     }
 
     /**
      * Hide the fact that this request is a POST request.
      * <p>
-     * Sometimes it is useful to make <tt>isPOST</tt> methods return false even if the
-     * current request is a POST requests. Login forms would be one example. As
-     * a login request is sent to any URL, we don't want a common POST handler to
-     * trigger on that post data.
+     * This can be used to prevent common POST handlers from triggering on this request. This is especially useful for
+     * login forms, as they are often sent to the same URL as the actual page, and we don't want a common POST handler
+     * to trigger on the login data.
      */
-    public void hidePost() {
+    public void hidePostRequest() {
         this.hidePost = true;
     }
 

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -54,7 +54,6 @@ import sirius.pasta.noodle.sandbox.NoodleSandbox;
 import sirius.web.controller.Controller;
 import sirius.web.security.UserContext;
 
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.xml.namespace.NamespaceContext;
@@ -1685,18 +1684,6 @@ public class WebContext implements SubContext {
     }
 
     /**
-     * Determines if the current request is a POST request with checking for a valid CSRF-token.
-     * <p>
-     * A POST request signal the server to alter its state, knowing that side effects will occur.
-     *
-     * @return <tt>true</tt> if the method of the current request is POST and the provided CSRF-token is valid,
-     * <tt>false</tt> otherwise
-     */
-    public boolean isSafePOST() {
-        return isUnsafePOST() && checkCSRFToken();
-    }
-
-    /**
      * Determines if the current request is a POST request without checking for a valid CSRF-token.
      * <p>
      * A POST request signal the server to alter its state, knowing that side effects will occur.
@@ -1705,32 +1692,6 @@ public class WebContext implements SubContext {
      */
     public boolean isUnsafePOST() {
         return HttpMethod.POST.equals(request.method()) && !hidePost;
-    }
-
-    /**
-     * Determines if the current request is a POST request with checking for a valid CSRF-token.
-     * If the token is not valid an exception is thrown in contrast to {@link #isSafePOST()}.
-     * <p>
-     * A POST request signal the server to alter its state, knowing that side effects will occur.
-     *
-     * @return <tt>true</tt> if the method of the current request is POST and the provided CSRF-token is valid,
-     * <tt>false</tt> otherwise
-     */
-    @CheckReturnValue
-    public boolean ensureSafePOST() {
-        if (!isUnsafePOST()) {
-            return false;
-        }
-
-        if (!checkCSRFToken()) {
-            throw Exceptions.createHandled().withNLSKey("WebContext.invalidCSRFToken").handle();
-        }
-
-        return true;
-    }
-
-    private boolean checkCSRFToken() {
-        return csrfHelper.hasValidCsrfToken(this);
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1730,16 +1730,7 @@ public class WebContext implements SubContext {
     }
 
     private boolean checkCSRFToken() {
-        if (skipCSRFTokens) {
-            return true;
-        }
-
-        String requestToken = this.get(CSRFHelper.CSRF_TOKEN).asString();
-        String sessionToken = getSessionValue(CSRFHelper.CSRF_TOKEN).asString();
-        String lastSessionToken = getSessionValue(CSRFHelper.PREVIOUS_CSRF_TOKEN).asString();
-        return Strings.isFilled(requestToken) && (Strings.areEqual(requestToken, sessionToken) || Strings.areEqual(
-                requestToken,
-                lastSessionToken));
+        return csrfHelper.hasValidCsrfToken(this);
     }
 
     /**

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -218,7 +218,7 @@ public abstract class GenericUserManager implements UserManager {
             return null;
         }
 
-        webContext.hidePost();
+        webContext.hidePostRequest();
         UserInfo result = findUserByName(webContext, user);
         if (result == null) {
             UserContext.message(Message.error().withTextMessage(NLS.get("GenericUserManager.invalidSSO")));
@@ -368,7 +368,7 @@ public abstract class GenericUserManager implements UserManager {
             return null;
         }
 
-        webContext.hidePost();
+        webContext.hidePostRequest();
 
         String user = webContext.get(PARAM_USER).trim();
         String passwordOrToken = webContext.getFirstFilled(PARAM_PASSWORD, PARAM_TOKEN).trim();

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -285,6 +285,9 @@ http {
         # Contains the default cache duration for static assets.
         defaultStaticAssetTTL = 6h
     }
+
+    # Contains a list of raw route patterns (e.g. "/system/api/:1") which are exempted from CSRF checks.
+    csrfExemptions = []
 }
 
 # Configures the help system

--- a/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
@@ -14,7 +14,7 @@
 
 <!--@
 Only declare as POST request if no confirmation is required as both simultaneously would clash. In the case of
-requiering confirmation via an extra dialog, it will automatically be a POST request including a CSRF token after the
+requiring confirmation via an extra dialog, it will automatically be a POST request including a CSRF token after the
 user confirms the action.
 -->
 <t:dropdownItem class="@dropdownClass"

--- a/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
@@ -15,7 +15,7 @@
 <!--@
 Only declare as POST request if no confirmation is required as both simultaneously would clash. In the case of
 requiring confirmation via an extra dialog, it will automatically be a POST request including a CSRF token after the
-user confirms the action.
+user confirms the action. TODO SIRI-1223: Fix this.
 -->
 <t:dropdownItem class="@dropdownClass"
                 permission="@permission"

--- a/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
@@ -12,10 +12,16 @@
 
 <i:local name="dropdownClass" value="@apply('danger %s %s', class, withConfirm ? 'confirm-link-js' : '')"/>
 
+<!--@
+Only declare as POST request if no confirmation is required as both simultaneously would clash. In the case of
+requiering confirmation via an extra dialog, it will automatically be a POST request including a CSRF token after the
+user confirms the action.
+-->
 <t:dropdownItem class="@dropdownClass"
                 permission="@permission"
                 framework="@framework"
                 icon="fa-solid fa-trash fa-fw"
                 labelKey="@labelKey"
                 adminOnly="@adminOnly"
+                sendPostRequest="@!withConfirm"
                 url="@(page != null) ? page.linkToCurrentPage(url) : url"/>

--- a/src/main/resources/default/taglib/t/dropdownItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownItem.html.pasta
@@ -13,6 +13,11 @@
 
 <i:pragma name="description" value="Renders menu entry within a tycho template"/>
 
+<!--@
+Note: Do not declare both the 'confirm-link-js' class and 'sendPostRequest=true' at the same time as they clash with
+each other. TODO SIRI-1223: Fix this.
+-->
+
 <i:local name="dataSerialized"
          value="@data.entrySet()
                      .stream()

--- a/src/main/resources/default/taglib/t/dropdownItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownItem.html.pasta
@@ -5,7 +5,8 @@
 <i:arg type="String" name="framework" default=""/>
 <i:arg type="String" name="class" default=""/>
 <i:arg type="String" name="url"/>
-<i:arg type="boolean" name="sendPostRequest" default="false"/>
+<i:arg type="boolean" name="sendPostRequest" default="false"
+       description="Whether to send a POST request (including a CSRF token) instead of a GET request when the dropdown item is clicked"/>
 <i:arg type="boolean" name="adminOnly" default="false"/>
 <i:arg type="String" name="linkTarget" default="_self"/>
 <i:arg type="java.util.Map" name="data" default="java.util.Collections.emptyMap()"/>

--- a/src/main/resources/default/taglib/t/dropdownItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownItem.html.pasta
@@ -28,9 +28,7 @@ each other. TODO SIRI-1223: Fix this.
     <t:permission permission="@permission">
         <i:if test="sendPostRequest">
             <form method="POST" action="@url" target="@linkTarget" <i:raw>@dataSerialized</i:raw>>
-                <input name="CSRFToken"
-                       value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken(WebContext.getCurrent())"
-                       type="hidden"/>
+                <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
                 <button type="submit" class="dropdown-item @if (adminOnly) { admin-link } @class">
                     <i:if test="isFilled(icon)">
                         <i class="@icon fa-fw"></i>

--- a/src/main/resources/default/taglib/t/editForm.html.pasta
+++ b/src/main/resources/default/taglib/t/editForm.html.pasta
@@ -6,5 +6,5 @@
 
 <form id="@id" action="@url" method="post" class="edit-form @class">
     <i:render name="body"/>
-    <input name="CSRFToken" value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()" type="hidden"/>
+    <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
 </form>

--- a/src/main/resources/default/taglib/t/fileUpload.html.pasta
+++ b/src/main/resources/default/taglib/t/fileUpload.html.pasta
@@ -33,11 +33,14 @@
     Dropzone.options[sirius.camelize('@id')] = {
         url: function (files) {
             const uploadUrl = '@raw {@escapeJS(uploadUrl)}';
+            const csrfToken = '@escapeJS(part(sirius.web.http.CSRFHelper.class).getCSRFToken())';
             let parameterIndicator = '?';
             if (uploadUrl.indexOf('?') >= 0) {
                 parameterIndicator = '&';
             }
-            return uploadUrl + parameterIndicator + 'filename=' + encodeURIComponent(files[0].name);
+            return uploadUrl + parameterIndicator
+                + 'filename=' + encodeURIComponent(files[0].name)
+                + '&CSRFToken=' + encodeURIComponent(csrfToken);
         },
         sendFileAsBody: true,
         parallelUploads: ___maxParallelConnections,

--- a/src/main/resources/default/taglib/t/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/t/imageUpload.html.pasta
@@ -36,11 +36,14 @@
     Dropzone.options[sirius.camelize('@id')] = {
         url: function (files) {
             const uploadUrl = '@raw {@escapeJS(uploadUrl)}';
+            const csrfToken = '@escapeJS(part(sirius.web.http.CSRFHelper.class).getCSRFToken())';
             let parameterIndicator = '?';
             if (uploadUrl.indexOf('?') >= 0) {
                 parameterIndicator = '&';
             }
-            return uploadUrl + parameterIndicator + 'filename=' + encodeURIComponent(files[0].name);
+            return uploadUrl + parameterIndicator
+                + 'filename=' + encodeURIComponent(files[0].name)
+                + '&CSRFToken=' + encodeURIComponent(csrfToken);
         },
         sendFileAsBody: true,
         parallelUploads: 1,

--- a/src/main/resources/default/taglib/w/deleteButton.html.pasta
+++ b/src/main/resources/default/taglib/w/deleteButton.html.pasta
@@ -16,5 +16,5 @@
         <i class="fa fa-trash"></i>
         @i18n("NLS.delete")
     </a>
-    <input name="CSRFToken" value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()" type="hidden"/>
+    <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
 </form>

--- a/src/main/resources/default/taglib/w/deleteLink.html.pasta
+++ b/src/main/resources/default/taglib/w/deleteLink.html.pasta
@@ -10,5 +10,5 @@
     <a role="button" class="link link-danger guarded-link @if (adminOnly) {admin-link}" data-deleteid="@deleteFormId">
         @i18n("NLS.delete")
     </a>
-    <input name="CSRFToken" value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()" type="hidden"/>
+    <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
 </form>

--- a/src/main/resources/default/taglib/w/editForm.html.pasta
+++ b/src/main/resources/default/taglib/w/editForm.html.pasta
@@ -5,5 +5,5 @@
 
 <form action="@url" method="post" id="editForm" class="edit-form @class">
     <i:render name="body" />
-    <input name="CSRFToken" value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()" type="hidden"/>
+    <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
 </form>

--- a/src/main/resources/default/taglib/w/fileUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/fileUpload.html.pasta
@@ -11,7 +11,7 @@
         $('.@name').each(function (index) {
             fileUpload('@uploadUrl',
                 this,
-                undefined,
+                {CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'},
                 <i:raw>@allowedExtensions</i:raw>,
                 @maxParallelConnections);
         });

--- a/src/main/resources/default/templates/system/console.html.pasta
+++ b/src/main/resources/default/templates/system/console.html.pasta
@@ -24,7 +24,10 @@
                     }
 
                     term.pause();
-                    $.post('/system/console/api', {command: command})
+                    $.post('/system/console/api', {
+                        command: command,
+                        CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'
+                    })
                         .done(function (response) {
                             term.echo(response.result, {exec: false}).resume();
                         })

--- a/src/main/resources/default/templates/system/console.html.pasta
+++ b/src/main/resources/default/templates/system/console.html.pasta
@@ -27,13 +27,11 @@
                     $.post('/system/console/api', {
                         command: command,
                         CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'
-                    })
-                        .done(function (response) {
-                            term.echo(response.result, {exec: false}).resume();
-                        })
-                        .fail(function (call) {
-                            term.echo("\n", {exec: false}).error(call.responseJSON.message).echo("\n\n", {exec: false}).resume();
-                        });
+                    }).done(function (response) {
+                        term.echo(response.result, {exec: false}).resume();
+                    }).fail(function (call) {
+                        term.echo("\n", {exec: false}).error(call.responseJSON.message).echo("\n\n", {exec: false}).resume();
+                    });
                 }, {
                     prompt: function (output) {
                         const now = new Date();

--- a/src/main/resources/default/templates/tycho/page-dialogs.html.pasta
+++ b/src/main/resources/default/templates/tycho/page-dialogs.html.pasta
@@ -4,8 +4,6 @@
          cancelKey="NLS.cancel">
     <p>@i18n("template.html.confirmText")</p>
     <form action="placeholder" method="post" class="confirm-form-js">
-        <input name="CSRFToken"
-               value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()"
-               type="hidden"/>
+        <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
     </form>
 </t:modal>

--- a/src/test/java/sirius/web/controller/SkipCsrfValidationTestController.java
+++ b/src/test/java/sirius/web/controller/SkipCsrfValidationTestController.java
@@ -1,0 +1,37 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.di.std.Register;
+import sirius.web.http.WebContext;
+
+/**
+ * Test controller used to verify controller-wide CSRF validation skipping via {@link Controller#isSkipCsrfValidation()}.
+ */
+@Register
+public class SkipCsrfValidationTestController extends BasicController {
+
+    @Override
+    public boolean isSkipCsrfValidation() {
+        return true;
+    }
+
+    @Routed(value = "/test/controller-skip-csrf", methods = HttpMethod.POST)
+    public void controllerSkipCsrf(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
+
+    @Routed(value = "/test/controller-skip-csrf/explicit-route-skip",
+            methods = HttpMethod.POST,
+            skipCsrfValidation = true)
+    public void controllerAndRouteSkipCsrf(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
+}

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -59,7 +59,7 @@ public class TestController extends BasicController {
         webContext.respondWith().error(HttpResponseStatus.INTERNAL_SERVER_ERROR, error.getMessage());
     }
 
-    @Routed("/test/post")
+    @Routed(value = "/test/post", skipCsrfValidation = true)
     public void postTest(WebContext webContext) {
         webContext.respondWith()
                   .setHeader(HttpHeaderNames.CONTENT_TYPE, "text/plain")
@@ -138,7 +138,7 @@ public class TestController extends BasicController {
                           null);
     }
 
-    @Routed("/tunnel/test/tune/target")
+    @Routed(value = "/tunnel/test/tune/target", skipCsrfValidation = true)
     public void tunnelTuneTestTarget(WebContext webContext) {
         webContext.respondWith().direct(HttpResponseStatus.OK, webContext.getRequest().method().name());
     }
@@ -191,7 +191,7 @@ public class TestController extends BasicController {
         }, null);
     }
 
-    @Routed(value = "/test/predispatch", preDispatchable = true)
+    @Routed(value = "/test/predispatch", preDispatchable = true, skipCsrfValidation = true)
     public void testPredispatch(WebContext webContext, InputStreamHandler input) throws Exception {
         int size = 0;
         while (input.read() >= 0) {
@@ -201,7 +201,7 @@ public class TestController extends BasicController {
         webContext.respondWith().direct(HttpResponseStatus.OK, String.valueOf(size));
     }
 
-    @Routed(value = "/test/predispatch/abort", preDispatchable = true)
+    @Routed(value = "/test/predispatch/abort", preDispatchable = true, skipCsrfValidation = true)
     public void testPredispatchAbort(WebContext webContext, InputStreamHandler input) {
         webContext.respondWith().direct(HttpResponseStatus.OK, "ABORT");
     }
@@ -259,37 +259,38 @@ public class TestController extends BasicController {
         webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
     }
 
-    @Routed("/test/fake-delete-data")
+    @Routed(value = "/test/fake-delete-data", methods = HttpMethod.POST)
     public void deleteData(WebContext webContext) {
-        if (!webContext.isSafePOST()) {
-            webContext.respondWith().status(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-            return;
-        }
         webContext.respondWith().status(HttpResponseStatus.OK);
     }
 
-    @Routed("/test/fake-delete-data-unsafe")
+    @Routed(value = "/test/fake-delete-data-unsafe", skipCsrfValidation = true)
     public void deleteDataUnsafe(WebContext webContext) {
-        if (!webContext.isUnsafePOST()) {
+        if (!webContext.isPostRequest()) {
             webContext.respondWith().status(HttpResponseStatus.INTERNAL_SERVER_ERROR);
             return;
         }
         webContext.respondWith().status(HttpResponseStatus.OK);
     }
 
-    @Routed("/test/fake-delete-data-ensure-safe")
-    public void deleteDataEnsureSafe(WebContext webContext) {
-        try {
-            if (!webContext.ensureSafePOST()) {
-                webContext.respondWith().status(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-                return;
-            }
-        } catch (HandledException _) {
-            webContext.respondWith().status(HttpResponseStatus.UNAUTHORIZED);
-            return;
-        }
+    @Routed(value = "/test/routed-ensure-safe-post", methods = HttpMethod.POST)
+    public void routedEnsureSafePost(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
 
-        webContext.respondWith().status(HttpResponseStatus.OK);
+    @Routed(value = "/test/routed-split", methods = HttpMethod.GET)
+    public void routedSplitGet(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, "GET");
+    }
+
+    @Routed(value = "/test/routed-split", methods = HttpMethod.POST)
+    public void routedSplitPost(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, "POST");
+    }
+
+    @Routed(value = "/test/routed-skip-csrf", methods = HttpMethod.POST, skipCsrfValidation = true)
+    public void routedSkipCsrf(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
     }
 
     @Routed("/test/provide-security-token")
@@ -335,12 +336,13 @@ public class TestController extends BasicController {
         webContext.respondWith().direct(HttpResponseStatus.OK, "GET OK");
     }
 
-    @Routed(value = "/test/restricted-method", methods = HttpMethod.POST)
+    @Routed(value = "/test/restricted-method", methods = HttpMethod.POST, skipCsrfValidation = true)
     public void postOnlyTest(WebContext webContext) {
         webContext.respondWith().direct(HttpResponseStatus.OK, "POST OK");
     }
 
-    @Routed(value = "/test/restricted-methods", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST})
+    @Routed(value = "/test/restricted-methods", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
+            skipCsrfValidation = true)
     public void getAndPostOnlyTest(WebContext webContext) {
         webContext.respondWith().direct(HttpResponseStatus.OK, "GET/POST OK");
     }
@@ -351,13 +353,14 @@ public class TestController extends BasicController {
         output.property("status", "GET OK");
     }
 
-    @Routed(value = "/test/restricted-method-api", methods = HttpMethod.POST)
+    @Routed(value = "/test/restricted-method-api", methods = HttpMethod.POST, skipCsrfValidation = true)
     @InternalService
     public void postOnlyTest(WebContext webContext, JSONStructuredOutput output) {
         output.property("status", "POST OK");
     }
 
-    @Routed(value = "/test/restricted-methods-api", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST})
+    @Routed(value = "/test/restricted-methods-api", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
+            skipCsrfValidation = true)
     @InternalService
     public void getAndPostOnlyTest(WebContext webContext, JSONStructuredOutput output) {
         output.property("status", "GET/POST OK");

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -106,7 +106,8 @@ public class TestRequest extends WebContext implements HttpRequest {
     /**
      * Creates a mock request simulating a POST on the given uri.
      * <p>
-     * The Request will be sent with a valid CSRF parameter so that it may pass a {@link WebContext#ensureSafePOST()} check.
+     * The request will be sent with a valid CSRF parameter so that routes with automatic CSRF validation can be
+     * invoked.
      *
      * @param uri the relative uri to call
      * @return an instance used to further specify the request to send

--- a/src/test/java/sirius/web/http/TestResponse.java
+++ b/src/test/java/sirius/web/http/TestResponse.java
@@ -251,12 +251,13 @@ public class TestResponse extends Response {
 
     private void completeResponse() {
         innerCallContext = CallContext.getCurrent();
-        responsePromise.success(this);
         webContext.responseCompleted = true;
 
         if (webContext.completionPromise != null) {
             webContext.completionPromise.success(status.code());
         }
+
+        responsePromise.success(this);
     }
 
     @Override

--- a/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
+++ b/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
@@ -19,6 +19,7 @@ import sirius.kernel.commons.Json
 import sirius.web.health.console.ConsoleController
 import sirius.web.http.TestRequest
 import sirius.web.http.TestResponse
+import sirius.web.security.ScopeInfo
 import sirius.web.security.UserContext
 import sirius.web.security.UserInfo
 import java.util.*
@@ -45,7 +46,10 @@ class ConsoleControllerTest {
     fun `System console API returns JSON for help`() {
         UserContext.get().setCurrentUser(
             UserInfo.Builder.createUser("test")
-                .withPermissions(Collections.singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE)).build()
+                .withPermissions(Collections.singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE))
+                // Avoid resolving settings via scope while CSRF is validated (that would clear the test user).
+                .withSettingsSupplier { ScopeInfo.DEFAULT_SCOPE.settings }
+                .build()
         )
         val result = TestRequest.SAFEPOST("/system/console/api")
             .withParameters(Context.create().set("command", "help"))

--- a/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
+++ b/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
@@ -21,39 +21,44 @@ import sirius.web.http.TestRequest
 import sirius.web.http.TestResponse
 import sirius.web.security.UserContext
 import sirius.web.security.UserInfo
+import java.util.*
 import kotlin.test.assertEquals
-import java.util.Collections
 
 @ExtendWith(SiriusExtension::class)
 class ConsoleControllerTest {
     @Test
     fun `System console renders its template`() {
-        UserContext.get().setCurrentUser(UserInfo.Builder.createUser("test")
-            .withPermissions(Collections.
-            singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE))
-            .build())
+        UserContext.get().setCurrentUser(
+            UserInfo.Builder.createUser("test")
+                .withPermissions(
+                    Collections.singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE)
+                )
+                .build()
+        )
         val result = TestRequest.GET("/system/console").execute()
-        assertEquals(HttpResponseStatus.OK,result.getStatus())
-        assertEquals(TestResponse.ResponseType.TEMPLATE, result.getType())
-        assertEquals("/templates/system/console.html.pasta", result.getTemplateName())
+        assertEquals(HttpResponseStatus.OK, result.status)
+        assertEquals(TestResponse.ResponseType.TEMPLATE, result.type)
+        assertEquals("/templates/system/console.html.pasta", result.templateName)
     }
 
     @Test
     fun `System console API returns JSON for help`() {
-        UserContext.get().setCurrentUser(UserInfo.
-        Builder.
-        createUser("test").
-        withPermissions(Collections.singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE)).
-        build())
-        val result = TestRequest.
-        POST("/system/console/api").
-        withParameters(Context.create().set("command", "help")).
-        execute()
+        UserContext.get().setCurrentUser(
+            UserInfo.Builder.createUser("test")
+                .withPermissions(Collections.singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE)).build()
+        )
+        val result = TestRequest.SAFEPOST("/system/console/api")
+            .withParameters(Context.create().set("command", "help"))
+            .execute()
         val json = result.getContentAsJson()
-        assertEquals(HttpResponseStatus.OK,result.getStatus())
-        assertTrue{Json.tryGetAt(json, JsonPointer.compile("/error/code"))
-            .map { Json.convertToValue(it) }.map { it.isEmptyString()}.orElse(true) }
-        assertTrue{ Json.tryGetAt(json, JsonPointer.compile("/result"))
-            .map { Json.convertToValue(it) }.map { it.isFilled() }.orElse(false)}
+        assertEquals(HttpResponseStatus.OK, result.status)
+        assertTrue {
+            Json.tryGetAt(json, JsonPointer.compile("/error/code"))
+                .map { Json.convertToValue(it) }.map { it.isEmptyString }.orElse(true)
+        }
+        assertTrue {
+            Json.tryGetAt(json, JsonPointer.compile("/result"))
+                .map { Json.convertToValue(it) }.map { it.isFilled }.orElse(false)
+        }
     }
 }

--- a/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
+++ b/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
@@ -19,7 +19,6 @@ import sirius.kernel.commons.Json
 import sirius.web.health.console.ConsoleController
 import sirius.web.http.TestRequest
 import sirius.web.http.TestResponse
-import sirius.web.security.ScopeInfo
 import sirius.web.security.UserContext
 import sirius.web.security.UserInfo
 import java.util.*
@@ -47,8 +46,6 @@ class ConsoleControllerTest {
         UserContext.get().setCurrentUser(
             UserInfo.Builder.createUser("test")
                 .withPermissions(Collections.singleton(ConsoleController.PERMISSION_SYSTEM_CONSOLE))
-                // Avoid resolving settings via scope while CSRF is validated (that would clear the test user).
-                .withSettingsSupplier { ScopeInfo.DEFAULT_SCOPE.settings }
                 .build()
         )
         val result = TestRequest.SAFEPOST("/system/console/api")

--- a/src/test/kotlin/sirius/web/http/CSRFTokenTest.kt
+++ b/src/test/kotlin/sirius/web/http/CSRFTokenTest.kt
@@ -23,37 +23,15 @@ import kotlin.test.assertEquals
 class CSRFTokenTest {
 
     @Test
-    fun `safePOST() fails if token is missing via GET`() {
-
-        val result = TestRequest.GET("/test/fake-delete-data").execute()
-
-        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, result.status)
-    }
-
-    @Test
-    fun `safePOST() works if the token is present via GET`() {
-
-        val connection =
-                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
-        connection.requestMethod = "GET"
-        connection.connect()
-        val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
-
-        val result = TestRequest.GET("/test/fake-delete-data?CSRFToken=$token").execute()
-
-        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, result.status)
-    }
-
-    @Test
-    fun `safePOST() fails if token is missing via POST`() {
+    fun `Routed POST fails if token is missing via POST`() {
 
         val result = TestRequest.POST("/test/fake-delete-data").execute()
 
-        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, result.status)
+        assertEquals(HttpResponseStatus.FORBIDDEN, result.status)
     }
 
     @Test
-    fun `safePOST() works on SAFEPOST if correct token is provided`() {
+    fun `Routed POST works on SAFEPOST if correct token is provided`() {
 
         val result = TestRequest.SAFEPOST("/test/fake-delete-data").execute()
 
@@ -61,22 +39,22 @@ class CSRFTokenTest {
     }
 
     @Test
-    fun `safePOST() works if correct token is present via POST`() {
+    fun `Routed POST works if correct token is present via POST`() {
 
         val connection =
-                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+            URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
         connection.requestMethod = "GET"
         connection.connect()
         val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
 
 
         val connection2 = URI(
-                "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
+            "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
         ).toURL().openConnection() as HttpURLConnection
         connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-                HttpHeaderNames.COOKIE.toString(),
-                connection.headerFields["set-cookie"]?.get(0)
+            HttpHeaderNames.COOKIE.toString(),
+            connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
@@ -84,22 +62,22 @@ class CSRFTokenTest {
     }
 
     @Test
-    fun `safePOST() success on POST if expired token is provided`() {
+    fun `Routed POST accepts previous token after token rotation`() {
 
         val connection =
-                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+            URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
         connection.requestMethod = "GET"
         connection.connect()
         val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
         TestRequest.GET("/test/expire-security-token").execute()
 
         val connection2 = URI(
-                "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
+            "http://localhost:9999/test/fake-delete-data?CSRFToken=$token"
         ).toURL().openConnection() as HttpURLConnection
         connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-                HttpHeaderNames.COOKIE.toString(),
-                connection.headerFields["set-cookie"]?.get(0)
+            HttpHeaderNames.COOKIE.toString(),
+            connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
@@ -107,24 +85,24 @@ class CSRFTokenTest {
     }
 
     @Test
-    fun `safePOST() works if false token is given via POST`() {
+    fun `Routed POST fails if false token is given via POST`() {
 
         val connection =
-                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
+            URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
         connection.requestMethod = "GET"
         connection.connect()
 
         val connection2 =
-                URI("http://localhost:9999/test/fake-delete-data?CSRFToken=w-r-o-n-g-t-o-k-e-n").toURL()
-                        .openConnection() as HttpURLConnection
+            URI("http://localhost:9999/test/fake-delete-data?CSRFToken=w-r-o-n-g-t-o-k-e-n").toURL()
+                .openConnection() as HttpURLConnection
         connection2.requestMethod = "POST"
         connection2.setRequestProperty(
-                HttpHeaderNames.COOKIE.toString(),
-                connection.headerFields["set-cookie"]?.get(0)
+            HttpHeaderNames.COOKIE.toString(),
+            connection.headerFields["set-cookie"]?.get(0)
         )
         connection2.connect()
 
-        assertEquals(500, connection2.responseCode)
+        assertEquals(403, connection2.responseCode)
     }
 
     @Test
@@ -144,44 +122,87 @@ class CSRFTokenTest {
     }
 
     @Test
-    fun `ensureSafePOST() fails if token is missing via GET`() {
+    fun `Routed POST fails without CSRF token by default`() {
 
-        val result = TestRequest.GET("/test/fake-delete-data-ensure-safe").execute()
+        val result = TestRequest.POST("/test/routed-ensure-safe-post").execute()
 
-        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, result.status)
+        assertEquals(HttpResponseStatus.FORBIDDEN, result.status)
     }
 
     @Test
-    fun `ensureSafePOST() goes wrong on POST if false token is given`() {
+    fun `Routed POST works on SAFEPOST by default`() {
 
-        val connection = URI(
-                "http://localhost:9999/test/fake-delete-data-ensure-safe?CSRFToken=w-r-o-n-g-t-o-k-e-n"
-        ).toURL().openConnection() as HttpURLConnection
-        connection.requestMethod = "POST"
-        connection.connect()
+        val result = TestRequest.SAFEPOST("/test/routed-ensure-safe-post").execute()
 
-        assertEquals(401, connection.responseCode)
+        assertEquals(HttpResponseStatus.OK, result.status)
     }
 
     @Test
-    fun `ensureSafePOST() works as intended if correct token is given via POST`() {
+    fun `Routed GET allows request without CSRF token`() {
 
-        val connection =
-                URI("http://localhost:9999/test/provide-security-token").toURL().openConnection() as HttpURLConnection
-        connection.requestMethod = "GET"
-        connection.connect()
-        val token = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
+        val result = TestRequest.GET("/test/routed-split").execute()
 
-        val connection2 =
-                URI("http://localhost:9999/test/fake-delete-data-ensure-safe?CSRFToken=$token").toURL()
-                        .openConnection() as HttpURLConnection
-        connection2.requestMethod = "POST"
-        connection2.setRequestProperty(
-                HttpHeaderNames.COOKIE.toString(),
-                connection.headerFields["set-cookie"]?.get(0)
-        )
-        connection2.connect()
+        assertEquals(HttpResponseStatus.OK, result.status)
+        assertEquals("GET", result.contentAsString)
+    }
 
-        assertEquals(200, connection2.getResponseCode())
+    @Test
+    fun `Routed POST rejects request without CSRF token on split route`() {
+
+        val result = TestRequest.POST("/test/routed-split").execute()
+
+        assertEquals(HttpResponseStatus.FORBIDDEN, result.status)
+    }
+
+    @Test
+    fun `Routed POST accepts request with CSRF token on split route`() {
+
+        val result = TestRequest.SAFEPOST("/test/routed-split").execute()
+
+        assertEquals(HttpResponseStatus.OK, result.status)
+        assertEquals("POST", result.contentAsString)
+    }
+
+    @Test
+    fun `Routed skipCsrfValidation allows POST without CSRF token`() {
+
+        val result = TestRequest.POST("/test/routed-skip-csrf").execute()
+
+        assertEquals(HttpResponseStatus.OK, result.status)
+    }
+
+    @Test
+    fun `Controller isSkipCsrfValidation allows POST without CSRF token`() {
+
+        val result = TestRequest.POST("/test/controller-skip-csrf").execute()
+
+        assertEquals(HttpResponseStatus.OK, result.status)
+    }
+
+    @Test
+    fun `Controller isSkipCsrfValidation allows POST even with invalid token`() {
+
+        val result = TestRequest.POST("/test/controller-skip-csrf?CSRFToken=invalid").execute()
+
+        assertEquals(HttpResponseStatus.OK, result.status)
+    }
+
+    @Test
+    fun `Controller isSkipCsrfValidation does not skip CSRF validation on other controllers`() {
+
+        val result = TestRequest.POST("/test/fake-delete-data").execute()
+
+        assertEquals(HttpResponseStatus.FORBIDDEN, result.status)
+    }
+
+    @Test
+    fun `Controller isSkipCsrfValidation skips all routes of the controller`() {
+
+        val withoutToken = TestRequest.POST("/test/controller-skip-csrf/explicit-route-skip").execute()
+        val withInvalidToken =
+            TestRequest.POST("/test/controller-skip-csrf/explicit-route-skip?CSRFToken=invalid").execute()
+
+        assertEquals(HttpResponseStatus.OK, withoutToken.status)
+        assertEquals(HttpResponseStatus.OK, withInvalidToken.status)
     }
 }

--- a/src/test/resources/templates/security-token.html.pasta
+++ b/src/test/resources/templates/security-token.html.pasta
@@ -1,1 +1,1 @@
-@part(sirius.web.http.CSRFHelper.class).getCSRFToken()
+@part(CSRFHelper.class).getCSRFToken()


### PR DESCRIPTION
### Description

POST requests that can be secured by CSRF tokens should be secured by these by default from a security standpoint.

Exceptions are POST requests without an existing session (e.g. login requests) or requests from external systems (e.g. API routes invoked by our clients). These must now be specifically exempt. **This means, the logic which routes check for a CSRF token and which don't has now been inverted!**

---

**BREAKING CHANGES:**
- ALL routes that MAY be invoked via a POST request MUST now either ensure that a CSRF token is sent as part of the request (by providing it in the templates) or they must exempt the route (via `skipCsrfValidation=true` in the `Routed` annotation or by exempting all routes in a controller or via the system or user config).
- `WebContext#hidePost()` was renamed to `WebContext#hidePostRequest`.
- `WebContext#isUnsafePOST()` was renamed to `WebContext#isPostRequest`.
- `WebContext#isSafePOST()` was removed. The CSRF validation is now handled automatically by the dispatcher, so you can be sure that if `WebContext#isPostRequest` returns true and the route is not exempt, the CSRF token will have been validated already and deemed valid.
- `WebContext#ensureSafePOST` was removed. It essentially worked the same as `WebContext#isSafePOST()` but would throw in case the request is a POST request but without providing a CSRF token. Now invoking `WebContext#isPostRequest` effectively does the same thing, althouth the exception in case of a missing CSRF token will be thrown earlier by the dispatcher.
- `BasicController#enforceMethodPost` was removed. Declare `methods = HttpMethod.POST` in the `Routed` annotation to ensure it is only called via POST.
- Controllers must now implement the isSkipCsrfValidation(), if they do not extend BasicController. However, most (if not all) controllers inherit it from BasicController.
- t:dropdownDeleteItem with `withConfirm=false` now uses POST (with a CSRF token) instead of GET.

---

Migration help:

1) Methods that would throw on non-POST requests like this
```
if (!ctx.isUnsafePOST()) {
  throw Exceptions.createHandled().withNLSKey("MyController.notPOST").handle();
}
```
should now instead declare `methods = HttpMethod.POST` in the Routed annotation. Alternatively they can check `WebContext#isPostRequest` in case they want to throw a very specific error. However, enforcing it via the annotation is preferable as that will result in a proper 403 HTTP status and in most cases, invoking POST routes via GET is only done by accident or by attackers or bots.

2) Methods that do something extra when the request is a POST request without a CSRF token like this
```
if (ctx.isUnsafePOST()) {
  loadConfiguration(ctx, configuration);
}
```
should now instead check `WebContext#isPostRequest`. Additional, it must now be checked whether the call happens from inside a template, meaning code we control, or from an external system. In the case of the former, the template must now provide a CSRF token via `part(sirius.web.http.CSRFHelper.class).getCSRFToken()`, in the case of the later the CSRF check must be skipped via declaring `skipCsrfValidation = true` in the Routed annotation.

3) Methods that do something extra when the request is a safe POST request like this
```
@Routed("/foo-bar")
public void sendOfferMail(WebContext ctx) {
    if (ctx.isSafePOST()) {
        sendMails(ctx);
    }

    ctx.respondWith().template("/templates/xyz.html.pasta");
}
```
or like this
```
if (webContext.ensureSafePOST()) {
    somethingExtra();
}
webContext.respondWith().redirectToGet("/xyz");
```
were already secured by a CSRF token check. Therefore they can now simply check WebContext#isPostRequest instead of the now removed WebContext#isSafePOST and WebContext#ensureSafePOST methods to do the extra actions only when a CSRF-protected POST request is being processed.

4) Methods that do something wild where they check for a safe POST request (which includes the CSRF token check) but don't throw if it fails like this
```
try {
    if (ctx.ensureSafePOST() && checkParameters(ctx) && checkValidation(ctx)) {
        ctx.respondWith().redirectToGet("/start");
        return;
    }
} catch (HandledException e) {
    UserContext.message(Message.error(e));
}
ctx.respondWith().template("xyz.html.pasta");
```
should now skip the automatic check by declaring `skipCsrfValidation = true` in the Routed annotation. Instead, they must manually check for `WebContext#isPostRequest` and invoke the check via `csrfHelper.hasValidCsrfToken(webContext)`. (Note: CSRFHelper is despite of its name a part class and not a common helper!)

5) Note, that some some elements like the `t:dropdownDeleteItem` tag or or the "confirm-link-js" css class already ensured that the request would be a POST including a CSRF token. Hoewever, it should still be checked whether the route could be closed down to only allow POST requests.

---

Because this has a massive impact on potentially hundreds of routes, there are many different ways to skip the check:
- Declare `skipCsrfValidation = true` in the Routed annotation of a method.
- Override `isSkipCsrfValidation` method in a controller and return true to skip the check for all of its routes.
- Exempt the route via system settings (for ease of use, the raw routed string is now propagated so no re-writes and co. must be considered). This however requires a system restart.
- System wide kill switch for all routes is still supported.

---

sirius-web routes overview: Routes with no CSRF info **CAN ONLY** be accessed via GET.
```
| Route                   | CSRF  | Notes                                                   |
|-------------------------|-------|---------------------------------------------------------|
| /api                    |       |                                                         |
| /barcode                |       |                                                         |
| /captcha-challenge      |       |                                                         |
| /licenses               |       |                                                         |
| /qr                     |       |                                                         |
| /system/api             |       |                                                         |
| /system/api/:1          |       |                                                         |
| /system/console         |       |                                                         |
| /system/console/api     | added | POST $.post with CSRFToken in console UI                |
| /system/fail            |       |                                                         |
| /system/info            |       |                                                         |
| /system/load            |       |                                                         |
| /system/metric/:1       |       |                                                         |
| /system/metrics         |       |                                                         |
| /system/monitor         |       |                                                         |
| /system/ok              |       |                                                         |
| /system/reset           |       |                                                         |
| /system/scope-config    |       |                                                         |
| /system/scope-config/:1 |       |                                                         |
| /system/state           |       |                                                         |
| /system/tag/:1/:2       |       |                                                         |
| /system/tags            |       |                                                         |
| /system/tags.md         |       |                                                         |
| /system/tags/state      |       | state change still reachable via GET ?reset             |
| /system/timing          |       | state change still reachable via GET ?enable / ?disable |
```


---

See commits for details :)

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1216](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1216)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
