### PR TITLE
Add generic page attributes API

### DIFF
--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -183,7 +183,7 @@ public class Page<E> {
      */
     public Page<E> withAttribute(String name, @Nullable Object value) {
         if (Strings.isEmpty(name)) {
-            return this;
+            throw new IllegalArgumentException("The attribute name must not be empty.");
         }
 
         attributes.put(name, value);
@@ -200,7 +200,7 @@ public class Page<E> {
     @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
     public Object getAttribute(String name) {
         if (Strings.isEmpty(name)) {
-            return null;
+            throw new IllegalArgumentException("The attribute name must not be empty.");
         }
 
         return attributes.get(name);

--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -19,7 +19,9 @@ import sirius.web.util.LinkBuilder;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -50,6 +52,7 @@ public class Page<E> {
     private Boolean hasFacets = null;
     private int pageSize = DEFAULT_PAGE_SIZE;
     private final List<String> emptyParameters = new ArrayList<>();
+    private final Map<String, Object> attributes = new HashMap<>();
 
     /**
      * Specifies the query used to compute the result list.
@@ -169,6 +172,38 @@ public class Page<E> {
     public Page<E> withEmptyParameter(String emptyParameter) {
         this.emptyParameters.add(emptyParameter);
         return this;
+    }
+
+    /**
+     * Adds a custom attribute to this page.
+     *
+     * @param name  the name of the attribute
+     * @param value the attribute value
+     * @return the page itself for fluent method calls
+     */
+    public Page<E> withAttribute(String name, @Nullable Object value) {
+        if (Strings.isEmpty(name)) {
+            return this;
+        }
+
+        attributes.put(name, value);
+        return this;
+    }
+
+    /**
+     * Retrieves a custom attribute stored on this page.
+     *
+     * @param name the name of the attribute
+     * @return the attribute value or <tt>null</tt> if no such attribute exists
+     */
+    @Nullable
+    @NoodleSandbox(NoodleSandbox.Accessibility.GRANTED)
+    public Object getAttribute(String name) {
+        if (Strings.isEmpty(name)) {
+            return null;
+        }
+
+        return attributes.get(name);
     }
 
     /**


### PR DESCRIPTION
### Description

- Add a generic attributes map to `Page` for passing additional template context.
- Expose `getAttribute` to templates while keeping `withAttribute` server-side only.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1009](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1009)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2306

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
