### PR TITLE
Automatically include OPTIONS method for routes

### DIFF
--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -96,6 +96,8 @@ public class Route {
                                         .map(sirius.web.controller.HttpMethod::toHttpMethod)
                                         .toList());
         failForInvalidMethods(result.httpMethods);
+        // We auto include OPTIONS for all routes, mostly to support preflight CORS checks without having to explicitly add the method to the annotation.
+        result.httpMethods.add(HttpMethod.OPTIONS);
 
         result.label = String.format("%s%s -> %s#%s",
                                      result.uri,

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -902,12 +902,12 @@ class WebServerTest {
     @ParameterizedTest
     @CsvSource(
         delimiter = '|', useHeadersInDisplayName = true, textBlock = // language=CSV
-            """uri                             | method | allow
-            /test/restricted-method         | PUT    | GET, POST
-            /test/restricted-method         | DELETE | GET, POST
-            /test/restricted-methods        | PUT    | GET, POST
-            /test/restricted-methods        | DELETE | GET, POST
-            /test/another-restricted-method | POST   | GET"""
+            """uri                          | method | allow
+            /test/restricted-method         | PUT    | GET, OPTIONS, POST 
+            /test/restricted-method         | DELETE | GET, OPTIONS, POST
+            /test/restricted-methods        | PUT    | GET, OPTIONS, POST
+            /test/restricted-methods        | DELETE | GET, OPTIONS, POST
+            /test/another-restricted-method | POST   | GET, OPTIONS"""
     )
     fun `Requests to plain text routes with wrong method fail with 405`(uri: String, method: String, allow: String) {
         val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
@@ -935,13 +935,13 @@ class WebServerTest {
     @ParameterizedTest
     @CsvSource(
         delimiter = '|', useHeadersInDisplayName = true, textBlock = // language=CSV
-            """uri                                     | method | allow
-            /test/restricted-method-api             | PUT    | GET, POST
-            /test/restricted-method-api             | DELETE | GET, POST
-            /test/restricted-methods-api            | PUT    | GET, POST
-            /test/restricted-methods-api            | DELETE | GET, POST
-            /test/another-restricted-method-api     | POST   | GET
-            /test/restricted-method-api-predispatch | GET    | POST"""
+            """uri                                  | method | allow
+            /test/restricted-method-api             | PUT    | GET, OPTIONS, POST
+            /test/restricted-method-api             | DELETE | GET, OPTIONS, POST
+            /test/restricted-methods-api            | PUT    | GET, OPTIONS, POST
+            /test/restricted-methods-api            | DELETE | GET, OPTIONS, POST
+            /test/another-restricted-method-api     | POST   | GET, OPTIONS
+            /test/restricted-method-api-predispatch | GET    | OPTIONS, POST"""
     )
     fun `Requests to JSON routes with wrong method fail with 405`(uri: String, method: String, allow: String) {
         val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection


### PR DESCRIPTION
### Description

Mostly to support preflight CORS checks without having to explicitly add the method to the annotation.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1230](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1230)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
