### PR TITLE
Increases robustness against client connection aborts on api calls

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -308,7 +308,7 @@ public class ControllerDispatcher implements WebDispatcher {
         out.property("error", false);
         Object result = route.invoke(params);
         if (result instanceof Promise<?> promise) {
-            promise.onSuccess(ignored -> {
+            promise.onSuccess(_ -> {
                 // Increase robustness against clients aborting the connection mid-stream with
                 // multiple success handlers.
                 if (!promise.isFailed()) {

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -307,9 +307,14 @@ public class ControllerDispatcher implements WebDispatcher {
         out.property("success", true);
         out.property("error", false);
         Object result = route.invoke(params);
-        if (result instanceof Promise) {
-            ((Promise<?>) result).onSuccess(ignored -> out.endResult())
-                                 .onFailure(throwable -> handleFailure(webContext, route, throwable));
+        if (result instanceof Promise<?> promise) {
+            promise.onSuccess(ignored -> {
+                // Increase robustness against clients aborting the connection mid-stream with
+                // multiple success handlers.
+                if (!promise.isFailed()) {
+                    out.endResult();
+                }
+            }).onFailure(throwable -> handleFailure(webContext, route, throwable));
         } else {
             out.endResult();
         }


### PR DESCRIPTION
### Description
- routes might return a promise with other success handlers or one might just have bad luck with timing to get a promise that is already failed while executing the onSuccess callback
- this fix will increase robustness and prevent "Invalid result structure" log messages

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15325](https://scireum.myjetbrains.com/youtrack/issue/SE-15325)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
