### PR TITLE
Reduces session pinning error log level

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -978,7 +978,8 @@ public class WebContext implements SubContext {
         } else {
             // A legacy plain text cookie has nothing to decrypt. We try each known secret when verifying the
             // integrity hash to support secret rotation for these cookies as well.
-            Map<String, String> decodedSession = parseSessionPayload(encodedSession, sessionSecrets.getAllSessionSecrets());
+            Map<String, String> decodedSession =
+                    parseSessionPayload(encodedSession, sessionSecrets.getAllSessionSecrets());
             if (decodedSession != null) {
                 return decodedSession;
             }
@@ -1567,11 +1568,7 @@ public class WebContext implements SubContext {
         if (ttl == 0) {
             setHTTPSessionCookie(sessionCookieName, cookieValue);
         } else {
-            setCookie(sessionCookieName,
-                      cookieValue,
-                      ttl,
-                      determineSessionCookieSameSite(),
-                      sessionCookieSecurity);
+            setCookie(sessionCookieName, cookieValue, ttl, determineSessionCookieSameSite(), sessionCookieSecurity);
         }
     }
 

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -881,13 +881,15 @@ public class WebContext implements SubContext {
 
         if (Strings.isFilled(sessionPin) && !Strings.areEqual(sessionPin, effectiveSessionPin) && !isLegacyCookieValid(
                 sessionPin)) {
-            SESSION_CHECK.SEVERE(Strings.apply("Session pin mismatch: %s (%s) vs. %s%n%s%n%s%nIP: %s",
-                                               givenSessionPin,
-                                               effectiveSessionPin,
-                                               sessionPin,
-                                               session,
-                                               this,
-                                               getRemoteIP()));
+            if (SESSION_CHECK.isFINE()) {
+                SESSION_CHECK.FINE(Strings.apply("Session pin mismatch: %s (%s) vs. %s%n%s%n%s%nIP: %s",
+                                                 givenSessionPin,
+                                                 effectiveSessionPin,
+                                                 sessionPin,
+                                                 session,
+                                                 this,
+                                                 getRemoteIP()));
+            }
             clearSession();
         } else if (Strings.isEmpty(sessionPin) && Strings.isFilled(givenSessionPin)) {
             if (SESSION_CHECK.isFINE()) {

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -882,13 +882,13 @@ public class WebContext implements SubContext {
         if (Strings.isFilled(sessionPin) && !Strings.areEqual(sessionPin, effectiveSessionPin) && !isLegacyCookieValid(
                 sessionPin)) {
             if (SESSION_CHECK.isFINE()) {
-                SESSION_CHECK.FINE(Strings.apply("Session pin mismatch: %s (%s) vs. %s%n%s%n%s%nIP: %s",
+                SESSION_CHECK.FINE("Session pin mismatch: %s (%s) vs. %s%n%s%n%s%nIP: %s",
                                                  givenSessionPin,
                                                  effectiveSessionPin,
                                                  sessionPin,
                                                  session,
                                                  this,
-                                                 getRemoteIP()));
+                                                 getRemoteIP());
             }
             clearSession();
         } else if (Strings.isEmpty(sessionPin) && Strings.isFilled(givenSessionPin)) {


### PR DESCRIPTION
### Description
- we must not log on every erroneous request
- bot networks seems to share some parts of their cookies. this results
  in lots of session pinning failures

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1243](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1243)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
