### PR TITLE
Consider Pre-Dispatchable Routes in the "Are there any matching routes with a different allowed HTTP method" Check

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -232,14 +232,10 @@ public class ControllerDispatcher implements WebDispatcher {
                 return DispatchDecision.DONE;
             }
 
-            if (parametersMatch) {
+            if (parametersMatch || (route.isPreDispatchable()
+                                    && !httpMethodMatches
+                                    && shouldExecute(webContext, uri, route, true) != Route.NO_MATCH)) {
                 routesWithDifferentMethod.add(route);
-            } else if (route.isPreDispatchable()) {
-                final List<Object> preDispatchParameters = shouldExecute(webContext, uri, route, true);
-                boolean preDispatchParametersMatch = preDispatchParameters != Route.NO_MATCH;
-                if (preDispatchParametersMatch && !httpMethodMatches) {
-                    routesWithDifferentMethod.add(route);
-                }
             }
         }
 

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -226,10 +226,13 @@ public class ControllerDispatcher implements WebDispatcher {
             final List<Object> parameters = shouldExecute(webContext, uri, route, false);
             boolean parametersMatch = parameters != Route.NO_MATCH;
             boolean httpMethodMatches = route.matchesHttpMethod(webContext);
+
             if (parametersMatch && httpMethodMatches) {
                 preparePerformRoute(webContext, route, parameters, null);
                 return DispatchDecision.DONE;
-            } else if (parametersMatch) {
+            }
+
+            if (parametersMatch) {
                 routesWithDifferentMethod.add(route);
             } else if (route.isPreDispatchable()) {
                 final List<Object> preDispatchParameters = shouldExecute(webContext, uri, route, true);

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -224,14 +224,17 @@ public class ControllerDispatcher implements WebDispatcher {
 
         for (Route route : getRoutes()) {
             final List<Object> parameters = shouldExecute(webContext, uri, route, false);
-            if (parameters != Route.NO_MATCH && route.matchesHttpMethod(webContext)) {
+            boolean parametersMatch = parameters != Route.NO_MATCH;
+            boolean httpMethodMatches = route.matchesHttpMethod(webContext);
+            if (parametersMatch && httpMethodMatches) {
                 preparePerformRoute(webContext, route, parameters, null);
                 return DispatchDecision.DONE;
-            } else if (parameters != Route.NO_MATCH) {
+            } else if (parametersMatch) {
                 routesWithDifferentMethod.add(route);
             } else if (route.isPreDispatchable()) {
                 final List<Object> preDispatchParameters = shouldExecute(webContext, uri, route, true);
-                if (preDispatchParameters != Route.NO_MATCH && !route.matchesHttpMethod(webContext)) {
+                boolean preDispatchParametersMatch = preDispatchParameters != Route.NO_MATCH;
+                if (preDispatchParametersMatch && !httpMethodMatches) {
                     routesWithDifferentMethod.add(route);
                 }
             }

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -229,6 +229,11 @@ public class ControllerDispatcher implements WebDispatcher {
                 return DispatchDecision.DONE;
             } else if (parameters != Route.NO_MATCH) {
                 routesWithDifferentMethod.add(route);
+            } else if (route.isPreDispatchable()) {
+                final List<Object> preDispatchParameters = shouldExecute(webContext, uri, route, true);
+                if (preDispatchParameters != Route.NO_MATCH && !route.matchesHttpMethod(webContext)) {
+                    routesWithDifferentMethod.add(route);
+                }
             }
         }
 

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -373,6 +373,22 @@ public class TestController extends BasicController {
         }
     }
 
+    @Routed(value = "/test/restricted-method-api-predispatch-2/:1",
+            methods = HttpMethod.POST,
+            preDispatchable = true,
+            skipCsrfValidation = true)
+    @InternalService
+    public void postOnlyPredispatchWithParameterTest(WebContext webContext,
+                                                     JSONStructuredOutput output,
+                                                     String parameter1,
+                                                     InputStreamHandler upload) throws IOException {
+        try (upload) {
+            Streams.exhaust(upload);
+            output.property("status", "POST OK");
+            output.property("parameter1", parameter1);
+        }
+    }
+
     @Routed(value = "/test/restricted-methods-api", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
             skipCsrfValidation = true)
     @InternalService

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -359,6 +359,20 @@ public class TestController extends BasicController {
         output.property("status", "POST OK");
     }
 
+    @Routed(value = "/test/restricted-method-api-predispatch",
+            methods = HttpMethod.POST,
+            preDispatchable = true,
+            skipCsrfValidation = true)
+    @InternalService
+    public void postOnlyPredispatchTest(WebContext webContext,
+                                        JSONStructuredOutput output,
+                                        InputStreamHandler upload) throws IOException {
+        try (upload) {
+            Streams.exhaust(upload);
+            output.property("status", "POST OK");
+        }
+    }
+
     @Routed(value = "/test/restricted-methods-api", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
             skipCsrfValidation = true)
     @InternalService

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -935,12 +935,13 @@ class WebServerTest {
     @ParameterizedTest
     @CsvSource(
         delimiter = '|', useHeadersInDisplayName = true, textBlock = // language=CSV
-            """uri                                 | method | allow
-            /test/restricted-method-api         | PUT    | GET, POST
-            /test/restricted-method-api         | DELETE | GET, POST
-            /test/restricted-methods-api        | PUT    | GET, POST
-            /test/restricted-methods-api        | DELETE | GET, POST
-            /test/another-restricted-method-api | POST   | GET"""
+            """uri                                  | method | allow
+            /test/restricted-method-api             | PUT    | GET, POST
+            /test/restricted-method-api             | DELETE | GET, POST
+            /test/restricted-methods-api            | PUT    | GET, POST
+            /test/restricted-methods-api            | DELETE | GET, POST
+            /test/another-restricted-method-api     | POST   | GET
+            /test/restricted-method-api-predispatch | GET    | POST"""
     )
     fun `Requests to JSON routes with wrong method fail with 405`(uri: String, method: String, allow: String) {
         val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -935,7 +935,7 @@ class WebServerTest {
     @ParameterizedTest
     @CsvSource(
         delimiter = '|', useHeadersInDisplayName = true, textBlock = // language=CSV
-            """uri                                  | method | allow
+            """uri                                     | method | allow
             /test/restricted-method-api             | PUT    | GET, POST
             /test/restricted-method-api             | DELETE | GET, POST
             /test/restricted-methods-api            | PUT    | GET, POST
@@ -953,6 +953,28 @@ class WebServerTest {
         val result = Json.parseObject(String(Streams.toByteArray(connection.errorStream), StandardCharsets.UTF_8))
         assertTrue(result.get("error").asBoolean())
         assertFalse(result.get("success").asBoolean())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = '|', useHeadersInDisplayName = true, textBlock = // language=CSV
+            """uri                                        | method
+            /test/restricted-method-api-predispatch-2 | GET
+            /test/restricted-method-api-predispatch-2 | POST"""
+    )
+    fun `Requests to pre-dispatchable routes with non-matching parameters fail with 404`(
+        uri: String,
+        method: String
+    ) {
+        val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
+        connection.setRequestMethod(method)
+
+        if (HttpMethod.POST.name() == method) {
+            connection.setDoOutput(true)
+            connection.outputStream.use { it.write("test".toByteArray()) }
+        }
+
+        assertEquals(404, connection.responseCode)
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description

Otherwise, calling a pre-dispatchable route via for example GET instead of POST (and there not being a GET-variant) will result in an HTML "no dispatcher found" message instead of proper failure handling (e.g. returning JSON).

This does not directly have something to do with the CSRF validation by default logic, but it simplifies in tightening all POST routes as now no GET variant needs to exist only to respond in the correct format.


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1216](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1216)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1641

### Checklist

- [X] Code change has been tested and works locally
- [X] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [X] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
