### PR TITLE
Upgrade jackson from 2.22.0 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>15.3.0</version>
+        <version>16.0.0</version>
     </parent>
     <artifactId>sirius-web</artifactId>
     <version>DEVELOPMENT-SNAPSHOT</version>
@@ -14,7 +14,7 @@
     <description>Provides a modern and scalable web server as SIRIUS module</description>
 
     <properties>
-        <sirius.kernel>52.1.1</sirius.kernel>
+        <sirius.kernel>53.0.0</sirius.kernel>
     </properties>
 
     <repositories>

--- a/src/main/java/sirius/pasta/noodle/macros/JsonMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/JsonMacro.java
@@ -8,7 +8,7 @@
 
 package sirius.pasta.noodle.macros;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Json;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.tokenizer.Position;

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -7,7 +7,7 @@
  */
 package sirius.web.http;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;

--- a/src/main/java/sirius/web/security/oauth/OAuthAuthentication.java
+++ b/src/main/java/sirius/web/security/oauth/OAuthAuthentication.java
@@ -8,7 +8,7 @@
 
 package sirius.web.security.oauth;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Context;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.URLBuilder;
@@ -128,8 +128,8 @@ public class OAuthAuthentication {
      * @param response the JSON response when requesting an OAuth token
      */
     public void assertNoErrorResponse(ObjectNode response) {
-        String error = response.path(OAuth.ERROR).asText(null);
-        String errorDescription = response.path(OAuth.ERROR_DESCRIPTION).asText("Unknown error");
+        String error = response.path(OAuth.ERROR).asString(null);
+        String errorDescription = response.path(OAuth.ERROR_DESCRIPTION).asString("Unknown error");
         assertNoError(error, errorDescription);
     }
 

--- a/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
+++ b/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
@@ -10,7 +10,7 @@ package sirius.web.security.oauth;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.JWTDecodeException;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Strings;
 
 import java.time.LocalDateTime;
@@ -42,9 +42,9 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
      * @return the tokens received from the authorization server
      */
     public static ReceivedTokens fromJson(ObjectNode response) {
-        String accessToken = response.required(OAuth.ACCESS_TOKEN).asText("");
-        String refreshToken = response.path(OAuth.REFRESH_TOKEN).asText("");
-        String type = response.required(OAuth.TOKEN_TYPE).asText("");
+        String accessToken = response.required(OAuth.ACCESS_TOKEN).asString("");
+        String refreshToken = response.path(OAuth.REFRESH_TOKEN).asString("");
+        String type = response.required(OAuth.TOKEN_TYPE).asString("");
         long accessTokenExpiresIn = response.path(OAuth.EXPIRES_IN).asLong(0L);
         LocalDateTime accessTokenExpiresAt =
                 accessTokenExpiresIn > 0 ? LocalDateTime.now().plusSeconds(accessTokenExpiresIn) : null;

--- a/src/main/java/sirius/web/services/ApiController.java
+++ b/src/main/java/sirius/web/services/ApiController.java
@@ -8,7 +8,7 @@
 
 package sirius.web.services;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;

--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -8,9 +8,9 @@
 
 package sirius.web.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Outcall;
@@ -174,7 +174,7 @@ public class JSONCall {
 
         try {
             return Json.writePretty(Json.MAPPER.readTree(response));
-        } catch (JsonProcessingException exception) {
+        } catch (JacksonException exception) {
             Exceptions.ignore(exception);
             return response;
         }

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -8,7 +8,7 @@
 
 package sirius.web.services;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;

--- a/src/main/java/sirius/web/services/OpenApiGenerator.java
+++ b/src/main/java/sirius/web/services/OpenApiGenerator.java
@@ -8,9 +8,6 @@
 
 package sirius.web.services;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -23,6 +20,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.nls.NLS;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
@@ -267,7 +267,7 @@ public class OpenApiGenerator {
         node.set(FIELD_SCHEMA, schema);
 
         if (Strings.isFilled(parameter.example())) {
-            node.set(FIELD_EXAMPLE, typedExample(schema.path(FIELD_TYPE).asText(), parameter.example()));
+            node.set(FIELD_EXAMPLE, typedExample(schema.path(FIELD_TYPE).asString(""), parameter.example()));
         }
         return node;
     }
@@ -475,7 +475,7 @@ public class OpenApiGenerator {
         try {
             return Json.MAPPER.readTree(value);
         } catch (Exception _) {
-            return Json.MAPPER.getNodeFactory().textNode(value);
+            return Json.MAPPER.getNodeFactory().stringNode(value);
         }
     }
 
@@ -610,7 +610,7 @@ public class OpenApiGenerator {
     }
 
     private void putExample(ObjectNode schema, String example) {
-        schema.set(FIELD_EXAMPLE, typedExample(schema.path(FIELD_TYPE).asText(), example));
+        schema.set(FIELD_EXAMPLE, typedExample(schema.path(FIELD_TYPE).asString(""), example));
     }
 
     private JsonNode typedExample(String type, String example) {
@@ -619,18 +619,18 @@ public class OpenApiGenerator {
                 try {
                     yield Json.MAPPER.getNodeFactory().numberNode(Long.parseLong(example));
                 } catch (NumberFormatException _) {
-                    yield Json.MAPPER.getNodeFactory().textNode(example);
+                    yield Json.MAPPER.getNodeFactory().stringNode(example);
                 }
             }
             case TYPE_NUMBER -> {
                 try {
                     yield Json.MAPPER.getNodeFactory().numberNode(Double.parseDouble(example));
                 } catch (NumberFormatException _) {
-                    yield Json.MAPPER.getNodeFactory().textNode(example);
+                    yield Json.MAPPER.getNodeFactory().stringNode(example);
                 }
             }
             case TYPE_BOOLEAN -> Json.MAPPER.getNodeFactory().booleanNode(Boolean.parseBoolean(example));
-            default -> Json.MAPPER.getNodeFactory().textNode(example);
+            default -> Json.MAPPER.getNodeFactory().stringNode(example);
         };
     }
 

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePdfViaGotenbergChromiumContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePdfViaGotenbergChromiumContentHandler.java
@@ -8,7 +8,7 @@
 
 package sirius.web.templates.pdf;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -8,7 +8,7 @@
 
 package sirius.web.http;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.DefaultHttpHeaders;

--- a/src/test/java/sirius/web/http/TestResponse.java
+++ b/src/test/java/sirius/web/http/TestResponse.java
@@ -8,7 +8,7 @@
 
 package sirius.web.http;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;

--- a/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
+++ b/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
@@ -8,9 +8,9 @@
 
 package sirius.web.service;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.POJONode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.POJONode;
 import org.junit.jupiter.api.Test;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Json;

--- a/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
+++ b/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
@@ -8,7 +8,7 @@
 
 package sirius.web.health
 
-import com.fasterxml.jackson.core.JsonPointer
+import tools.jackson.core.JsonPointer
 import io.netty.handler.codec.http.HttpResponseStatus
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
@@ -129,7 +129,7 @@ class WebServerNightlyTest {
 
         val data = WebServerTest.callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("test").asText())
+        assertEquals("1", Json.parseObject(data).get("test").asString())
     }
 
 }

--- a/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
@@ -129,7 +129,7 @@ class WebServerNightlyTest {
 
         val data = WebServerTest.callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("test").asString())
+        assertEquals("1", Json.parseObject(data).get("test").asString(""))
     }
 
 }

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -521,7 +521,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello_World", Json.parseObject(data).get("test").asText())
+        assertEquals("Hello_World", Json.parseObject(data).get("test").asString())
     }
 
     @ParameterizedTest
@@ -551,7 +551,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello", Json.parseObject(data).get("test").asText())
+        assertEquals("Hello", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -562,8 +562,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("param1").asText())
-        assertEquals("2", Json.parseObject(data).get("param2").asText())
+        assertEquals("1", Json.parseObject(data).get("param1").asString())
+        assertEquals("2", Json.parseObject(data).get("param2").asString())
     }
 
     @Test
@@ -574,8 +574,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("param1").asText())
-        assertEquals("2", Json.parseObject(data).get("param2").asText())
+        assertEquals("1", Json.parseObject(data).get("param1").asString())
+        assertEquals("2", Json.parseObject(data).get("param2").asString())
     }
 
     @Test
@@ -586,13 +586,13 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("param1").asText())
-        assertEquals("2", Json.parseObject(data).get("param2").asText())
+        assertEquals("1", Json.parseObject(data).get("param1").asString())
+        assertEquals("2", Json.parseObject(data).get("param2").asString())
 
         val varargs = Json.getArray(Json.parseObject(data), "params")
         assertEquals(7, varargs.size())
-        assertEquals("3", varargs.get(0).asText())
-        assertEquals("9", varargs.get(6).asText())
+        assertEquals("3", varargs.get(0).asString())
+        assertEquals("9", varargs.get(6).asString())
     }
 
     /**
@@ -749,7 +749,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello/World", Json.parseObject(data).get("test").asText())
+        assertEquals("Hello/World", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -760,7 +760,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello World", Json.parseObject(data).get("test").asText())
+        assertEquals("Hello World", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -771,7 +771,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello/World", Json.parseObject(data).get("test").asText())
+        assertEquals("Hello/World", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -782,7 +782,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello World", Json.parseObject(data).get("test").asText())
+        assertEquals("Hello World", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -793,8 +793,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("one", Json.parseObject(data).get("param1").asText())
-        assertEquals("t/wo", Json.parseObject(data).get("param2").asText())
+        assertEquals("one", Json.parseObject(data).get("param1").asString())
+        assertEquals("t/wo", Json.parseObject(data).get("param2").asString())
     }
 
     @Test
@@ -805,8 +805,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("one", Json.parseObject(data).get("param1").asText())
-        assertEquals("t wo", Json.parseObject(data).get("param2").asText())
+        assertEquals("one", Json.parseObject(data).get("param1").asString())
+        assertEquals("t wo", Json.parseObject(data).get("param2").asString())
     }
 
     @Test
@@ -817,17 +817,17 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1/", Json.parseObject(data).get("param1").asText())
-        assertEquals("/2", Json.parseObject(data).get("param2").asText())
+        assertEquals("1/", Json.parseObject(data).get("param1").asString())
+        assertEquals("/2", Json.parseObject(data).get("param2").asString())
 
         val varargs = Json.getArray(Json.parseObject(data), "params")
 
         assertEquals(5, varargs.size())
-        assertEquals("one", varargs.get(0).asText())
-        assertEquals("t/wo", varargs.get(1).asText())
-        assertEquals("t/hree", varargs.get(2).asText())
-        assertEquals("/four", varargs.get(3).asText())
-        assertEquals("five/", varargs.get(4).asText())
+        assertEquals("one", varargs.get(0).asString())
+        assertEquals("t/wo", varargs.get(1).asString())
+        assertEquals("t/hree", varargs.get(2).asString())
+        assertEquals("/four", varargs.get(3).asString())
+        assertEquals("five/", varargs.get(4).asString())
     }
 
     @Test
@@ -838,17 +838,17 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1 ", Json.parseObject(data).get("param1").asText())
-        assertEquals(" 2", Json.parseObject(data).get("param2").asText())
+        assertEquals("1 ", Json.parseObject(data).get("param1").asString())
+        assertEquals(" 2", Json.parseObject(data).get("param2").asString())
 
         val varargs = Json.getArray(Json.parseObject(data), "params")
 
         assertEquals(5, varargs.size())
-        assertEquals("one", varargs.get(0).asText())
-        assertEquals("t wo", varargs.get(1).asText())
-        assertEquals("t hree", varargs.get(2).asText())
-        assertEquals(" four", varargs.get(3).asText())
-        assertEquals("five ", varargs.get(4).asText())
+        assertEquals("one", varargs.get(0).asString())
+        assertEquals("t wo", varargs.get(1).asString())
+        assertEquals("t hree", varargs.get(2).asString())
+        assertEquals(" four", varargs.get(3).asString())
+        assertEquals("five ", varargs.get(4).asString())
     }
 
     @Test
@@ -859,7 +859,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("///", Json.parseObject(data).get("test").asText())
+        assertEquals("///", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -870,7 +870,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("   ", Json.parseObject(data).get("test").asText())
+        assertEquals("   ", Json.parseObject(data).get("test").asString())
     }
 
     @Test
@@ -931,7 +931,7 @@ class WebServerTest {
     )
     fun `Requests to JSON routes with restricted method work`(uri: String, method: String, result: String) {
         val data = callAndRead(uri, null, null, method)
-        assertEquals(result, Json.parseObject(data).get("status").asText())
+        assertEquals(result, Json.parseObject(data).get("status").asString())
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -521,7 +521,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello_World", Json.parseObject(data).get("test").asString())
+        assertEquals("Hello_World", Json.parseObject(data).get("test").asString(""))
     }
 
     @ParameterizedTest
@@ -551,7 +551,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello", Json.parseObject(data).get("test").asString())
+        assertEquals("Hello", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -562,8 +562,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("param1").asString())
-        assertEquals("2", Json.parseObject(data).get("param2").asString())
+        assertEquals("1", Json.parseObject(data).get("param1").asString(""))
+        assertEquals("2", Json.parseObject(data).get("param2").asString(""))
     }
 
     @Test
@@ -574,8 +574,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("param1").asString())
-        assertEquals("2", Json.parseObject(data).get("param2").asString())
+        assertEquals("1", Json.parseObject(data).get("param1").asString(""))
+        assertEquals("2", Json.parseObject(data).get("param2").asString(""))
     }
 
     @Test
@@ -586,13 +586,13 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1", Json.parseObject(data).get("param1").asString())
-        assertEquals("2", Json.parseObject(data).get("param2").asString())
+        assertEquals("1", Json.parseObject(data).get("param1").asString(""))
+        assertEquals("2", Json.parseObject(data).get("param2").asString(""))
 
         val varargs = Json.getArray(Json.parseObject(data), "params")
         assertEquals(7, varargs.size())
-        assertEquals("3", varargs.get(0).asString())
-        assertEquals("9", varargs.get(6).asString())
+        assertEquals("3", varargs.get(0).asString(""))
+        assertEquals("9", varargs.get(6).asString(""))
     }
 
     /**
@@ -749,7 +749,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello/World", Json.parseObject(data).get("test").asString())
+        assertEquals("Hello/World", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -760,7 +760,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello World", Json.parseObject(data).get("test").asString())
+        assertEquals("Hello World", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -771,7 +771,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello/World", Json.parseObject(data).get("test").asString())
+        assertEquals("Hello/World", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -782,7 +782,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("Hello World", Json.parseObject(data).get("test").asString())
+        assertEquals("Hello World", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -793,8 +793,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("one", Json.parseObject(data).get("param1").asString())
-        assertEquals("t/wo", Json.parseObject(data).get("param2").asString())
+        assertEquals("one", Json.parseObject(data).get("param1").asString(""))
+        assertEquals("t/wo", Json.parseObject(data).get("param2").asString(""))
     }
 
     @Test
@@ -805,8 +805,8 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("one", Json.parseObject(data).get("param1").asString())
-        assertEquals("t wo", Json.parseObject(data).get("param2").asString())
+        assertEquals("one", Json.parseObject(data).get("param1").asString(""))
+        assertEquals("t wo", Json.parseObject(data).get("param2").asString(""))
     }
 
     @Test
@@ -817,17 +817,17 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1/", Json.parseObject(data).get("param1").asString())
-        assertEquals("/2", Json.parseObject(data).get("param2").asString())
+        assertEquals("1/", Json.parseObject(data).get("param1").asString(""))
+        assertEquals("/2", Json.parseObject(data).get("param2").asString(""))
 
         val varargs = Json.getArray(Json.parseObject(data), "params")
 
         assertEquals(5, varargs.size())
-        assertEquals("one", varargs.get(0).asString())
-        assertEquals("t/wo", varargs.get(1).asString())
-        assertEquals("t/hree", varargs.get(2).asString())
-        assertEquals("/four", varargs.get(3).asString())
-        assertEquals("five/", varargs.get(4).asString())
+        assertEquals("one", varargs.get(0).asString(""))
+        assertEquals("t/wo", varargs.get(1).asString(""))
+        assertEquals("t/hree", varargs.get(2).asString(""))
+        assertEquals("/four", varargs.get(3).asString(""))
+        assertEquals("five/", varargs.get(4).asString(""))
     }
 
     @Test
@@ -838,17 +838,17 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("1 ", Json.parseObject(data).get("param1").asString())
-        assertEquals(" 2", Json.parseObject(data).get("param2").asString())
+        assertEquals("1 ", Json.parseObject(data).get("param1").asString(""))
+        assertEquals(" 2", Json.parseObject(data).get("param2").asString(""))
 
         val varargs = Json.getArray(Json.parseObject(data), "params")
 
         assertEquals(5, varargs.size())
-        assertEquals("one", varargs.get(0).asString())
-        assertEquals("t wo", varargs.get(1).asString())
-        assertEquals("t hree", varargs.get(2).asString())
-        assertEquals(" four", varargs.get(3).asString())
-        assertEquals("five ", varargs.get(4).asString())
+        assertEquals("one", varargs.get(0).asString(""))
+        assertEquals("t wo", varargs.get(1).asString(""))
+        assertEquals("t hree", varargs.get(2).asString(""))
+        assertEquals(" four", varargs.get(3).asString(""))
+        assertEquals("five ", varargs.get(4).asString(""))
     }
 
     @Test
@@ -859,7 +859,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("///", Json.parseObject(data).get("test").asString())
+        assertEquals("///", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -870,7 +870,7 @@ class WebServerTest {
 
         val data = callAndRead(uri, null, expectedHeaders)
 
-        assertEquals("   ", Json.parseObject(data).get("test").asString())
+        assertEquals("   ", Json.parseObject(data).get("test").asString(""))
     }
 
     @Test
@@ -931,7 +931,7 @@ class WebServerTest {
     )
     fun `Requests to JSON routes with restricted method work`(uri: String, method: String, result: String) {
         val data = callAndRead(uri, null, null, method)
-        assertEquals(result, Json.parseObject(data).get("status").asString())
+        assertEquals(result, Json.parseObject(data).get("status").asString(""))
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/sirius/web/service/MappedServiceTest.kt
+++ b/src/test/kotlin/sirius/web/service/MappedServiceTest.kt
@@ -66,7 +66,7 @@ class MappedServiceTest {
         val (status, data, _) = call("/test/mapped/echo/Hello")
 
         assertEquals(HttpURLConnection.HTTP_OK, status)
-        assertEquals("Hello", Json.parseObject(data).get("greeting").asText())
+        assertEquals("Hello", Json.parseObject(data).get("greeting").asString(""))
     }
 
     @Test
@@ -74,7 +74,7 @@ class MappedServiceTest {
         val (status, data, _) = call("/test/mapped/async", """{"name": "Async"}""")
 
         assertEquals(HttpURLConnection.HTTP_OK, status)
-        assertEquals("Hello Async", Json.parseObject(data).get("greeting").asText())
+        assertEquals("Hello Async", Json.parseObject(data).get("greeting").asString(""))
     }
 
     @Test
@@ -85,7 +85,7 @@ class MappedServiceTest {
         val json = Json.parseObject(data)
         assertFalse(json.get("success").asBoolean())
         assertTrue(json.get("error").asBoolean())
-        assertTrue(json.get("message").asText().contains("World"))
+        assertTrue(json.get("message").asString("").contains("World"))
     }
 
     @Test

--- a/src/test/kotlin/sirius/web/service/OpenApiGeneratorTest.kt
+++ b/src/test/kotlin/sirius/web/service/OpenApiGeneratorTest.kt
@@ -10,7 +10,7 @@
 
 package sirius.web.service
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 import io.swagger.v3.oas.annotations.media.Schema
 import sirius.web.services.OpenApiGenerator
 import kotlin.test.Test
@@ -34,13 +34,13 @@ class OpenApiGeneratorTest {
         assertEquals(true, schemas.containsKey("SearchItem"))
 
         val properties = schemas["SearchResponse"]!!.get("properties")
-        assertEquals("integer", properties.get("totalHits").get("type").asText())
-        assertEquals("boolean", properties.get("hasMore").get("type").asText())
+        assertEquals("integer", properties.get("totalHits").get("type").asString(""))
+        assertEquals("boolean", properties.get("hasMore").get("type").asString(""))
 
-        assertEquals("array", properties.get("items").get("type").asText())
+        assertEquals("array", properties.get("items").get("type").asString(""))
         assertEquals("#/components/schemas/SearchItem", ref(properties.get("items").get("items")))
 
-        assertEquals("object", properties.get("itemsById").get("type").asText())
+        assertEquals("object", properties.get("itemsById").get("type").asString(""))
         assertEquals("#/components/schemas/SearchItem", ref(properties.get("itemsById").get("additionalProperties")))
     }
 
@@ -52,14 +52,14 @@ class OpenApiGeneratorTest {
         val itemSchema = generator.componentSchemas["SearchItem"]!!
         val itemProperties = itemSchema.get("properties")
 
-        assertEquals("number", itemProperties.get("price").get("type").asText())
-        assertEquals("Item price", itemProperties.get("price").get("description").asText())
+        assertEquals("number", itemProperties.get("price").get("type").asString(""))
+        assertEquals("Item price", itemProperties.get("price").get("description").asString(""))
 
         val availability = itemProperties.get("availability")
-        assertEquals("string", availability.get("type").asText())
-        assertEquals(listOf("IN_STOCK", "OUT_OF_STOCK"), availability.get("enum").map { it.asText() })
+        assertEquals("string", availability.get("type").asString(""))
+        assertEquals(listOf("IN_STOCK", "OUT_OF_STOCK"), availability.get("enum").values().map { it.asString("") })
 
-        assertEquals(listOf("code"), itemSchema.get("required").map { it.asText() })
+        assertEquals(listOf("code"), itemSchema.get("required").values().map { it.asString("") })
     }
 
     @Test
@@ -98,7 +98,7 @@ class OpenApiGeneratorTest {
         assertEquals(1, example.intValue())
     }
 
-    private fun ref(node: JsonNode): String = node.get("\$ref").asText()
+    private fun ref(node: JsonNode): String = node.get("\$ref").asString("")
 
     @Suppress("unused")
     private enum class Availability { IN_STOCK, OUT_OF_STOCK }

--- a/src/test/kotlin/sirius/web/util/CaptchaControllerTest.kt
+++ b/src/test/kotlin/sirius/web/util/CaptchaControllerTest.kt
@@ -39,11 +39,11 @@ class CaptchaControllerTest {
         jsonOutput.endResult()
 
         val json = Json.parseObject(outputStream.toString(StandardCharsets.UTF_8))
-        assertEquals(challenge.algorithm(), json.get("algorithm").asText())
-        assertEquals(challenge.challenge(), json.get("challenge").asText())
+        assertEquals(challenge.algorithm(), json.get("algorithm").asString())
+        assertEquals(challenge.challenge(), json.get("challenge").asString())
         assertEquals(challenge.maxnumber(), json.get("maxnumber").asLong())
-        assertEquals(challenge.salt(), json.get("salt").asText())
-        assertEquals(challenge.signature(), json.get("signature").asText())
+        assertEquals(challenge.salt(), json.get("salt").asString())
+        assertEquals(challenge.signature(), json.get("signature").asString())
     }
 
     @Test

--- a/src/test/kotlin/sirius/web/util/CaptchaControllerTest.kt
+++ b/src/test/kotlin/sirius/web/util/CaptchaControllerTest.kt
@@ -39,11 +39,11 @@ class CaptchaControllerTest {
         jsonOutput.endResult()
 
         val json = Json.parseObject(outputStream.toString(StandardCharsets.UTF_8))
-        assertEquals(challenge.algorithm(), json.get("algorithm").asString())
-        assertEquals(challenge.challenge(), json.get("challenge").asString())
+        assertEquals(challenge.algorithm(), json.get("algorithm").asString(""))
+        assertEquals(challenge.challenge(), json.get("challenge").asString(""))
         assertEquals(challenge.maxnumber(), json.get("maxnumber").asLong())
-        assertEquals(challenge.salt(), json.get("salt").asString())
-        assertEquals(challenge.signature(), json.get("signature").asString())
+        assertEquals(challenge.salt(), json.get("salt").asString(""))
+        assertEquals(challenge.signature(), json.get("signature").asString(""))
     }
 
     @Test

--- a/src/test/resources/templates/define.html.pasta
+++ b/src/test/resources/templates/define.html.pasta
@@ -5,4 +5,4 @@
     { doesWork: 'Yesss' }
 </i:define>
 _@xml(test).queryString('@attr')_
-_@json(test2).get('doesWork').asText()_
+_@json(test2).get('doesWork').asString("")_


### PR DESCRIPTION
### BREAKING CHANGES

Upgrades Jackson from 2.22.0 to 3.2.0 across the sirius stack. Jackson 3 uses new Maven coordinates and Java packages — see the official [Jackson 3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) and [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0) for the complete list of renames and behavioral changes.

What applications using the sirius framework have to change:

- Rename imports `com.fasterxml.jackson.*` → `tools.jackson.*` (annotations stay on `com.fasterxml.jackson.annotation`); drop `jackson-datatype-jsr310` and `JavaTimeModule` registrations (built-in now).
- Fix the resulting compile errors: unchecked exceptions (`JsonProcessingException` → `JacksonException`, dead `catch (IOException)` blocks), method renames (`asText()` → `asString()` etc., `writeFieldName()` → `writeName()` etc.), builder-based mapper/generator configuration — see the migration guide for details.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1149](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1149)
- This PR is related to PRs:
  - https://github.com/scireum/sirius-parent/pull/79
  - https://github.com/scireum/sirius-kernel/pull/628

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
