### PR TITLE
Handles OPTIONS centrally to fix spurious route collision warnings (SIRI-1241)

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -226,7 +226,11 @@ public class ControllerDispatcher implements WebDispatcher {
         // routes registered for this path. It must never reach any business logic - not even a controller which
         // explicitly handles OPTIONS - so we intercept it before matching the routes below.
         if (isCorsPreflightRequest(webContext)) {
-            return answerOptionsRequest(webContext, collectSupportedMethods(webContext, uri));
+            Set<HttpMethod> supportedMethods = collectSupportedMethods(webContext, uri);
+            if (!supportedMethods.isEmpty()) {
+                return answerOptionsRequest(webContext, supportedMethods);
+            }
+            // No route matches this path - fall through to the regular 404 / next-dispatcher handling.
         }
 
         List<Route> routesWithDifferentMethod = new ArrayList<>();

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -302,9 +302,10 @@ public class ControllerDispatcher implements WebDispatcher {
     @Explain("We actually can use object identity here as this is a marker object.")
     private Set<HttpMethod> collectSupportedMethods(WebContext webContext, String uri) {
         return collectSupportedMethods(getRoutes().stream()
-                                                  .filter(route -> route.matches(webContext, uri, false) != Route.NO_MATCH
-                                                                   || route.matches(webContext, uri, true)
-                                                                      != Route.NO_MATCH)
+                                                  .filter(route -> route.matches(webContext,
+                                                                                 uri,
+                                                                                 route.isPreDispatchable())
+                                                                   != Route.NO_MATCH)
                                                   .toList());
     }
 

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -33,6 +33,7 @@ import sirius.web.http.CSRFHelper;
 import sirius.web.http.Firewall;
 import sirius.web.http.InputStreamHandler;
 import sirius.web.http.Limited;
+import sirius.web.http.Response;
 import sirius.web.http.Unlimited;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -220,6 +221,14 @@ public class ControllerDispatcher implements WebDispatcher {
     @Explain("We actually can use object identity here as this is a marker object.")
     public DispatchDecision dispatch(WebContext webContext) throws Exception {
         String uri = determineEffectiveURI(webContext);
+
+        // A genuine CORS preflight request must always be answered centrally with a method list derived from the
+        // routes registered for this path. It must never reach any business logic - not even a controller which
+        // explicitly handles OPTIONS - so we intercept it before matching the routes below.
+        if (isCorsPreflightRequest(webContext)) {
+            return answerOptionsRequest(webContext, collectSupportedMethods(webContext, uri));
+        }
+
         List<Route> routesWithDifferentMethod = new ArrayList<>();
 
         for (Route route : getRoutes()) {
@@ -240,12 +249,16 @@ public class ControllerDispatcher implements WebDispatcher {
         }
 
         if (!routesWithDifferentMethod.isEmpty()) {
-            String allowedMethods = routesWithDifferentMethod.stream()
-                                                             .flatMap(route -> route.getHttpMethods().stream())
-                                                             .map(HttpMethod::toString)
-                                                             .distinct()
-                                                             .sorted()
-                                                             .collect(Collectors.joining(", "));
+            Set<HttpMethod> supportedMethods = collectSupportedMethods(routesWithDifferentMethod);
+
+            // A plain (non-preflight) OPTIONS request is not handled by any controller unless one explicitly
+            // opts in via 'methods = OPTIONS' (which would have matched above). We therefore answer it centrally
+            // with the methods supported for this path, instead of the 405 which any other method would receive.
+            if (HttpMethod.OPTIONS.equals(webContext.getRequest().method())) {
+                return answerOptionsRequest(webContext, supportedMethods);
+            }
+
+            String allowedMethods = formatMethods(supportedMethods);
             handleFailure(webContext,
                           routesWithDifferentMethod.getFirst(),
                           Exceptions.createHandled()
@@ -257,6 +270,94 @@ public class ControllerDispatcher implements WebDispatcher {
         }
 
         return DispatchDecision.CONTINUE;
+    }
+
+    /**
+     * Determines whether the given request is a genuine CORS preflight request.
+     * <p>
+     * Such a request uses the {@link HttpMethod#OPTIONS} method and carries the
+     * {@link HttpHeaderNames#ACCESS_CONTROL_REQUEST_METHOD} header. It is always answered centrally and must never
+     * be dispatched to a controller method.
+     *
+     * @param webContext the current request
+     * @return <tt>true</tt> if the request is a CORS preflight request, <tt>false</tt> otherwise
+     */
+    private boolean isCorsPreflightRequest(WebContext webContext) {
+        return HttpMethod.OPTIONS.equals(webContext.getRequest().method())
+               && Strings.isFilled(webContext.getHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD));
+    }
+
+    /**
+     * Collects all HTTP methods supported for the given URI across every route matching it.
+     *
+     * @param webContext the current request
+     * @param uri        the effective request URI
+     * @return the set of supported HTTP methods, or an empty set if no route matches the URI
+     */
+    @SuppressWarnings("squid:S1698")
+    @Explain("We actually can use object identity here as this is a marker object.")
+    private Set<HttpMethod> collectSupportedMethods(WebContext webContext, String uri) {
+        return collectSupportedMethods(getRoutes().stream()
+                                                  .filter(route -> route.matches(webContext, uri, false) != Route.NO_MATCH
+                                                                   || route.matches(webContext, uri, true)
+                                                                      != Route.NO_MATCH)
+                                                  .toList());
+    }
+
+    /**
+     * Collects the union of all HTTP methods supported by the given routes.
+     * <p>
+     * As OPTIONS is answered centrally by this dispatcher, it is always added unless the given list is empty.
+     *
+     * @param routes the routes to collect the supported methods from
+     * @return the set of supported HTTP methods, including OPTIONS unless the list is empty
+     */
+    private Set<HttpMethod> collectSupportedMethods(List<Route> routes) {
+        Set<HttpMethod> methods = routes.stream()
+                                        .flatMap(route -> route.getHttpMethods().stream())
+                                        .collect(Collectors.toCollection(HashSet::new));
+        if (!methods.isEmpty()) {
+            methods.add(HttpMethod.OPTIONS);
+        }
+        return methods;
+    }
+
+    /**
+     * Formats the given HTTP methods as a sorted, comma-separated string suitable for the {@code Allow} and
+     * {@code Access-Control-Allow-Methods} headers.
+     *
+     * @param methods the methods to format
+     * @return the formatted method list
+     */
+    private String formatMethods(Set<HttpMethod> methods) {
+        return methods.stream().map(HttpMethod::toString).sorted().collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Answers an OPTIONS request centrally with the given supported methods.
+     * <p>
+     * The {@code Allow} header is always set. For CORS preflight requests, the
+     * {@link HttpHeaderNames#ACCESS_CONTROL_ALLOW_METHODS} and {@link HttpHeaderNames#ACCESS_CONTROL_ALLOW_HEADERS}
+     * headers are added as well. The origin related CORS headers are attached centrally by
+     * {@link sirius.web.http.Response}.
+     *
+     * @param webContext       the current request
+     * @param supportedMethods the HTTP methods supported for the requested URI
+     * @return always {@link DispatchDecision#DONE} as the request has been handled
+     */
+    private DispatchDecision answerOptionsRequest(WebContext webContext, Set<HttpMethod> supportedMethods) {
+        String allowedMethods = formatMethods(supportedMethods);
+        Response response = webContext.respondWith().setHeader(HttpHeaderNames.ALLOW, allowedMethods);
+
+        if (isCorsPreflightRequest(webContext)) {
+            String requestedHeaders = webContext.getHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS);
+            response.setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, allowedMethods)
+                    .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS,
+                               requestedHeaders == null ? "" : requestedHeaders);
+        }
+
+        response.status(HttpResponseStatus.OK);
+        return DispatchDecision.DONE;
     }
 
     private void performRoute(WebContext webContext, Route route, List<Object> params, int interceptorIndex) {

--- a/src/main/java/sirius/web/controller/HttpMethod.java
+++ b/src/main/java/sirius/web/controller/HttpMethod.java
@@ -21,9 +21,13 @@ public enum HttpMethod {
     CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE;
 
     /**
-     * Holds all possible HTTP methods for quick reference.
+     * Holds all HTTP methods except OPTIONS.
+     * <p>
+     * OPTIONS is not part of a route's default methods and is answered centrally by the framework whether or not
+     * a route opts into it (see {@link Routed#methods()}). It is therefore irrelevant to whether a route restricts
+     * its HTTP methods, and is excluded from {@link #coversAllMethodsExceptOptions(HttpMethod...)}.
      */
-    private static final Set<HttpMethod> ALL_METHODS = EnumSet.allOf(HttpMethod.class);
+    private static final Set<HttpMethod> METHODS_WITHOUT_OPTIONS = EnumSet.complementOf(EnumSet.of(OPTIONS));
 
     /**
      * Converts this enum to the corresponding Netty {@link io.netty.handler.codec.http.HttpMethod HttpMethod}.
@@ -35,21 +39,16 @@ public enum HttpMethod {
     }
 
     /**
-     * Determines if the given array of methods contains all possible HTTP methods.
-     * <p>
-     * As OPTIONS is handled centrally by the framework and is not part of a route's declared methods, it is
-     * treated as always present here. A route enumerating all remaining methods therefore still counts as
-     * complete.
+     * Determines whether the given methods cover every HTTP method except the centrally handled OPTIONS, i.e. the
+     * route places no meaningful restriction on the HTTP method.
      *
      * @param methods the list of methods to check
-     * @return <tt>true</tt> if all HTTP methods are contained, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if all methods except OPTIONS are contained, <tt>false</tt> otherwise
      */
-    public static boolean isCompleteList(HttpMethod... methods) {
-        if (methods == null || methods.length == 0) {
+    public static boolean coversAllMethodsExceptOptions(HttpMethod... methods) {
+        if (methods == null || methods.length < METHODS_WITHOUT_OPTIONS.size()) {
             return false;
         }
-        EnumSet<HttpMethod> declaredMethods = EnumSet.of(methods[0], methods);
-        declaredMethods.add(OPTIONS);
-        return declaredMethods.containsAll(ALL_METHODS);
+        return EnumSet.of(methods[0], methods).containsAll(METHODS_WITHOUT_OPTIONS);
     }
 }

--- a/src/main/java/sirius/web/controller/HttpMethod.java
+++ b/src/main/java/sirius/web/controller/HttpMethod.java
@@ -36,14 +36,20 @@ public enum HttpMethod {
 
     /**
      * Determines if the given array of methods contains all possible HTTP methods.
+     * <p>
+     * As OPTIONS is handled centrally by the framework and is not part of a route's declared methods, it is
+     * treated as always present here. A route enumerating all remaining methods therefore still counts as
+     * complete.
      *
      * @param methods the list of methods to check
      * @return <tt>true</tt> if all HTTP methods are contained, <tt>false</tt> otherwise
      */
     public static boolean isCompleteList(HttpMethod... methods) {
-        if (methods == null || methods.length == 0 || methods.length < ALL_METHODS.size()) {
+        if (methods == null || methods.length == 0) {
             return false;
         }
-        return EnumSet.of(methods[0], methods).containsAll(ALL_METHODS);
+        EnumSet<HttpMethod> declaredMethods = EnumSet.of(methods[0], methods);
+        declaredMethods.add(OPTIONS);
+        return declaredMethods.containsAll(ALL_METHODS);
     }
 }

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -124,7 +124,7 @@ public class Route {
 
     private static Optional<String> stringifyMethods(sirius.web.controller.HttpMethod[] methods) {
         // if a route supports all methods, we don't list them explicitly
-        if (sirius.web.controller.HttpMethod.isCompleteList(methods)) {
+        if (sirius.web.controller.HttpMethod.coversAllMethodsExceptOptions(methods)) {
             return Optional.empty();
         }
         return Optional.of(Stream.of(methods)

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -96,8 +96,6 @@ public class Route {
                                         .map(sirius.web.controller.HttpMethod::toHttpMethod)
                                         .toList());
         failForInvalidMethods(result.httpMethods);
-        // We auto include OPTIONS for all routes, mostly to support preflight CORS checks without having to explicitly add the method to the annotation.
-        result.httpMethods.add(HttpMethod.OPTIONS);
 
         result.label = String.format("%s%s -> %s#%s",
                                      result.uri,

--- a/src/main/java/sirius/web/controller/Routed.java
+++ b/src/main/java/sirius/web/controller/Routed.java
@@ -100,6 +100,10 @@ public @interface Routed {
 
     /**
      * Determines the HTTP methods supported by the route. By default, all methods are supported.
+     * <p>
+     * Note that OPTIONS is intentionally not part of the default list: it is handled centrally by the
+     * {@link ControllerDispatcher} (for CORS preflight checks and to advertise the allowed methods) and only
+     * reaches a controller method if it is listed here explicitly (opt-in).
      *
      * @return the supported HTTP methods
      */
@@ -109,7 +113,6 @@ public @interface Routed {
                                     HttpMethod.POST,
                                     HttpMethod.CONNECT,
                                     HttpMethod.DELETE,
-                                    HttpMethod.OPTIONS,
                                     HttpMethod.PATCH,
                                     HttpMethod.TRACE};
 

--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -335,34 +335,14 @@ class WebServerHandler extends ChannelDuplexHandler implements ActiveHTTPConnect
         if (currentRequest != null && currentCall != null) {
             CallContext.setCurrent(currentCall);
             if (!preDispatched) {
-                if (WebContext.isCorsAllowAll() && isPreflightRequest()) {
-                    handlePreflightRequest();
-                } else {
-                    dispatch();
-                }
+                // OPTIONS requests, including CORS preflight checks, are answered centrally by the
+                // ControllerDispatcher based on the routes registered for the requested path.
+                dispatch();
             }
         } else if (!preDispatched) {
             WebServer.LOG.FINE("Terminating a channel for a last http content without a request: " + message);
             channelHandlerContext.channel().close();
         }
-    }
-
-    private void handlePreflightRequest() {
-        String requestHeaders = currentRequest.headers().get(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS);
-        currentContext.respondWith()
-                      .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, "GET,PUT,POST,DELETE")
-                      .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true")
-                      .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS,
-                                 requestHeaders == null ? "" : requestHeaders)
-                      .status(HttpResponseStatus.OK);
-    }
-
-    private boolean isPreflightRequest() {
-        if (currentRequest == null || !HttpMethod.OPTIONS.equals(currentRequest.method())) {
-            return false;
-        }
-
-        return currentRequest.headers().contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
     }
 
     private void channelReadRequest(ChannelHandlerContext channelHandlerContext, HttpRequest message) {

--- a/src/main/java/sirius/web/services/PublicServiceInfo.java
+++ b/src/main/java/sirius/web/services/PublicServiceInfo.java
@@ -282,7 +282,7 @@ public class PublicServiceInfo {
     }
 
     private String determineAnchor() {
-        if (sirius.web.controller.HttpMethod.isCompleteList(routed.methods())) {
+        if (sirius.web.controller.HttpMethod.coversAllMethodsExceptOptions(routed.methods())) {
             return this.uri;
         }
         return getHttpMethod().name() + "_" + this.uri;

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -415,6 +415,11 @@ public class TestController extends BasicController {
         output.property("status", "GET OK");
     }
 
+    @Routed(value = "/test/explicit-options", methods = {HttpMethod.GET, HttpMethod.OPTIONS})
+    public void explicitOptionsTest(WebContext webContext) {
+        webContext.respondWith().direct(HttpResponseStatus.OK, webContext.getRequest().method().name() + " OK");
+    }
+
     @Routed(value = "/test/without-method", methods = {})
     public void inaccessibleTest(WebContext webContext) {
         webContext.respondWith().direct(HttpResponseStatus.OK, "NOPE");

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -57,6 +57,21 @@ class CorsTest {
     }
 
     @Test
+    fun `preflight 'Access-Control-Allow-Methods' is derived from the registered routes`() {
+        // '/test/another-restricted-method' only declares GET, so the preflight must advertise exactly GET and the
+        // centrally handled OPTIONS - and not the previously hard-coded "GET,PUT,POST,DELETE".
+        val connection =
+            URI("http://localhost:9999/test/another-restricted-method").toURL().openConnection() as HttpURLConnection
+        connection.setRequestMethod(HttpMethod.OPTIONS.name())
+        connection.addRequestProperty("Origin", "TEST")
+        connection.addRequestProperty("Access-Control-Request-Method", "GET")
+
+        connection.getInputStream().close()
+        val allowedMethods = connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString())
+        assertEquals("GET, OPTIONS", allowedMethods)
+    }
+
+    @Test
     fun `configured scope disables automatic cors even if global setting is enabled`() {
         UserContext.get().setCurrentScope(configuredScope("corsDisabled", false))
         assertFalse(WebContext.isCorsAllowAll())

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -997,6 +997,16 @@ class WebServerTest {
     }
 
     @Test
+    fun `CORS preflight requests without a matching route fall through to 404`() {
+        val connection =
+            URI("http://localhost:9999/test/no-such-route").toURL().openConnection() as HttpURLConnection
+        connection.setRequestMethod("OPTIONS")
+        connection.addRequestProperty("Access-Control-Request-Method", "GET")
+
+        assertEquals(404, connection.responseCode)
+    }
+
+    @Test
     fun `Method-restricted routes no longer implicitly support OPTIONS`() {
         val dispatcher = Injector.context().getPart(ControllerDispatcher::class.java)!!
         val methods = dispatcher.routes

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -35,12 +35,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import sirius.kernel.SiriusExtension
+import sirius.kernel.di.Injector
 import sirius.kernel.commons.Json
 import sirius.kernel.commons.Streams
 import sirius.kernel.commons.Strings
 import sirius.kernel.commons.Wait
 import sirius.kernel.health.Log
 import sirius.kernel.health.LogHelper
+import sirius.web.controller.ControllerDispatcher
 import sirius.web.dispatch.TestDispatcher
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -953,6 +955,57 @@ class WebServerTest {
         val result = Json.parseObject(String(Streams.toByteArray(connection.errorStream), StandardCharsets.UTF_8))
         assertTrue(result.get("error").asBoolean())
         assertFalse(result.get("success").asBoolean())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = '|', useHeadersInDisplayName = true, textBlock = // language=CSV
+            """uri                          | allow
+            /test/restricted-method         | GET, OPTIONS, POST
+            /test/another-restricted-method | GET, OPTIONS"""
+    )
+    fun `Plain OPTIONS requests are answered centrally with the derived Allow header`(uri: String, allow: String) {
+        val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
+        connection.setRequestMethod("OPTIONS")
+
+        assertEquals(200, connection.responseCode)
+        assertEquals(allow, connection.getHeaderField("Allow"))
+        // No controller method must have been invoked, so the body stays empty.
+        assertEquals("", String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun `Routes explicitly declaring OPTIONS handle plain OPTIONS requests themselves`() {
+        assertEquals("GET OK", callAndRead("/test/explicit-options", null, null, "GET"))
+        // The controller opted into OPTIONS, so a plain (non-preflight) OPTIONS reaches its business logic.
+        assertEquals("OPTIONS OK", callAndRead("/test/explicit-options", null, null, "OPTIONS"))
+    }
+
+    @Test
+    fun `CORS preflight requests never reach a route explicitly declaring OPTIONS`() {
+        val connection =
+            URI("http://localhost:9999/test/explicit-options").toURL().openConnection() as HttpURLConnection
+        connection.setRequestMethod("OPTIONS")
+        connection.addRequestProperty("Access-Control-Request-Method", "GET")
+
+        assertEquals(200, connection.responseCode)
+        // The preflight is answered centrally, so the opted-in controller method is not invoked.
+        assertEquals("", String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8))
+        val allowedMethods = connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString())
+        assertTrue { allowedMethods.contains("GET") }
+        assertTrue { allowedMethods.contains("OPTIONS") }
+    }
+
+    @Test
+    fun `Method-restricted routes no longer implicitly support OPTIONS`() {
+        val dispatcher = Injector.context().getPart(ControllerDispatcher::class.java)!!
+        val methods = dispatcher.routes
+            .filter { it.uri == "/test/restricted-method" }
+            .flatMap { it.httpMethods }
+            .toSet()
+        // Two routes (GET and POST) share this path. Without an implicit OPTIONS their method sets are disjoint,
+        // so the route collision detection no longer warns about them.
+        assertEquals(setOf(HttpMethod.GET, HttpMethod.POST), methods)
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Description

Handles `OPTIONS` centrally in the `ControllerDispatcher` instead of implicitly attaching it to every route, which fixes the spurious `Route collision` startup warning for same-path routes with disjoint HTTP methods (e.g. `GET` vs. `POST`).

**Root cause:** SIRI-1230 (commit `622e07e1`) added `OPTIONS` to every compiled route to support CORS preflight checks. This defeated the method-aware collision detection from `b0493d4b` — two routes on the same path always shared at least `OPTIONS`, so their method intersection was never empty and the warning fired even for disjoint methods. It also let `OPTIONS` requests reach (and ambiguously invoke) real controller methods, while the actual preflight was answered elsewhere with a hard-coded method list.

**What changed:**

- **`OPTIONS` is now opt-in per route.** Removed the blanket auto-add in `Route.compile` and dropped `OPTIONS` from the default `Routed.methods()` list. A controller only matches `OPTIONS` if it lists it explicitly (`methods = OPTIONS`). `isCompleteList` treats `OPTIONS` as always-present so default routes keep clean labels/API anchors.
- **`OPTIONS` is answered centrally by the `ControllerDispatcher`.** A genuine CORS preflight (carrying `Access-Control-Request-Method`) is intercepted before route matching and answered with an `Allow` / `Access-Control-Allow-Methods` list **derived from the routes registered for the path**, plus the echoed `Access-Control-Allow-Headers` — it never reaches business logic. A plain `OPTIONS` without an explicit handler is answered with the same derived `Allow` header instead of a `405`. The `405` `Allow` header is likewise derived centrally and re-includes `OPTIONS`.
- **Removed the hard-coded preflight handler** in `WebServerHandler` (which responded with a static `GET,PUT,POST,DELETE` and only for `corsAllowAll` scopes). Origin/credential CORS headers keep being added centrally by `Response`.

This preserves the SIRI-1230 requirement (OPTIONS accepted everywhere) — just centrally rather than per route.

**Behavioural notes (no breaking API, but worth calling out):**
- Default routes no longer invoke business logic for `OPTIONS`; such requests now receive the central answer. This is the intended outcome of the ticket.
- CORS preflights are answered inside the dispatcher rather than before it. A preflight to a path served by a dispatcher ahead of the `ControllerDispatcher` (e.g. assets) is unaffected in practice, as those are `GET` and don't preflight.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1241](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1241)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
