### PR TITLE
Adds Partitioned (CHIPS) support for the session cookie

### DIFF
--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -360,6 +360,17 @@ public class WebContext implements SubContext {
     private static boolean sessionCookieEncryption;
 
     /**
+     * Determines if the session cookie (and its pin cookie) is marked as
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies">Partitioned</a>
+     * (CHIPS). A partitioned cookie is stored and sent under a per-top-level-site partition, which lets it work in
+     * cross-site (third-party) iframe contexts that would otherwise block or partition it away. Browsers only honor the
+     * attribute on a {@code Secure} cookie; and for the cross-site iframe use case it additionally has to be combined
+     * with {@code SameSite=None} (otherwise the cookie is not sent cross-site in the first place).
+     */
+    @ConfigValue("http.sessionCookie.partitioned")
+    private static boolean sessionCookiePartitioned;
+
+    /**
      * Determines the domain set for all cookies. If empty no domain will be set.
      * If a cookie's domain attribute is not set, the cookie is only applicable to the domain of the originating request, EXCLUDING all its subdomains.
      * (However in IE 9 and older versions, a cookie made for abc.com is also sent in requests to xyz.abc.com)
@@ -950,11 +961,7 @@ public class WebContext implements SubContext {
                                getRemoteIP());
         }
 
-        setCookie(getSessionPinCookieName(),
-                  givenSessionPin,
-                  SESSION_PIN_COOKIE_TTL,
-                  determineSessionCookieSameSite(),
-                  sessionCookieSecurity);
+        setSessionScopedCookie(getSessionPinCookieName(), givenSessionPin, SESSION_PIN_COOKIE_TTL);
     }
 
     private Map<String, String> decodeSession(String encodedSession) {
@@ -1563,14 +1570,27 @@ public class WebContext implements SubContext {
 
         long ttl = determineSessionCookieTTL();
         if (ttl == 0) {
-            setHTTPSessionCookie(sessionCookieName, cookieValue);
+            setSessionScopedCookie(sessionCookieName, cookieValue, Long.MIN_VALUE);
         } else {
-            setCookie(sessionCookieName,
-                      cookieValue,
-                      ttl,
-                      determineSessionCookieSameSite(),
-                      sessionCookieSecurity);
+            setSessionScopedCookie(sessionCookieName, cookieValue, ttl);
         }
+    }
+
+    /**
+     * Writes an http-only cookie belonging to the client session - the session cookie itself or its pin cookie -
+     * applying the session cookie's SameSite, security and {@link #sessionCookiePartitioned Partitioned} attributes so
+     * the whole session works consistently in cross-site iframe contexts.
+     *
+     * @param name          the cookie name
+     * @param value         the cookie value
+     * @param maxAgeSeconds the max age in seconds, or {@link Long#MIN_VALUE} for a browser-session cookie
+     */
+    private void setSessionScopedCookie(String name, String value, long maxAgeSeconds) {
+        DefaultCookie cookie =
+                createCookie(name, value, maxAgeSeconds, determineSessionCookieSameSite(), sessionCookieSecurity);
+        cookie.setHttpOnly(true);
+        cookie.setPartitioned(sessionCookiePartitioned);
+        setCookie(cookie);
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -363,9 +363,11 @@ public class WebContext implements SubContext {
      * Determines if the session cookie (and its pin cookie) is marked as
      * <a href="https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies">Partitioned</a>
      * (CHIPS). A partitioned cookie is stored and sent under a per-top-level-site partition, which lets it work in
-     * cross-site (third-party) iframe contexts that would otherwise block or partition it away. Browsers only honor the
-     * attribute on a {@code Secure} cookie; and for the cross-site iframe use case it additionally has to be combined
-     * with {@code SameSite=None} (otherwise the cookie is not sent cross-site in the first place).
+     * cross-site (third-party) iframe contexts that would otherwise block or partition it away. Browsers reject a
+     * {@code Partitioned} cookie that is not {@code Secure}, and the attribute is only meaningful on a cookie that is
+     * actually sent cross-site (i.e. {@code SameSite=None}). It is therefore only emitted when the resulting cookie is
+     * both {@code Secure} and {@code SameSite=None}; otherwise it is silently skipped, so enabling the flag can never
+     * produce an invalid cookie or break a session.
      */
     @ConfigValue("http.sessionCookie.partitioned")
     private static boolean sessionCookiePartitioned;
@@ -1578,8 +1580,10 @@ public class WebContext implements SubContext {
 
     /**
      * Writes an http-only cookie belonging to the client session - the session cookie itself or its pin cookie -
-     * applying the session cookie's SameSite, security and {@link #sessionCookiePartitioned Partitioned} attributes so
-     * the whole session works consistently in cross-site iframe contexts.
+     * applying the session cookie's SameSite and security attributes. The {@link #sessionCookiePartitioned Partitioned}
+     * (CHIPS) attribute is applied only when it is enabled and the resulting cookie is both {@code Secure} and
+     * {@code SameSite=None}, so the whole session works consistently in cross-site iframe contexts without ever emitting
+     * a {@code Partitioned} attribute that a browser would reject.
      *
      * @param name          the cookie name
      * @param value         the cookie value
@@ -1589,7 +1593,9 @@ public class WebContext implements SubContext {
         DefaultCookie cookie =
                 createCookie(name, value, maxAgeSeconds, determineSessionCookieSameSite(), sessionCookieSecurity);
         cookie.setHttpOnly(true);
-        cookie.setPartitioned(sessionCookiePartitioned);
+        cookie.setPartitioned(sessionCookiePartitioned
+                              && cookie.isSecure()
+                              && cookie.sameSite() == CookieHeaderNames.SameSite.None);
         setCookie(cookie);
     }
 

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -171,6 +171,13 @@ http {
         # When reading, legacy unencrypted cookies are still accepted, so this can be enabled without logging
         # everyone out. Disable only for debugging or to temporarily roll back the behaviour.
         encrypt = true
+
+        # Determines whether the session cookie (and its pin cookie) is marked "Partitioned" (CHIPS). A partitioned
+        # cookie is stored and sent under a per-top-level-site partition, which lets the session work inside a
+        # cross-site (third-party) iframe that browsers would otherwise block or partition away - e.g. an embedded
+        # widget. Browsers only honor it on a secure cookie; for the cross-site iframe use case it must additionally be
+        # combined with #sameSite = "None" (otherwise the cookie is not sent cross-site at all).
+        partitioned = false
     }
 
     # Specifies the secret used to protect client sessions and to derive the key for encrypting the session cookie

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -175,8 +175,9 @@ http {
         # Determines whether the session cookie (and its pin cookie) is marked "Partitioned" (CHIPS). A partitioned
         # cookie is stored and sent under a per-top-level-site partition, which lets the session work inside a
         # cross-site (third-party) iframe that browsers would otherwise block or partition away - e.g. an embedded
-        # widget. Browsers only honor it on a secure cookie; for the cross-site iframe use case it must additionally be
-        # combined with #sameSite = "None" (otherwise the cookie is not sent cross-site at all).
+        # widget. The attribute is only emitted on a cookie that is both secure and #sameSite = "None"; otherwise it is
+        # skipped (browsers reject a Partitioned cookie that is not secure, and it is pointless on a cookie that is not
+        # sent cross-site), so enabling this flag without those settings never breaks a session - it just has no effect.
         partitioned = false
     }
 

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -146,6 +146,24 @@ class WebContextTest {
     }
 
     @Test
+    fun `the session cookie is not partitioned by default`() {
+
+        // Guards http.sessionCookie.partitioned defaulting to false: without opting in, the session cookie must not
+        // carry the Partitioned (CHIPS) attribute, so behaviour is unchanged for existing products.
+        val connection =
+            URI("http://localhost:9999/test/session-test").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+        connection.connect()
+
+        assertEquals(200, connection.responseCode)
+        val sessionCookieLine = connection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!!
+            .first { it.startsWith("SIRIUS_SESSION=") }
+
+        assertFalse { sessionCookieLine.contains("Partitioned", ignoreCase = true) }
+
+    }
+
+    @Test
     fun `a legacy unencrypted session cookie is read and upgraded to the encrypted format`() {
 
         // Build a legacy (unencrypted) session cookie in the "<sha512 hash>:<querystring>" format, signed with the

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -146,10 +146,11 @@ class WebContextTest {
     }
 
     @Test
-    fun `the session cookie is not partitioned by default`() {
+    fun `the session cookie keeps its attributes and is not partitioned by default`() {
 
-        // Guards http.sessionCookie.partitioned defaulting to false: without opting in, the session cookie must not
-        // carry the Partitioned (CHIPS) attribute, so behaviour is unchanged for existing products.
+        // Guards the setSessionScopedCookie refactor: the session cookie must still be marked HttpOnly (the attribute
+        // moved into the new helper), and - since http.sessionCookie.partitioned defaults to false - must NOT carry the
+        // Partitioned (CHIPS) attribute, so behaviour is unchanged for existing products.
         val connection =
             URI("http://localhost:9999/test/session-test").toURL().openConnection() as HttpURLConnection
         connection.requestMethod = "GET"
@@ -159,6 +160,7 @@ class WebContextTest {
         val sessionCookieLine = connection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!!
             .first { it.startsWith("SIRIUS_SESSION=") }
 
+        assertTrue { sessionCookieLine.contains("HTTPOnly", ignoreCase = true) }
         assertFalse { sessionCookieLine.contains("Partitioned", ignoreCase = true) }
 
     }


### PR DESCRIPTION
### Description

Adds an opt-in `http.sessionCookie.partitioned` (CHIPS) config that marks the client session cookie **and its session-pin cookie** with the `Partitioned` attribute. A partitioned cookie is stored and sent under a per-top-level-site partition, which lets the client session work inside a **cross-site (third-party) iframe** — e.g. an embedded support widget — that browsers (Safari ITP, Firefox TCP, Chrome 3PCD) would otherwise block or partition away.

- **Opt-in, defaults to `false`** → behaviour is unchanged for every existing product unless it enables the flag. When `false`, `setPartitioned(false)` is a genuine no-op (the encoder only emits `; Partitioned` when the flag is set), so no cookie changes on the wire.
- Only honored by browsers on a `Secure` cookie; for the cross-site iframe use case it additionally has to be combined with `SameSite=None`.
- Writing of the session and pin cookies is now funnelled through a single `setSessionScopedCookie` helper, so both consistently carry the SameSite, Secure and Partitioned attributes (the pin cookie must share the session cookie's partition, or pinning would break when CHIPS is enabled).

No breaking changes. Operational note when enabling: a partitioned session is scoped per top-level site (a session established under one embedding site is not shared with another) — this is the intended CHIPS behaviour.

### Additional Notes

- This PR fixes or works on following ticket(s): [MIO-6543](https://scireum.myjetbrains.com/youtrack/issue/MIO-6543) (memoio support widget needs its session cookie to survive a cross-site iframe)
- This PR is related to PR: <!-- none -->

### Checklist

- [x] Code change has been tested and works locally <!-- compiles on netty 4.2.15; WebContextTest 14/14, incl. a new regression test asserting the session cookie is NOT partitioned by default -->
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc) <!-- hand-written to match surrounding style; not run through the IntelliJ formatter -->
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? <!-- no -->
