### PR TITLE
Provide a not-cached CSRF token that may be used in cached files

### DIFF
--- a/src/main/resources/default/taglib/t/page.html.pasta
+++ b/src/main/resources/default/taglib/t/page.html.pasta
@@ -45,6 +45,7 @@
     <script type="text/javascript">
         // This cannot be moved into tycho.js as it has to be re-evaluated for each call and must not be cached...
         const tycho_current_locale = '@NLS.getCurrentLanguage()';
+        const tycho_csrf_token = '@escapeJS(part(CSRFHelper.class).getCSRFToken())';
 
         if (randomizeCharts) {
             randomizeCharts('@sirius.kernel.commons.Hasher.md5().hash(currentRenderContext().getRootContext().getTemplate().getName()).toString()')


### PR DESCRIPTION
### Description

This will be used in sirius-biz in a file that is part of the cached tycho.js file.

Relates to https://github.com/scireum/sirius-biz/pull/2314

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1216](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1216)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
