### PR TITLE
Clear captcha secret from configuration

### DIFF
--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -192,7 +192,7 @@ http {
 
     # Configures the captcha key used in forms to protect them against spam bots.
     # For real safe captchas you should provide your own secret here, but by default we use a fixed value to make it work
-    captcha.secret = "superSecureCaptchaSecret"
+    captcha.secret = ""
 
     # Should a default robots.txt be served?
     robots.txt.enabled = true


### PR DESCRIPTION
### Description

Removed the captcha secret configuration from `component-065-web.conf` to enhance security and ensure sensitive information is not hard-coded.

BREAKING: due to the fact that a default secret is no longer in a public repository, products must define their own.

### Additional Notes

- This PR fixes or works on the following ticket(s): [SIRI-1225](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1225)

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.