### PR TITLE
Add AES-256-GCM client session encryption

### DIFF
--- a/src/main/java/sirius/web/http/ClientSessionCrypto.java
+++ b/src/main/java/sirius/web/http/ClientSessionCrypto.java
@@ -34,6 +34,8 @@ import java.util.Base64;
  * <p>
  * Encrypted values are marked with {@link #ENCRYPTION_PREFIX} so that the reading side can distinguish them from
  * legacy (unencrypted) cookies and transparently support both formats during a migration period.
+ *
+ * @see ClientSessionSecrets for the management of the secrets used here
  */
 class ClientSessionCrypto {
 

--- a/src/main/java/sirius/web/http/ClientSessionCrypto.java
+++ b/src/main/java/sirius/web/http/ClientSessionCrypto.java
@@ -1,0 +1,138 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import sirius.kernel.commons.Hasher;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.health.Exceptions;
+
+import javax.annotation.Nullable;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Encrypts and decrypts the payload stored within the client session cookie.
+ * <p>
+ * The client session is stored on the client side within a cookie. In order to keep its contents confidential
+ * (and not just tamper-proof), the payload is encrypted using <b>AES-256 in GCM mode</b>. GCM is an authenticated
+ * encryption mode and therefore also guarantees the integrity of the encrypted data.
+ * <p>
+ * The symmetric key is derived from the configured session secret (see {@code http.sessionSecret}) by hashing it
+ * with SHA-256. A fresh random initialization vector (IV) is generated for every encryption and prepended to the
+ * cipher text so that encrypting the same payload twice yields different cookies.
+ * <p>
+ * Encrypted values are marked with {@link #ENCRYPTION_PREFIX} so that the reading side can distinguish them from
+ * legacy (unencrypted) cookies and transparently support both formats during a migration period.
+ */
+class ClientSessionCrypto {
+
+    /**
+     * Marks a cookie value as being encrypted using version 1 of this scheme.
+     * <p>
+     * Legacy cookies start with a hex encoded SHA-512 hash and therefore never collide with this prefix.
+     */
+    static final String ENCRYPTION_PREFIX = "E1:";
+
+    private static final String KEY_ALGORITHM = "AES";
+    private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private ClientSessionCrypto() {
+    }
+
+    /**
+     * Determines if the given cookie value is an encrypted payload created by {@link #encrypt(String, String)}.
+     *
+     * @param cookieValue the raw cookie value to inspect
+     * @return <tt>true</tt> if the value is encrypted, <tt>false</tt> if it is a legacy plain text value
+     */
+    static boolean isEncrypted(@Nullable String cookieValue) {
+        return cookieValue != null && cookieValue.startsWith(ENCRYPTION_PREFIX);
+    }
+
+    /**
+     * Encrypts the given plain text using a key derived from the given secret.
+     *
+     * @param plainText the payload to encrypt
+     * @param secret    the secret used to derive the symmetric key
+     * @return the encrypted payload, marked with {@link #ENCRYPTION_PREFIX} and Base64 encoded
+     */
+    static String encrypt(String plainText, String secret) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            SECURE_RANDOM.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, deriveKey(secret), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            byte[] cipherText = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            byte[] combined = new byte[iv.length + cipherText.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(cipherText, 0, combined, iv.length, cipherText.length);
+
+            return ENCRYPTION_PREFIX + Base64.getEncoder().encodeToString(combined);
+        } catch (Exception exception) {
+            throw Exceptions.handle()
+                            .to(WebServer.LOG)
+                            .error(exception)
+                            .withSystemErrorMessage("Failed to encrypt the client session: %s (%s)")
+                            .handle();
+        }
+    }
+
+    /**
+     * Decrypts a payload previously created by {@link #encrypt(String, String)}.
+     * <p>
+     * If the value cannot be decrypted (e.g. because it has been tampered with or was encrypted using a different
+     * secret), <tt>null</tt> is returned so that the caller can reset the session instead of failing the request.
+     *
+     * @param encryptedValue the encrypted payload, including the {@link #ENCRYPTION_PREFIX}
+     * @param secret         the secret used to derive the symmetric key
+     * @return the decrypted plain text or <tt>null</tt> if decryption failed
+     */
+    @Nullable
+    static String decrypt(String encryptedValue, String secret) {
+        if (!isEncrypted(encryptedValue)) {
+            return null;
+        }
+        try {
+            byte[] combined = Base64.getDecoder().decode(encryptedValue.substring(ENCRYPTION_PREFIX.length()));
+            if (combined.length <= GCM_IV_LENGTH) {
+                return null;
+            }
+
+            byte[] iv = Arrays.copyOfRange(combined, 0, GCM_IV_LENGTH);
+            byte[] cipherText = Arrays.copyOfRange(combined, GCM_IV_LENGTH, combined.length);
+
+            Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, deriveKey(secret), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(cipherText), StandardCharsets.UTF_8);
+        } catch (Exception exception) {
+            // A failed decryption (wrong secret, tampered data, ...) must not break the request. The caller
+            // treats a null result like an invalid integrity hash and simply resets the session.
+            return null;
+        }
+    }
+
+    /**
+     * Derives a 256 bit AES key from the given secret by hashing it with SHA-256.
+     */
+    private static SecretKeySpec deriveKey(String secret) {
+        byte[] key = Hasher.sha256().hash(Strings.isEmpty(secret) ? "" : secret).toHash();
+        return new SecretKeySpec(key, KEY_ALGORITHM);
+    }
+}

--- a/src/main/java/sirius/web/http/ClientSessionSecrets.java
+++ b/src/main/java/sirius/web/http/ClientSessionSecrets.java
@@ -1,0 +1,109 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import sirius.kernel.Startable;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.ConfigValue;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Manages the secrets used to protect (sign and encrypt) the client session cookie.
+ * <p>
+ * Besides providing the primary secret used for writing sessions, this also exposes all accepted secrets (the primary
+ * plus all configured legacy ones), which permits to rotate {@code http.sessionSecret} without invalidating sessions
+ * that were written using a previous secret.
+ * <p>
+ * On startup this verifies that a fixed secret is configured if session encryption is enabled, as a random secret
+ * (the default if none is given) would make sessions undecryptable across restarts or cluster nodes.
+ */
+@Register(classes = {Startable.class, ClientSessionSecrets.class})
+public class ClientSessionSecrets implements Startable {
+
+    @ConfigValue("http.sessionCookie.encrypt")
+    private boolean isSessionCookieEncryptionEnabled;
+
+    @ConfigValue("http.sessionSecret")
+    @Nullable
+    private String sessionSecret;
+
+    @ConfigValue("http.legacySessionSecrets")
+    private List<String> legacySessionSecrets;
+
+    private String effectiveSessionSecret;
+
+    /**
+     * Verifies the secret configuration as early as possible by resolving the primary secret on startup.
+     */
+    @Override
+    public void started() {
+        requireSessionSecret();
+    }
+
+    /**
+     * Returns the primary secret used to write (sign and encrypt) client sessions.
+     * <p>
+     * If no secret is configured via {@code http.sessionSecret}, a random one is generated once - but only if
+     * encryption is disabled. If encryption is enabled, a fixed secret is mandatory (otherwise sessions could not be
+     * decrypted across restarts or cluster nodes) and a missing secret is rejected instead.
+     *
+     * @return the primary session secret, never empty
+     */
+    @Nonnull
+    public String requireSessionSecret() {
+        if (effectiveSessionSecret != null) {
+            return effectiveSessionSecret;
+        }
+        if (Strings.isFilled(sessionSecret)) {
+            effectiveSessionSecret = sessionSecret;
+            return effectiveSessionSecret;
+        }
+        if (isSessionCookieEncryptionEnabled) {
+            throw Exceptions.handle()
+                            .to(WebServer.LOG)
+                            .withSystemErrorMessage("Client session encryption (http.sessionCookie.encrypt) is "
+                                                    + "enabled, but no fixed http.sessionSecret is configured. A "
+                                                    + "stable secret is required - otherwise sessions cannot be "
+                                                    + "decrypted across restarts or cluster nodes. Please configure "
+                                                    + "http.sessionSecret with a sufficiently long random value.")
+                            .handle();
+        }
+        effectiveSessionSecret = UUID.randomUUID().toString();
+        return effectiveSessionSecret;
+    }
+
+    /**
+     * Returns all secrets which are accepted when reading a client session.
+     * <p>
+     * The primary secret (used for writing) comes first, followed by all configured legacy secrets in the given
+     * order. This is used to support secret rotation: a cookie written with a previous secret can still be read.
+     *
+     * @return the list of accepted secrets, the primary one first
+     */
+    public List<String> getAllSessionSecrets() {
+        List<String> secrets = new ArrayList<>();
+        secrets.add(requireSessionSecret());
+        if (legacySessionSecrets != null) {
+            for (String legacySecret : legacySessionSecrets) {
+                if (Strings.isFilled(legacySecret)) {
+                    secrets.add(legacySecret);
+                }
+            }
+        }
+        return Collections.unmodifiableList(secrets);
+    }
+}

--- a/src/main/java/sirius/web/http/ClientSessionSecrets.java
+++ b/src/main/java/sirius/web/http/ClientSessionSecrets.java
@@ -10,6 +10,7 @@ package sirius.web.http;
 
 import sirius.kernel.Startable;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Wait;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
@@ -45,15 +46,22 @@ public class ClientSessionSecrets implements Startable {
     private List<String> legacySessionSecrets;
 
     private String effectiveSessionSecret;
-    private List<String> effectiveSessionSecrets;
+    private final List<String> effectiveSessionSecrets = new ArrayList<>();
+    private volatile boolean initialized;
 
     /**
-     * Verifies the secret configuration as early as possible and resolves all secrets on startup, so they are
-     * initialised before any (concurrent) request is handled.
+     * Verifies the secret configuration as early as possible and resolves all accepted secrets on startup, so they
+     * are fully initialised before any (concurrent) request is handled.
      */
     @Override
     public void started() {
-        getAllSessionSecrets();
+        effectiveSessionSecrets.add(requireSessionSecret());
+        for (String legacySecret : legacySessionSecrets) {
+            if (Strings.isFilled(legacySecret)) {
+                effectiveSessionSecrets.add(legacySecret);
+            }
+        }
+        initialized = true;
     }
 
     /**
@@ -97,14 +105,10 @@ public class ClientSessionSecrets implements Startable {
      * @return the list of accepted secrets, the primary one first
      */
     public List<String> getAllSessionSecrets() {
-        if (effectiveSessionSecrets == null) {
-            effectiveSessionSecrets = new ArrayList<>();
-            effectiveSessionSecrets.add(requireSessionSecret());
-            for (String legacySecret : legacySessionSecrets) {
-                if (Strings.isFilled(legacySecret)) {
-                    effectiveSessionSecrets.add(legacySecret);
-                }
-            }
+        // The list is populated once in started(). Should a request arrive before startup finished, we wait for the
+        // initialization to complete instead of returning an incomplete list.
+        while (!initialized) {
+            Wait.millis(10);
         }
 
         return Collections.unmodifiableList(effectiveSessionSecrets);

--- a/src/main/java/sirius/web/http/ClientSessionSecrets.java
+++ b/src/main/java/sirius/web/http/ClientSessionSecrets.java
@@ -45,6 +45,7 @@ public class ClientSessionSecrets implements Startable {
     private List<String> legacySessionSecrets;
 
     private String effectiveSessionSecret;
+    private List<String> effectiveSessionSecrets;
 
     /**
      * Verifies the secret configuration as early as possible by resolving the primary secret on startup.
@@ -95,15 +96,19 @@ public class ClientSessionSecrets implements Startable {
      * @return the list of accepted secrets, the primary one first
      */
     public List<String> getAllSessionSecrets() {
-        List<String> secrets = new ArrayList<>();
-        secrets.add(requireSessionSecret());
-        if (legacySessionSecrets != null) {
-            for (String legacySecret : legacySessionSecrets) {
-                if (Strings.isFilled(legacySecret)) {
-                    secrets.add(legacySecret);
+        if (effectiveSessionSecrets == null) {
+            List<String> secrets = new ArrayList<>();
+            secrets.add(requireSessionSecret());
+            if (legacySessionSecrets != null) {
+                for (String legacySecret : legacySessionSecrets) {
+                    if (Strings.isFilled(legacySecret)) {
+                        secrets.add(legacySecret);
+                    }
                 }
             }
+            effectiveSessionSecrets = secrets;
         }
-        return Collections.unmodifiableList(secrets);
+
+        return Collections.unmodifiableList(effectiveSessionSecrets);
     }
 }

--- a/src/main/java/sirius/web/http/ClientSessionSecrets.java
+++ b/src/main/java/sirius/web/http/ClientSessionSecrets.java
@@ -48,11 +48,12 @@ public class ClientSessionSecrets implements Startable {
     private List<String> effectiveSessionSecrets;
 
     /**
-     * Verifies the secret configuration as early as possible by resolving the primary secret on startup.
+     * Verifies the secret configuration as early as possible and resolves all secrets on startup, so they are
+     * initialised before any (concurrent) request is handled.
      */
     @Override
     public void started() {
-        requireSessionSecret();
+        getAllSessionSecrets();
     }
 
     /**
@@ -97,16 +98,13 @@ public class ClientSessionSecrets implements Startable {
      */
     public List<String> getAllSessionSecrets() {
         if (effectiveSessionSecrets == null) {
-            List<String> secrets = new ArrayList<>();
-            secrets.add(requireSessionSecret());
-            if (legacySessionSecrets != null) {
-                for (String legacySecret : legacySessionSecrets) {
-                    if (Strings.isFilled(legacySecret)) {
-                        secrets.add(legacySecret);
-                    }
+            effectiveSessionSecrets = new ArrayList<>();
+            effectiveSessionSecrets.add(requireSessionSecret());
+            for (String legacySecret : legacySessionSecrets) {
+                if (Strings.isFilled(legacySecret)) {
+                    effectiveSessionSecrets.add(legacySecret);
                 }
             }
-            effectiveSessionSecrets = secrets;
         }
 
         return Collections.unmodifiableList(effectiveSessionSecrets);

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -222,6 +222,12 @@ public class WebContext implements SubContext {
     private volatile boolean sessionModified;
 
     /**
+     * Determines if the client session was read from a legacy (unencrypted) cookie and should be re-written in the
+     * encrypted format, even if it was not otherwise modified during this request.
+     */
+    private volatile boolean sessionUpgradeRequired;
+
+    /**
      * Specifies the micro-timing key used for this request. If null, no micro-timing will be recorded.
      */
     protected String microtimingKey;
@@ -846,6 +852,11 @@ public class WebContext implements SubContext {
         if (Strings.isFilled(encodedSession)) {
             session = decodeSession(encodedSession);
             checkAndEnforceSessionPinning();
+            if (sessionCookieEncryption && !session.isEmpty() && !ClientSessionCrypto.isEncrypted(encodedSession)) {
+                // Eagerly upgrade a successfully decoded legacy (unencrypted) cookie to the encrypted format, so it
+                // does not stay in plain text until the session happens to be modified.
+                sessionUpgradeRequired = true;
+            }
         } else {
             session = new HashMap<>();
         }
@@ -1517,7 +1528,7 @@ public class WebContext implements SubContext {
     }
 
     private void buildClientSessionCookie() {
-        if (!sessionModified) {
+        if (!sessionModified && !sessionUpgradeRequired) {
             if (session != null && !session.isEmpty()) {
                 installSessionPinningCookieIfRequired();
             }

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -83,7 +83,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -367,20 +366,6 @@ public class WebContext implements SubContext {
     private static String cookieDomain;
 
     /**
-     * Shared secret used to protect the client session. If empty one will be created on startup.
-     */
-    @ConfigValue("http.sessionSecret")
-    private static String sessionSecret;
-
-    /**
-     * Previously used session secrets which are still accepted when reading (but never used for writing) client
-     * sessions. This permits to rotate {@link #sessionSecret} without invalidating sessions which were encrypted or
-     * signed using an older secret.
-     */
-    @ConfigValue("http.legacySessionSecrets")
-    private static List<String> legacySessionSecrets;
-
-    /**
      * Input size limit for structured data (as this is loaded into heap)
      */
     @ConfigValue("http.maxStructuredInputSize")
@@ -428,6 +413,9 @@ public class WebContext implements SubContext {
 
     @Part
     private static CSRFHelper csrfHelper;
+
+    @Part
+    private static ClientSessionSecrets sessionSecrets;
 
     /**
      * Provides access to the <tt>WebContext</tt> for the current thread.
@@ -964,7 +952,7 @@ public class WebContext implements SubContext {
             // and all legacy secrets so that rotating the secret does not invalidate sessions which are still
             // encrypted using a previous one. The secret which successfully decrypts is also the one used to verify
             // the (global) integrity hash.
-            for (String secret : getGlobalSessionSecrets()) {
+            for (String secret : sessionSecrets.getAllSessionSecrets()) {
                 String payload = ClientSessionCrypto.decrypt(encodedSession, secret);
                 if (payload != null) {
                     Map<String, String> decodedSession =
@@ -977,7 +965,7 @@ public class WebContext implements SubContext {
         } else {
             // A legacy plain text cookie has nothing to decrypt. We try each known secret when verifying the
             // integrity hash to support secret rotation for these cookies as well.
-            Map<String, String> decodedSession = parseSessionPayload(encodedSession, getGlobalSessionSecrets());
+            Map<String, String> decodedSession = parseSessionPayload(encodedSession, sessionSecrets.getAllSessionSecrets());
             if (decodedSession != null) {
                 return decodedSession;
             }
@@ -1588,7 +1576,7 @@ public class WebContext implements SubContext {
         if (!sessionCookieEncryption) {
             return payload;
         }
-        return ClientSessionCrypto.encrypt(payload, getGlobalSessionSecret());
+        return ClientSessionCrypto.encrypt(payload, sessionSecrets.requireSessionSecret());
     }
 
     private long determineSessionCookieTTL() {
@@ -1624,31 +1612,7 @@ public class WebContext implements SubContext {
             return sessionSecretComputer.computeSecret(currentSession);
         }
 
-        return getGlobalSessionSecret();
-    }
-
-    private static String getGlobalSessionSecret() {
-        if (Strings.isEmpty(sessionSecret)) {
-            sessionSecret = UUID.randomUUID().toString();
-        }
-        return sessionSecret;
-    }
-
-    /*
-     * Returns all global secrets which are accepted when reading a client session. The primary secret (used for
-     * writing) comes first, followed by all configured legacy secrets in the order given.
-     */
-    private static List<String> getGlobalSessionSecrets() {
-        List<String> secrets = new ArrayList<>();
-        secrets.add(getGlobalSessionSecret());
-        if (legacySessionSecrets != null) {
-            for (String legacySecret : legacySessionSecrets) {
-                if (Strings.isFilled(legacySecret)) {
-                    secrets.add(legacySecret);
-                }
-            }
-        }
-        return secrets;
+        return sessionSecrets.requireSessionSecret();
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -348,6 +348,13 @@ public class WebContext implements SubContext {
     private static CookieSecurity sessionCookieSecurity;
 
     /**
+     * Determines if the client session payload should be encrypted within the cookie. If disabled, the payload is
+     * only protected against tampering (using an integrity hash) but is readable as plain text by the client.
+     */
+    @ConfigValue("http.sessionCookie.encrypt")
+    private static boolean sessionCookieEncryption;
+
+    /**
      * Determines the domain set for all cookies. If empty no domain will be set.
      * If a cookie's domain attribute is not set, the cookie is only applicable to the domain of the originating request, EXCLUDING all its subdomains.
      * (However in IE 9 and older versions, a cookie made for abc.com is also sent in requests to xyz.abc.com)
@@ -364,6 +371,14 @@ public class WebContext implements SubContext {
      */
     @ConfigValue("http.sessionSecret")
     private static String sessionSecret;
+
+    /**
+     * Previously used session secrets which are still accepted when reading (but never used for writing) client
+     * sessions. This permits to rotate {@link #sessionSecret} without invalidating sessions which were encrypted or
+     * signed using an older secret.
+     */
+    @ConfigValue("http.legacySessionSecrets")
+    private static List<String> legacySessionSecrets;
 
     /**
      * Input size limit for structured data (as this is loaded into heap)
@@ -944,10 +959,57 @@ public class WebContext implements SubContext {
     }
 
     private Map<String, String> decodeSession(String encodedSession) {
-        Tuple<String, String> sessionInfo = Strings.split(encodedSession, ":");
+        if (ClientSessionCrypto.isEncrypted(encodedSession)) {
+            // For an encrypted cookie only the matching secret is able to decrypt the payload. We try the primary
+            // and all legacy secrets so that rotating the secret does not invalidate sessions which are still
+            // encrypted using a previous one. The secret which successfully decrypts is also the one used to verify
+            // the (global) integrity hash.
+            for (String secret : getGlobalSessionSecrets()) {
+                String payload = ClientSessionCrypto.decrypt(encodedSession, secret);
+                if (payload != null) {
+                    Map<String, String> decodedSession =
+                            parseSessionPayload(payload, Collections.singletonList(secret));
+                    if (decodedSession != null) {
+                        return decodedSession;
+                    }
+                }
+            }
+        } else {
+            // A legacy plain text cookie has nothing to decrypt. We try each known secret when verifying the
+            // integrity hash to support secret rotation for these cookies as well.
+            Map<String, String> decodedSession = parseSessionPayload(encodedSession, getGlobalSessionSecrets());
+            if (decodedSession != null) {
+                return decodedSession;
+            }
+        }
+
+        if (SESSION_CHECK.isFINE()) {
+            SESSION_CHECK.FINE("Resetting client session as it could not be decoded: %s%n%s%nURI: %s%nIP: %s",
+                               encodedSession,
+                               this,
+                               getRequestedURL(),
+                               getRemoteIP());
+        }
+        return new HashMap<>();
+    }
+
+    /**
+     * Parses a decoded {@code hash:querystring} session payload and verifies its integrity.
+     * <p>
+     * As a side effect, the {@link #sessionCookieTTL} is updated if the payload contains a TTL and the integrity
+     * check succeeds.
+     *
+     * @param payload                the plain text {@code hash:querystring} payload
+     * @param candidateGlobalSecrets the global secrets to try when verifying the integrity hash. Only used if no
+     *                               {@link SessionSecretComputer} is configured.
+     * @return the decoded session or <tt>null</tt> if the integrity hash did not match any candidate secret
+     */
+    @Nullable
+    private Map<String, String> parseSessionPayload(String payload, List<String> candidateGlobalSecrets) {
+        Tuple<String, String> sessionInfo = Strings.split(payload, ":");
         Map<String, String> decodedSession = new HashMap<>();
         long decodedSessionTTL = -1;
-        QueryStringDecoder qsd = new QueryStringDecoder(encodedSession);
+        QueryStringDecoder qsd = new QueryStringDecoder(payload);
         for (Map.Entry<String, List<String>> entry : qsd.parameters().entrySet()) {
             if (TTL_SESSION_KEY.equals(entry.getKey())) {
                 decodedSessionTTL = Values.of(entry.getValue()).at(0).getLong();
@@ -955,28 +1017,32 @@ public class WebContext implements SubContext {
                 decodedSession.put(entry.getKey(), Values.of(entry.getValue()).at(0).getString());
             }
         }
-        if (checkSessionDataIntegrity(decodedSession, sessionInfo)) {
-            if (decodedSessionTTL >= 0) {
-                sessionCookieTTL = decodedSessionTTL;
-            }
-            return decodedSession;
-        } else {
-            if (SESSION_CHECK.isFINE()) {
-                SESSION_CHECK.FINE("Resetting client session due to inconsistent security hash: %s%n%s%nURI: %s%nIP: %s",
-                                   encodedSession,
-                                   this,
-                                   getRequestedURL(),
-                                   getRemoteIP());
-            }
-            return new HashMap<>();
+        if (!checkSessionDataIntegrity(decodedSession, sessionInfo, candidateGlobalSecrets)) {
+            return null;
         }
+        if (decodedSessionTTL >= 0) {
+            sessionCookieTTL = decodedSessionTTL;
+        }
+        return decodedSession;
     }
 
-    private boolean checkSessionDataIntegrity(Map<String, String> currentSession, Tuple<String, String> sessionInfo) {
+    private boolean checkSessionDataIntegrity(Map<String, String> currentSession,
+                                              Tuple<String, String> sessionInfo,
+                                              List<String> candidateGlobalSecrets) {
+        if (sessionSecretComputer != null) {
+            return matchesIntegrityHash(sessionInfo, sessionSecretComputer.computeSecret(currentSession));
+        }
+        for (String secret : candidateGlobalSecrets) {
+            if (matchesIntegrityHash(sessionInfo, secret)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesIntegrityHash(Tuple<String, String> sessionInfo, String secret) {
         return Strings.areEqual(sessionInfo.getFirst(),
-                                Hasher.sha512()
-                                      .hash(sessionInfo.getSecond() + getSessionSecret(currentSession))
-                                      .toHexString());
+                                Hasher.sha512().hash(sessionInfo.getSecond() + secret).toHexString());
     }
 
     /**
@@ -1494,17 +1560,35 @@ public class WebContext implements SubContext {
 
         String value = encoder.toString();
         String protection = Hasher.sha512().hash(value + getSessionSecret(session)).toHexString();
+        String cookieValue = wrapSessionPayload(protection + ":" + value);
 
         long ttl = determineSessionCookieTTL();
         if (ttl == 0) {
-            setHTTPSessionCookie(sessionCookieName, protection + ":" + value);
+            setHTTPSessionCookie(sessionCookieName, cookieValue);
         } else {
             setCookie(sessionCookieName,
-                      protection + ":" + value,
+                      cookieValue,
                       ttl,
                       determineSessionCookieSameSite(),
                       sessionCookieSecurity);
         }
+    }
+
+    /**
+     * Encrypts the given session payload if encryption is enabled.
+     * <p>
+     * The payload is encrypted using the global session secret which - unlike a per-session secret computed by a
+     * {@link SessionSecretComputer} - is available before the session has been decoded. The inner integrity hash
+     * (which may use a per-session secret) remains part of the encrypted payload and is verified after decryption.
+     *
+     * @param payload the {@code hash:querystring} payload to protect
+     * @return the encrypted payload if encryption is enabled, otherwise the unchanged plain text payload
+     */
+    private String wrapSessionPayload(String payload) {
+        if (!sessionCookieEncryption) {
+            return payload;
+        }
+        return ClientSessionCrypto.encrypt(payload, getGlobalSessionSecret());
     }
 
     private long determineSessionCookieTTL() {
@@ -1548,6 +1632,23 @@ public class WebContext implements SubContext {
             sessionSecret = UUID.randomUUID().toString();
         }
         return sessionSecret;
+    }
+
+    /*
+     * Returns all global secrets which are accepted when reading a client session. The primary secret (used for
+     * writing) comes first, followed by all configured legacy secrets in the order given.
+     */
+    private static List<String> getGlobalSessionSecrets() {
+        List<String> secrets = new ArrayList<>();
+        secrets.add(getGlobalSessionSecret());
+        if (legacySessionSecrets != null) {
+            for (String legacySecret : legacySessionSecrets) {
+                if (Strings.isFilled(legacySecret)) {
+                    secrets.add(legacySecret);
+                }
+            }
+        }
+        return secrets;
     }
 
     /**

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -173,11 +173,10 @@ http {
         encrypt = true
     }
 
-    # Specifies the secret used to validate the consistency of client sessions. If no value is present (default)
-    # a random secret is created on startup. However this implies that sessions do not work across clusters
-    # or across server restart. Therefore its a good idea to provide a fixed secret here. The value should be
-    # reasonable long and cryptographically computed - rather than your dogs name ;-)
-    # This secret is also used to derive the key for encrypting the session cookie (see #sessionCookie.encrypt).
+    # Specifies the secret used to protect client sessions and to derive the key for encrypting the session cookie
+    # (see #sessionCookie.encrypt). A fixed, reasonably long and random value must be configured - otherwise sessions
+    # do not survive a restart or work across a cluster. With encryption enabled (the default), an empty value fails
+    # on startup; without encryption a random secret is generated as a fallback.
     sessionSecret = ""
 
     # Specifies previously used secrets which are still accepted when reading client sessions, but never used for

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -164,13 +164,27 @@ http {
         # You probably want this, especially if you do not expect unsecure http connections without SSL.
         # Possible values are: ALWAYS_SECURE, NEVER, IF_SSL
         secure = "IF_SSL"
+
+        # Determines whether the client session payload is encrypted (AES-256/GCM) within the cookie instead of
+        # being stored as plain text. The encryption key is derived from #sessionSecret, therefore a fixed secret
+        # should be configured - otherwise sessions cannot be decrypted across a cluster or a server restart.
+        # When reading, legacy unencrypted cookies are still accepted, so this can be enabled without logging
+        # everyone out. Disable only for debugging or to temporarily roll back the behaviour.
+        encrypt = true
     }
 
     # Specifies the secret used to validate the consistency of client sessions. If no value is present (default)
     # a random secret is created on startup. However this implies that sessions do not work across clusters
     # or across server restart. Therefore its a good idea to provide a fixed secret here. The value should be
     # reasonable long and cryptographically computed - rather than your dogs name ;-)
+    # This secret is also used to derive the key for encrypting the session cookie (see #sessionCookie.encrypt).
     sessionSecret = ""
+
+    # Specifies previously used secrets which are still accepted when reading client sessions, but never used for
+    # writing them. This permits to rotate #sessionSecret without logging everyone out: put the old secret here,
+    # set a new #sessionSecret, and remove the old one once all sessions encrypted/signed with it have expired
+    # (see #sessionCookie.ttl). Example: legacySessionSecrets = ["previous-secret", "even-older-secret"]
+    legacySessionSecrets = []
 
     # Specifies the lifetime of CSRF security tokens in a user session before being recomputed.
     # The token is guaranteed to be valid for at least this time since we store the last token after recomputing a new one.

--- a/src/main/resources/default/templates/system/info.html.pasta
+++ b/src/main/resources/default/templates/system/info.html.pasta
@@ -65,21 +65,4 @@
             </t:datacard>
         </div>
     </i:if>
-
-    <i:if test="!webContext.getSessionKeys().isEmpty()">
-        <div class="row">
-            <t:datacard title="Client Session">
-                <table class="table">
-                    <i:for type="String" var="name" items="webContext.getSessionKeys()">
-                        <tr>
-                            <td>@name</td>
-                            <td class="text-end">
-                                <div class="text-break">@webContext.getSessionValue(name)</div>
-                            </td>
-                        </tr>
-                    </i:for>
-                </table>
-            </t:datacard>
-        </div>
-    </i:if>
 </t:page>

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -321,6 +321,14 @@ public class TestController extends BasicController {
         webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
     }
 
+    @Routed("/test/session-test-read")
+    public void sessionTestRead(WebContext webContext) {
+        webContext.respondWith()
+                  .direct(HttpResponseStatus.OK,
+                          "test1=" + webContext.getSessionValue("test1").asString("<none>") + "&test2="
+                          + webContext.getSessionValue("test2").asString("<none>"));
+    }
+
     @Routed("/test/redirect-to-get")
     public void redirect(WebContext webContext) {
         webContext.respondWith().redirectToGet("/test/redirect-target");

--- a/src/test/java/sirius/web/http/ClientSessionCryptoTest.java
+++ b/src/test/java/sirius/web/http/ClientSessionCryptoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Provides tests for the {@link ClientSessionCrypto} used to protect the client session cookie.
+ */
+class ClientSessionCryptoTest {
+
+    private static final String SECRET = "a-reasonably-long-and-random-session-secret";
+    private static final String PAYLOAD = "abc123:?user=42&role=admin&name=John+Doe";
+
+    @Test
+    void encryptDecryptRoundTrip() {
+        String encrypted = ClientSessionCrypto.encrypt(PAYLOAD, SECRET);
+
+        assertTrue(ClientSessionCrypto.isEncrypted(encrypted));
+        assertFalse(encrypted.contains("user=42"));
+        assertEquals(PAYLOAD, ClientSessionCrypto.decrypt(encrypted, SECRET));
+    }
+
+    @Test
+    void encryptionUsesRandomIv() {
+        // Encrypting the same payload twice must yield different cookies (random IV) but decrypt to the same value.
+        String first = ClientSessionCrypto.encrypt(PAYLOAD, SECRET);
+        String second = ClientSessionCrypto.encrypt(PAYLOAD, SECRET);
+
+        assertNotEquals(first, second);
+        assertEquals(PAYLOAD, ClientSessionCrypto.decrypt(first, SECRET));
+        assertEquals(PAYLOAD, ClientSessionCrypto.decrypt(second, SECRET));
+    }
+
+    @Test
+    void decryptWithWrongSecretFails() {
+        String encrypted = ClientSessionCrypto.encrypt(PAYLOAD, SECRET);
+
+        assertNull(ClientSessionCrypto.decrypt(encrypted, "a-different-secret"));
+    }
+
+    @Test
+    void decryptDetectsTampering() {
+        String encrypted = ClientSessionCrypto.encrypt(PAYLOAD, SECRET);
+
+        // Flip a character within the Base64 cipher text - GCM authentication must reject it.
+        int lastIndex = encrypted.length() - 1;
+        char tamperedChar = encrypted.charAt(lastIndex) == 'A' ? 'B' : 'A';
+        String tampered = encrypted.substring(0, lastIndex) + tamperedChar;
+
+        assertNull(ClientSessionCrypto.decrypt(tampered, SECRET));
+    }
+
+    @Test
+    void decryptRejectsNonEncryptedValues() {
+        assertFalse(ClientSessionCrypto.isEncrypted(PAYLOAD));
+        assertNull(ClientSessionCrypto.decrypt(PAYLOAD, SECRET));
+        assertNull(ClientSessionCrypto.decrypt("E1:not-valid-base64-@@@", SECRET));
+    }
+}

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -144,4 +144,32 @@ class WebContextTest {
         assertFalse { body.contains("test2=test") }
 
     }
+
+    @Test
+    fun `a legacy unencrypted session cookie is read and upgraded to the encrypted format`() {
+
+        // Build a legacy (unencrypted) session cookie in the "<sha512 hash>:<querystring>" format, signed with the
+        // test secret "TEST" (see component-test-web.conf).
+        val value = "?test1=test"
+        val hash = java.security.MessageDigest.getInstance("SHA-512")
+            .digest((value + "TEST").toByteArray())
+            .joinToString("") { "%02x".format(it) }
+        val legacyCookie = "SIRIUS_SESSION=$hash:$value"
+
+        val connection =
+            URI("http://localhost:9999/test/session-test-read").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.setRequestProperty(HttpHeaderNames.COOKIE.toString(), legacyCookie)
+        connection.connect()
+
+        assertEquals(200, connection.responseCode)
+        // The legacy cookie is decoded correctly...
+        assertTrue { connection.inputStream.bufferedReader().readText().contains("test1=test") }
+        // ...and eagerly re-written in the encrypted format (marked with the "E1:" prefix).
+        val rewrittenCookie = connection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!!
+            .first { it.startsWith("SIRIUS_SESSION=") }
+        assertTrue { rewrittenCookie.contains("SIRIUS_SESSION=E1:") }
+        assertFalse { rewrittenCookie.contains("test1=test") }
+
+    }
 }

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -119,13 +119,29 @@ class WebContextTest {
     @Test
     fun `setSessionValue works as expected`() {
 
-        val connection = URI("http://localhost:9999/test/session-test").toURL().openConnection() as HttpURLConnection
-        connection.setRequestMethod("GET")
-        connection.connect()
+        // The first request stores the session values and returns the (encrypted) session cookie.
+        val writeConnection =
+            URI("http://localhost:9999/test/session-test").toURL().openConnection() as HttpURLConnection
+        writeConnection.requestMethod = "GET"
+        writeConnection.connect()
 
-        assertEquals(200, connection.responseCode)
-        assertTrue { connection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!![0].contains("test1=test") }
-        assertFalse { connection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!![0].contains("test2=") }
+        assertEquals(200, writeConnection.responseCode)
+        val sessionCookie = writeConnection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!!
+            .first { it.startsWith("SIRIUS_SESSION=") }
+            .substringBefore(";")
+
+        // The second request reads the session back, proving that the value round-trips through the encrypted
+        // cookie and that a value set to null is not stored.
+        val readConnection =
+            URI("http://localhost:9999/test/session-test-read").toURL().openConnection() as HttpURLConnection
+        readConnection.requestMethod = "GET"
+        readConnection.setRequestProperty(HttpHeaderNames.COOKIE.toString(), sessionCookie)
+        readConnection.connect()
+
+        assertEquals(200, readConnection.responseCode)
+        val body = readConnection.inputStream.bufferedReader().readText()
+        assertTrue { body.contains("test1=test") }
+        assertFalse { body.contains("test2=test") }
 
     }
 }


### PR DESCRIPTION
### Breaking Changes

Client session cookies are now encrypted by default (`http.sessionCookie.encrypt = true`). As a consequence, a fixed `http.sessionSecret` is mandatory: if encryption is enabled and no secret is configured, the application fails on startup (previously an empty secret silently generated a random one each start).

Before deploying, make sure a stable, sufficiently long and random `http.sessionSecret` is configured (the same value across all cluster nodes).

### Description

Introduces client session cookie encryption and secret rotation.

ClientSessionCrypto encrypts and decrypts the client session cookie payload using AES-256 in GCM mode. GCM is an authenticated encryption mode, so it provides confidentiality and integrity in one step.

The symmetric key is derived from the session secret via SHA-256. A fresh random IV is generated per encryption and prepended to the cipher text, so encrypting the same payload twice yields different cookies.
Encrypted values are marked with an E1: prefix so the reading side can distinguish them from legacy (unencrypted) cookies and support both during migration.
decrypt() returns null on any failure (wrong secret, tampering, malformed input) so the caller can simply reset the session instead of failing the request.
ClientSessionSecrets manages the secrets used to sign and encrypt sessions. It resolves all accepted secrets on startup, verifies that a fixed secret is present when encryption is enabled (failing startup otherwise), and exposes the primary secret plus all configured legacy secrets.

Secret rotation is supported via http.legacySessionSecrets: old secrets are still accepted when reading, but never used for writing. This allows rotating http.sessionSecret without logging everyone out — add the old secret to the legacy list, set a new primary secret, and remove the old one once all cookies signed/encrypted with it have expired.

WebContext wires this in: it writes sessions in the encrypted format, transparently reads both encrypted and legacy cookies (trying the primary and all legacy secrets), and eagerly upgrades a legacy unencrypted cookie to the encrypted format on read, instead of waiting for the next session modification.

Configuration: new `http.sessionCookie.encrypt` (default `true`) and `http.legacySessionSecrets` (default `[]`).

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1208](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1208)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
