### PR TITLE
Add system tool to decode client session cookies

### DIFF
--- a/src/main/java/sirius/web/http/SessionCookieController.java
+++ b/src/main/java/sirius/web/http/SessionCookieController.java
@@ -1,0 +1,107 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+import sirius.kernel.commons.Hasher;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
+import sirius.kernel.commons.Values;
+import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Register;
+import sirius.web.controller.BasicController;
+import sirius.web.controller.Routed;
+import sirius.web.security.Permission;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides a system tool which decodes the contents of a client session cookie for diagnostic purposes.
+ * <p>
+ * The client session is stored on the client side within an encrypted cookie (see {@link ClientSessionCrypto}). To
+ * support debugging, this controller accepts the raw cookie value, decrypts it using the configured session secrets
+ * (see {@link ClientSessionSecrets}) and displays the contained key/value pairs in a table.
+ */
+@Register
+public class SessionCookieController extends BasicController {
+
+    private static final String TEMPLATE = "/templates/system/session-cookie.html.pasta";
+
+    @Part
+    private ClientSessionSecrets sessionSecrets;
+
+    /**
+     * Renders the tool and, on a POST request, the decoded contents of the submitted cookie value.
+     *
+     * @param webContext the current request
+     */
+    @Routed("/system/session-cookie")
+    @Permission("permission-system-console")
+    public void sessionCookie(WebContext webContext) {
+        String cookieValue = webContext.get("cookieValue").asString();
+        if (!webContext.isPostRequest() || Strings.isEmpty(cookieValue)) {
+            webContext.respondWith().template(TEMPLATE, cookieValue, false, false, false, null);
+            return;
+        }
+
+        String rawValue = cookieValue.trim();
+        boolean encrypted = ClientSessionCrypto.isEncrypted(rawValue);
+        String readablePayload = null;
+        boolean integrityValid = false;
+
+        // For an encrypted cookie only the matching secret is able to decrypt the payload. For a legacy plain text
+        // cookie there is nothing to decrypt and we try each secret when verifying the integrity hash. In both cases
+        // we try the primary and all legacy secrets to support secret rotation. We remember the first readable payload
+        // so that we can still display its contents even if no secret matches the integrity hash (e.g. after a secret
+        // rotation without keeping the legacy one).
+        for (String secret : sessionSecrets.getAllSessionSecrets()) {
+            String payload = encrypted ? ClientSessionCrypto.decrypt(rawValue, secret) : rawValue;
+            if (payload == null) {
+                continue;
+            }
+            if (readablePayload == null) {
+                readablePayload = payload;
+            }
+            if (matchesIntegrityHash(payload, secret)) {
+                readablePayload = payload;
+                integrityValid = true;
+                break;
+            }
+        }
+
+        List<Tuple<String, String>> entries = readablePayload == null ? null : parseEntries(readablePayload);
+        webContext.respondWith().template(TEMPLATE, cookieValue, true, encrypted, integrityValid, entries);
+    }
+
+    /**
+     * Parses the key/value pairs of a {@code hash:querystring} payload (the internal TTL entry is kept as a regular
+     * row).
+     */
+    private List<Tuple<String, String>> parseEntries(String payload) {
+        List<Tuple<String, String>> entries = new ArrayList<>();
+        QueryStringDecoder decoder = new QueryStringDecoder(payload);
+        for (Map.Entry<String, List<String>> entry : decoder.parameters().entrySet()) {
+            entries.add(Tuple.create(entry.getKey(), Values.of(entry.getValue()).at(0).getString()));
+        }
+        entries.sort((first, second) -> String.CASE_INSENSITIVE_ORDER.compare(first.getFirst(), second.getFirst()));
+        return entries;
+    }
+
+    /**
+     * Verifies that the integrity hash within the payload matches the SHA-512 hash of the query string and the secret
+     * (mirrors the check performed by {@link WebContext} when reading a session).
+     */
+    private boolean matchesIntegrityHash(String payload, String secret) {
+        Tuple<String, String> sessionInfo = Strings.split(payload, ":");
+        return Strings.areEqual(sessionInfo.getFirst(),
+                                Hasher.sha512().hash(sessionInfo.getSecond() + secret).toHexString());
+    }
+}

--- a/src/main/java/sirius/web/http/SessionCookieController.java
+++ b/src/main/java/sirius/web/http/SessionCookieController.java
@@ -35,6 +35,11 @@ public class SessionCookieController extends BasicController {
 
     private static final String TEMPLATE = "/templates/system/session-cookie.html.pasta";
 
+    /**
+     * Describes the permission required to decode a client session cookie.
+     */
+    public static final String PERMISSION_SYSTEM_SESSION_COOKIE = "permission-system-session-cookie";
+
     @Part
     private ClientSessionSecrets sessionSecrets;
 
@@ -44,7 +49,7 @@ public class SessionCookieController extends BasicController {
      * @param webContext the current request
      */
     @Routed("/system/session-cookie")
-    @Permission("flag-system-administrator")
+    @Permission(PERMISSION_SYSTEM_SESSION_COOKIE)
     public void sessionCookie(WebContext webContext) {
         String cookieValue = webContext.get("cookieValue").asString();
         if (!webContext.isPostRequest() || Strings.isEmpty(cookieValue)) {

--- a/src/main/java/sirius/web/http/SessionCookieController.java
+++ b/src/main/java/sirius/web/http/SessionCookieController.java
@@ -44,7 +44,7 @@ public class SessionCookieController extends BasicController {
      * @param webContext the current request
      */
     @Routed("/system/session-cookie")
-    @Permission("permission-system-console")
+    @Permission("flag-system-administrator")
     public void sessionCookie(WebContext webContext) {
         String cookieValue = webContext.get("cookieValue").asString();
         if (!webContext.isPostRequest() || Strings.isEmpty(cookieValue)) {

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -746,6 +746,7 @@ security {
         permission-system-health-api: "Required to view the documentation of the health API"
         permission-system-state: "Required to view the system state"
         permission-system-load: "Required to view the system load"
+        permission-system-session-cookie: "Required to decode client session cookies"
         permission-system-tags: "Required to view all known Tagliatelle Tags"
         permission-system-tags-state: "Required to view the state of Tagliatelle"
         permission-babelfish: "Required to view and export loaded translations"

--- a/src/main/resources/default/templates/system/client-session.html.pasta
+++ b/src/main/resources/default/templates/system/client-session.html.pasta
@@ -1,0 +1,35 @@
+<i:arg type="String" name="title"/>
+<i:arg type="String" name="page" default=""/>
+
+<i:pragma name="description"
+          value="Wrapper for the system session pages, rendering a shared navigation sidebar on the left."/>
+
+<t:page title="@title">
+    <i:block name="head">
+        <i:render name="head"/>
+    </i:block>
+
+    <i:block name="breadcrumbs">
+        <li>
+            <a href="/system/info">Session</a>
+        </li>
+        <i:render name="breadcrumbs"/>
+    </i:block>
+
+    <i:block name="page-header">
+        <i:render name="page-header"/>
+    </i:block>
+
+    <t:sidebar>
+        <i:block name="sidebar">
+            <t:navbox label="Session">
+                <t:navboxLink label="Client Info" icon="fa-solid fa-circle-info" url="/system/info"
+                              active="@page == 'info'"/>
+                <t:navboxLink label="Session Cookie" icon="fa-solid fa-cookie-bite" url="/system/session-cookie"
+                              active="@page == 'session-cookie'" permission="flag-system-administrator"/>
+            </t:navbox>
+        </i:block>
+
+        <i:render name="body"/>
+    </t:sidebar>
+</t:page>

--- a/src/main/resources/default/templates/system/client-session.html.pasta
+++ b/src/main/resources/default/templates/system/client-session.html.pasta
@@ -26,7 +26,7 @@
                 <t:navboxLink label="Client Info" icon="fa-solid fa-circle-info" url="/system/info"
                               active="@page == 'info'"/>
                 <t:navboxLink label="Session Cookie" icon="fa-solid fa-cookie-bite" url="/system/session-cookie"
-                              active="@page == 'session-cookie'" permission="flag-system-administrator"/>
+                              active="@page == 'session-cookie'" permission="permission-system-session-cookie"/>
             </t:navbox>
         </i:block>
 

--- a/src/main/resources/default/templates/system/info.html.pasta
+++ b/src/main/resources/default/templates/system/info.html.pasta
@@ -1,10 +1,6 @@
 <i:arg type="sirius.web.http.WebContext" name="webContext"/>
 
-<t:page title="Client Info">
-    <i:block name="breadcrumbs">
-        <li><a href="/system/info">Client Info</a></li>
-    </i:block>
-
+<i:invoke template="/templates/system/client-session.html.pasta" title="Client Info" page="info">
     <i:block name="page-header">
         <t:pageHeader title="Client Info">
             <t:inlineInfo class="d-none d-md-block">
@@ -24,11 +20,11 @@
 
     <div class="row">
         <t:datacard title="Headers">
-            <table class="table">
+            <table class="table" style="table-layout: fixed">
                 <i:for type="String" var="name" items="webContext.getRequest().headers().names()">
                     <tr>
                         <td><b>@name</b></td>
-                        <td class="text-end">
+                        <td>
                             <i:for type="String" var="value" items="webContext.getRequest().headers().getAll(name)">
                                 <div class="text-break">@value</div>
                             </i:for>
@@ -44,7 +40,7 @@
                 <table class="table">
                     <tr>
                         <th>Name</th>
-                        <th class="text-end">
+                        <th>
                             Value
                         </th>
                         <th class="text-center">Secure</th>
@@ -65,4 +61,4 @@
             </t:datacard>
         </div>
     </i:if>
-</t:page>
+</i:invoke>

--- a/src/main/resources/default/templates/system/session-cookie.html.pasta
+++ b/src/main/resources/default/templates/system/session-cookie.html.pasta
@@ -1,0 +1,80 @@
+<i:arg type="String" name="cookieValue" default=""/>
+<i:arg type="boolean" name="submitted" default="false"/>
+<i:arg type="boolean" name="encrypted" default="false"/>
+<i:arg type="boolean" name="integrityValid" default="false"/>
+<i:arg type="java.util.List" name="entries" default="null"/>
+
+<t:page title="Session Cookie">
+    <i:block name="breadcrumbs">
+        <li>
+            <a href="/system/session-cookie">Session Cookie</a>
+        </li>
+    </i:block>
+
+    <i:block name="page-header">
+        <t:pageHeader title="Session Cookie"/>
+    </i:block>
+
+    <t:editForm url="/system/session-cookie">
+        <t:textarea name="cookieValue"
+                    value="@cookieValue"
+                    rows="6"
+                    label="Encrypted session cookie"
+                    class="font-monospace"/>
+        <t:formBar btnLabel="" backButton="false">
+            <button type="submit" class="btn btn-primary">Decode</button>
+        </t:formBar>
+    </t:editForm>
+
+    <i:if test="submitted">
+        <i:if test="entries != null">
+            <i:if test="!integrityValid">
+                <div class="alert alert-warning">
+                    The integrity check failed. The contents could be read, but they may have been created with a
+                    different (e.g. rotated) secret or been tampered with.
+                </div>
+            </i:if>
+
+            <t:heading label="Metadata"/>
+            <div class="card mb-4">
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-3">Encrypted</dt>
+                        <dd class="col-sm-9">@(encrypted ? 'Yes' : 'No')</dd>
+                        <dt class="col-sm-3">Integrity valid</dt>
+                        <dd class="col-sm-9">@(integrityValid ? 'Yes' : 'No')</dd>
+                    </dl>
+                </div>
+            </div>
+
+            <t:heading label="Contents"/>
+            <t:emptyCheck data="@entries">
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <table class="table" style="table-layout: fixed">
+                            <thead>
+                            <tr>
+                                <th style="width: 30%">Key</th>
+                                <th>Value</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <i:for type="sirius.kernel.commons.Tuple" var="entry" items="entries">
+                                <tr>
+                                    <td class="font-monospace text-break">@entry.getFirst()</td>
+                                    <td class="font-monospace text-break">@entry.getSecond()</td>
+                                </tr>
+                            </i:for>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </t:emptyCheck>
+            <i:else>
+                <div class="alert alert-danger">
+                    The cookie could not be decrypted with any of the configured session secrets.
+                </div>
+            </i:else>
+        </i:if>
+    </i:if>
+</t:page>

--- a/src/main/resources/default/templates/system/session-cookie.html.pasta
+++ b/src/main/resources/default/templates/system/session-cookie.html.pasta
@@ -1,8 +1,8 @@
-<i:arg type="String" name="cookieValue" default=""/>
-<i:arg type="boolean" name="submitted" default="false"/>
-<i:arg type="boolean" name="encrypted" default="false"/>
-<i:arg type="boolean" name="integrityValid" default="false"/>
-<i:arg type="java.util.List" name="entries" default="null"/>
+<i:arg type="String" name="cookieValue"/>
+<i:arg type="boolean" name="submitted"/>
+<i:arg type="boolean" name="encrypted"/>
+<i:arg type="boolean" name="integrityValid"/>
+<i:arg type="java.util.List" name="entries"/>
 
 <t:page title="Session Cookie">
     <i:block name="breadcrumbs">

--- a/src/main/resources/default/templates/system/session-cookie.html.pasta
+++ b/src/main/resources/default/templates/system/session-cookie.html.pasta
@@ -4,7 +4,7 @@
 <i:arg type="boolean" name="integrityValid"/>
 <i:arg type="java.util.List" name="entries"/>
 
-<t:page title="Session Cookie">
+<i:invoke template="/templates/system/client-session.html.pasta" title="Session Cookie" page="session-cookie">
     <i:block name="breadcrumbs">
         <li>
             <a href="/system/session-cookie">Session Cookie</a>
@@ -77,4 +77,4 @@
             </i:else>
         </i:if>
     </i:if>
-</t:page>
+</i:invoke>


### PR DESCRIPTION


### Description

Adds a system administrator page at /system/session-cookie that decrypts a submitted session cookie value and displays its contents in a table. Guarded by permission-system-console.

<img width="1232" height="1179" alt="image" src="https://github.com/user-attachments/assets/cfc33caa-1c1e-46a8-8947-c092d2e48157" />


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1208](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1208)
- https://github.com/scireum/sirius-biz/pull/2338

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
