### PR TITLE
Supports pojo mapping api routes

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -23,6 +23,7 @@ import sirius.kernel.commons.Strings;
 import sirius.kernel.di.Injector;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.di.std.Parts;
 import sirius.kernel.di.std.PriorityParts;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
@@ -40,6 +41,7 @@ import sirius.web.http.WebDispatcher;
 import sirius.web.security.MaintenanceInfo;
 import sirius.web.security.UserContext;
 import sirius.web.security.UserInfo;
+import sirius.web.services.ApiPayloadCodec;
 import sirius.web.services.Format;
 import sirius.web.templates.ClosedChannelHelper;
 
@@ -48,6 +50,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -104,6 +107,9 @@ public class ControllerDispatcher implements WebDispatcher {
     @Part
     @Nullable
     private Firewall firewall;
+
+    @Parts(ApiPayloadCodec.class)
+    private Collection<ApiPayloadCodec> apiPayloadCodecs;
 
     /**
      * The priority of this controller is {@code PriorityCollector.DEFAULT_PRIORITY + 10} as it is quite complex
@@ -287,8 +293,8 @@ public class ControllerDispatcher implements WebDispatcher {
      * @return <tt>true</tt> if the request is a CORS preflight request, <tt>false</tt> otherwise
      */
     private boolean isCorsPreflightRequest(WebContext webContext) {
-        return HttpMethod.OPTIONS.equals(webContext.getRequest().method())
-               && Strings.isFilled(webContext.getHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD));
+        return HttpMethod.OPTIONS.equals(webContext.getRequest().method()) && Strings.isFilled(webContext.getHeader(
+                HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD));
     }
 
     /**
@@ -407,6 +413,11 @@ public class ControllerDispatcher implements WebDispatcher {
     }
 
     private void executeApiCall(WebContext webContext, Route route, List<Object> params) throws Exception {
+        if (route.isMappedPayload()) {
+            executeMappedApiCall(webContext, route, params);
+            return;
+        }
+
         StructuredOutput out = createOutput(webContext, route.getApiResponseFormat());
         params.add(1, out);
         out.beginResult();
@@ -424,6 +435,41 @@ public class ControllerDispatcher implements WebDispatcher {
         } else {
             out.endResult();
         }
+    }
+
+    private void executeMappedApiCall(WebContext webContext, Route route, List<Object> params) throws Exception {
+        ApiPayloadCodec codec = findApiPayloadCodec(route.getApiResponseFormat());
+
+        if (route.getInputType() != null) {
+            params.add(1, codec.readBody(webContext, route.getInputType()));
+        }
+
+        Object result = route.invoke(params);
+        if (result instanceof Promise<?> promise) {
+            promise.onSuccess(value -> {
+                // Route serialization errors to handleFailure ourselves - exceptions thrown by a
+                // completion handler are only logged by the Promise and would never reach the client.
+                try {
+                    codec.writeResult(webContext, value);
+                } catch (Exception exception) {
+                    handleFailure(webContext, route, exception);
+                }
+            }).onFailure(throwable -> handleFailure(webContext, route, throwable));
+        } else {
+            codec.writeResult(webContext, result);
+        }
+    }
+
+    private ApiPayloadCodec findApiPayloadCodec(Format format) {
+        return apiPayloadCodecs.stream()
+                               .filter(codec -> codec.getFormat() == format)
+                               .findFirst()
+                               .orElseThrow(() -> Exceptions.handle()
+                                                            .to(LOG)
+                                                            .withSystemErrorMessage(
+                                                                    "No ApiPayloadCodec is registered for format %s",
+                                                                    format)
+                                                            .handle());
     }
 
     private StructuredOutput createOutput(WebContext webContext, Format apiResponseFormat) {

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -12,6 +12,8 @@ import io.netty.handler.codec.http.HttpMethod;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.async.Promise;
+import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -33,8 +35,10 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -68,6 +72,8 @@ public class Route {
     private Controller controller;
     private boolean preDispatchable;
     private Format format;
+    private boolean mappedPayload;
+    private Class<?> inputType;
     private boolean enforceMaintenanceMode;
     private Set<String> permissions = null;
     private String subScope;
@@ -115,6 +121,9 @@ public class Route {
         if (finalPattern.isEmpty()) {
             finalPattern = new StringBuilder("/");
         }
+        if (result.mappedPayload) {
+            extractMappedInputType(method, result, parameterTypes, params);
+        }
         failForInvalidParameterCount(routed, parameterTypes, params);
 
         result.parameterTypes = parameterTypes.toArray(CLASS_ARRAY);
@@ -142,18 +151,126 @@ public class Route {
         }
         parameterTypes.removeFirst();
         if (result.format == Format.JSON) {
-            failForInvalidJSONMethod(parameterTypes);
-            parameterTypes.removeFirst();
+            if (isLegacyStructuredOutput(JSONStructuredOutput.class, parameterTypes)) {
+                parameterTypes.removeFirst();
+            } else {
+                result.mappedPayload = true;
+            }
         }
         if (result.format == Format.XML) {
-            failForInvalidXMLMethod(parameterTypes);
-            parameterTypes.removeFirst();
+            if (isLegacyStructuredOutput(XMLStructuredOutput.class, parameterTypes)) {
+                parameterTypes.removeFirst();
+            } else {
+                throw new IllegalArgumentException(Strings.apply(
+                        "Mapped service method '%s' cannot use XML until an XML ApiPayloadCodec is available",
+                        result.label));
+            }
         }
         if (result.preDispatchable) {
             failForInvalidPredispatchableMethod(parameterTypes);
             parameterTypes.removeLast();
         }
         return parameterTypes;
+    }
+
+    private static boolean isLegacyStructuredOutput(Class<?> structuredOutputType, List<Class<?>> parameterTypes) {
+        return !parameterTypes.isEmpty() && structuredOutputType.equals(parameterTypes.getFirst());
+    }
+
+    /**
+     * Extracts the leading input POJO of a mapped service method (if any) from the parameter list.
+     * <p>
+     * A mapped method binds its request body to a POJO which is passed right after the {@link WebContext}. We detect
+     * such a parameter via the body-only binding rule: after removing the {@link WebContext}, the method declares
+     * exactly one parameter more than the route has path parameters. In that case the leading parameter is the input
+     * POJO. Otherwise (the parameter count matches the path parameters), the method has no request body.
+     * <p>
+     * As this rule is purely count-based, the parameter types are validated to detect miswired signatures at route
+     * compile time: a simple value type (String, number, enum, ...) cannot serve as request body and a POJO cannot
+     * serve as path parameter. Collections and arrays are rejected as request body as well, as the body must always
+     * be a JSON object.
+     */
+    private static void extractMappedInputType(Method method,
+                                               Route result,
+                                               List<Class<?>> parameterTypes,
+                                               int pathParameters) {
+        failForInvalidMappedMethod(method, result);
+        if (parameterTypes.size() == pathParameters + 1) {
+            failForPreDispatchableMappedBody(result);
+            failForSimpleValueBody(result, parameterTypes.getFirst());
+            failForCollectionBody(result, parameterTypes.getFirst());
+            result.inputType = parameterTypes.removeFirst();
+        }
+        failForPojoAsPathParameter(result, parameterTypes);
+    }
+
+    private static void failForCollectionBody(Route result, Class<?> bodyType) {
+        if (bodyType.isArray() || Collection.class.isAssignableFrom(bodyType)) {
+            throw new IllegalArgumentException(Strings.apply(
+                    "Mapped service method '%s' declares '%s' as request body which can never be parsed, as the"
+                    + " request body must be a JSON object. Wrap the elements in a dedicated input object instead",
+                    result.label,
+                    bodyType.getName()));
+        }
+    }
+
+    private static void failForSimpleValueBody(Route result, Class<?> bodyType) {
+        if (isSimpleValueType(bodyType)) {
+            throw new IllegalArgumentException(Strings.apply(
+                    "Mapped service method '%s' would bind '%s' as request body POJO. Either declare a proper POJO"
+                    + " directly after the WebContext parameter, declare a matching path parameter in the route or"
+                    + " use the legacy signature with '%s' as second parameter",
+                    result.label,
+                    bodyType.getName(),
+                    JSONStructuredOutput.class.getName()));
+        }
+    }
+
+    private static void failForPojoAsPathParameter(Route result, List<Class<?>> parameterTypes) {
+        for (Class<?> parameterType : parameterTypes) {
+            if (!isSimpleValueType(parameterType) && !List.class.equals(parameterType)) {
+                throw new IllegalArgumentException(Strings.apply(
+                        "Mapped service method '%s' declares '%s' as path parameter which cannot be bound from a"
+                        + " path element. A request body POJO must be declared directly after the WebContext"
+                        + " parameter and requires exactly one method parameter more than the route has path"
+                        + " parameters",
+                        result.label,
+                        parameterType.getName()));
+            }
+        }
+    }
+
+    @SuppressWarnings("java:S1067")
+    @Explain("The check is not very complex, It is best to handle all cases in one place.")
+    private static boolean isSimpleValueType(Class<?> type) {
+        return type.isPrimitive()
+               || type.isEnum()
+               || String.class.equals(type)
+               || Boolean.class.equals(type)
+               || Character.class.equals(type)
+               || Number.class.isAssignableFrom(type)
+               || Amount.class.equals(type)
+               || TemporalAccessor.class.isAssignableFrom(type);
+    }
+
+    private static void failForPreDispatchableMappedBody(Route result) {
+        if (result.preDispatchable) {
+            throw new IllegalArgumentException(Strings.apply(
+                    "Mapped service method '%s' cannot bind a request body POJO, as the body of a pre-dispatchable"
+                    + " route is streamed into the InputStreamHandler and thus cannot be parsed",
+                    result.label));
+        }
+    }
+
+    private static void failForInvalidMappedMethod(Method method, Route result) {
+        if (void.class.equals(method.getReturnType())) {
+            throw new IllegalArgumentException(Strings.apply(
+                    "Service method '%s' returns void. Either declare '%s' as second parameter to stream the"
+                    + " response (legacy service) or return a result object (or Promise/Future) to have it"
+                    + " serialized as response body (mapped service)",
+                    result.label,
+                    JSONStructuredOutput.class.getName()));
+        }
     }
 
     private static void createMethodHandle(Method method, Route result) {
@@ -230,20 +347,6 @@ public class Route {
         }
     }
 
-    private static void failForInvalidJSONMethod(List<Class<?>> parameterTypes) {
-        if (parameterTypes.isEmpty() || !JSONStructuredOutput.class.equals(parameterTypes.getFirst())) {
-            throw new IllegalArgumentException(Strings.apply("JSON API method needs '%s' as second parameter",
-                                                             JSONStructuredOutput.class.getName()));
-        }
-    }
-
-    private static void failForInvalidXMLMethod(List<Class<?>> parameterTypes) {
-        if (parameterTypes.isEmpty() || !XMLStructuredOutput.class.equals(parameterTypes.getFirst())) {
-            throw new IllegalArgumentException(Strings.apply("XML API method needs '%s' as second parameter",
-                                                             XMLStructuredOutput.class.getName()));
-        }
-    }
-
     private static void failForInvalidPredispatchableMethod(List<Class<?>> parameterTypes) {
         if (parameterTypes.isEmpty() || !InputStreamHandler.class.equals(parameterTypes.getLast())) {
             throw new IllegalArgumentException(Strings.apply("Pre-Dispatchable method needs '%s' as last parameter",
@@ -252,7 +355,7 @@ public class Route {
     }
 
     /*
-     * Compiles a routed URI (which is already split into its path parts.
+     * Compiles a routed URI, which is already split into its path parts.
      * See Route.value() for a description
      */
     private static int compileRouteURI(Route result, String[] elements, StringBuilder finalPattern) {
@@ -404,7 +507,7 @@ public class Route {
     }
 
     /**
-     * Returns the method which is to be invoked if an URI can be successfully routed using this route
+     * Returns the method which is to be invoked if a URI can be successfully routed using this route
      * (all parameters match).
      *
      * @return the method to be invoked in order to route a request using this route
@@ -448,6 +551,26 @@ public class Route {
      */
     public Format getApiResponseFormat() {
         return format;
+    }
+
+    /**
+     * Determines if this route uses the mapped payload mode in which the request body is deserialized into an input
+     * POJO and the returned object is serialized as response (instead of streaming via a
+     * {@link sirius.kernel.xml.StructuredOutput}).
+     *
+     * @return <tt>true</tt> if this route maps its payload to/from POJOs, <tt>false</tt> for the legacy streaming mode
+     */
+    public boolean isMappedPayload() {
+        return mappedPayload;
+    }
+
+    /**
+     * Returns the type into which the request body is deserialized for a {@link #isMappedPayload() mapped} route.
+     *
+     * @return the input POJO type or <tt>null</tt> if the route does not accept a request body
+     */
+    public Class<?> getInputType() {
+        return inputType;
     }
 
     /**

--- a/src/main/java/sirius/web/services/ApiController.java
+++ b/src/main/java/sirius/web/services/ApiController.java
@@ -8,6 +8,9 @@
 
 package sirius.web.services;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.commons.Json;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
@@ -17,6 +20,10 @@ import sirius.web.controller.DefaultRoute;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebContext;
 import sirius.web.security.Permission;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Provides a UI to view all public available APIs.
@@ -72,6 +79,41 @@ public class ApiController extends BasicController {
     @Routed("/system/api/:1")
     @Permission(PERMISSION_SYSTEM_API)
     public void api(WebContext webContext, String apiName) {
+        PublicApiInfo publicApiInfo = findApi(apiName);
+        if (hasPermission(publicApiInfo.getRequiredRoles())) {
+            webContext.respondWith().template("/templates/system/api.html.pasta", publicApiInfo);
+        } else {
+            raiseMissingPermissionError(publicApiInfo.getRequiredRoles());
+        }
+    }
+
+    /**
+     * Generates and downloads an OpenAPI 3.1 document for the given API.
+     *
+     * @param webContext the request to respond to
+     * @param apiName    the name of the API to generate the OpenAPI document for
+     * @throws IOException in case of an IO error while writing the response
+     */
+    @Routed("/system/api/:1/openapi.json")
+    @Permission(PERMISSION_SYSTEM_API)
+    public void apiOpenApiDocument(WebContext webContext, String apiName) throws IOException {
+        PublicApiInfo publicApiInfo = findApi(apiName);
+        if (!hasPermission(publicApiInfo.getRequiredRoles())) {
+            raiseMissingPermissionError(publicApiInfo.getRequiredRoles());
+            return;
+        }
+
+        ObjectNode document = new OpenApiGenerator().generate(publicApiInfo);
+        try (OutputStream outputStream = webContext.respondWith()
+                                                   .download(apiName + "-openapi.json")
+                                                   .notCached()
+                                                   .outputStream(HttpResponseStatus.OK,
+                                                                 "application/json;charset=utf-8")) {
+            outputStream.write(Json.writePretty(document).getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private PublicApiInfo findApi(String apiName) {
         PublicApiInfo publicApiInfo = publicServices.getApis()
                                                     .stream()
                                                     .filter(api -> Strings.areEqual(api.getApiName(), apiName))
@@ -80,11 +122,6 @@ public class ApiController extends BasicController {
         if (publicApiInfo == null) {
             throw Exceptions.createHandled().withSystemErrorMessage("Unknown API: %s", apiName).handle();
         }
-
-        if (hasPermission(publicApiInfo.getRequiredRoles())) {
-            webContext.respondWith().template("/templates/system/api.html.pasta", publicApiInfo);
-        } else {
-            raiseMissingPermissionError(publicApiInfo.getRequiredRoles());
-        }
+        return publicApiInfo;
     }
 }

--- a/src/main/java/sirius/web/services/ApiPayloadCodec.java
+++ b/src/main/java/sirius/web/services/ApiPayloadCodec.java
@@ -1,0 +1,55 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.services;
+
+import sirius.kernel.di.std.AutoRegister;
+import sirius.web.http.WebContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * Handles the (de-)serialization of request and response payloads for {@linkplain sirius.web.controller.Route mapped}
+ * service calls.
+ * <p>
+ * A mapped service method receives its request body deserialized into an input POJO and returns a result object which
+ * is serialized directly (without any {@code success}/{@code error} envelope). Each codec is responsible for exactly
+ * one {@link Format} and is selected by the {@link sirius.web.controller.ControllerDispatcher} based on the format
+ * declared by the route.
+ *
+ * @see JsonApiPayloadCodec
+ */
+@AutoRegister
+public interface ApiPayloadCodec {
+
+    /**
+     * Returns the format which is handled by this codec.
+     *
+     * @return the format which is handled by this codec
+     */
+    Format getFormat();
+
+    /**
+     * Reads the request body and deserializes it into the given input type.
+     *
+     * @param webContext the request providing the body to read
+     * @param inputType  the type into which the body is deserialized
+     * @return the deserialized input object
+     */
+    Object readBody(WebContext webContext, Class<?> inputType);
+
+    /**
+     * Serializes the given result object and sends it as response body.
+     * <p>
+     * The result is written as-is, i.e. without any wrapping envelope.
+     *
+     * @param webContext the request to respond to
+     * @param result     the result object to serialize, may be <tt>null</tt>
+     */
+    void writeResult(WebContext webContext, @Nullable Object result);
+}

--- a/src/main/java/sirius/web/services/JsonApiPayloadCodec.java
+++ b/src/main/java/sirius/web/services/JsonApiPayloadCodec.java
@@ -1,0 +1,80 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.services;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import sirius.kernel.commons.Json;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+import sirius.web.http.MimeHelper;
+import sirius.web.http.WebContext;
+import sirius.web.http.WebServer;
+
+import javax.annotation.Nullable;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Provides the {@link Format#JSON JSON} implementation of an {@link ApiPayloadCodec}.
+ * <p>
+ * The request body is parsed via the central {@link Json#MAPPER Jackson mapper} and the result is serialized directly
+ * into the JSON response body.
+ */
+@Register
+public class JsonApiPayloadCodec implements ApiPayloadCodec {
+
+    @Override
+    public Format getFormat() {
+        return Format.JSON;
+    }
+
+    @Override
+    public Object readBody(WebContext webContext, Class<?> inputType) {
+        try {
+            return Json.MAPPER.treeToValue(webContext.getJSONContent(), inputType);
+        } catch (Exception exception) {
+            throw Exceptions.createHandled()
+                            .to(WebServer.LOG)
+                            .error(exception)
+                            .withSystemErrorMessage("Cannot parse the request body as '%s': %s (%s)",
+                                                    inputType.getName())
+                            .handle();
+        }
+    }
+
+    @Override
+    public void writeResult(WebContext webContext, @Nullable Object result) {
+        // Serialize before opening the response stream - once the stream is opened, the 200 OK status is
+        // committed and a serialization failure could no longer be reported as a proper error response.
+        byte[] json;
+        try {
+            json = Json.MAPPER.writeValueAsBytes(result);
+        } catch (Exception exception) {
+            throw Exceptions.handle()
+                            .to(WebServer.LOG)
+                            .error(exception)
+                            .withSystemErrorMessage("Cannot serialize the result as JSON: %s (%s)")
+                            .handle();
+        }
+
+        try (OutputStream out = webContext.respondWith()
+                                          .outputStream(HttpResponseStatus.OK,
+                                                        MimeHelper.APPLICATION_JSON
+                                                        + ";charset="
+                                                        + StandardCharsets.UTF_8.name())) {
+            out.write(json);
+        } catch (Exception exception) {
+            throw Exceptions.handle()
+                            .to(WebServer.LOG)
+                            .error(exception)
+                            .withSystemErrorMessage("Cannot write the JSON response: %s (%s)")
+                            .handle();
+        }
+    }
+}

--- a/src/main/java/sirius/web/services/OpenApiGenerator.java
+++ b/src/main/java/sirius/web/services/OpenApiGenerator.java
@@ -1,0 +1,699 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import sirius.kernel.commons.Json;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.nls.NLS;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.temporal.Temporal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Generates an <a href="https://spec.openapis.org/oas/v3.1.0">OpenAPI 3.1</a> document for a {@link PublicApiInfo}.
+ * <p>
+ * The document is derived from the same metadata which is used to render the API explorer at <tt>/system/api</tt>:
+ * the {@link PublicService} / {@link sirius.web.controller.Routed} annotations, the {@code http.api} configuration and
+ * the {@link Schema} annotations placed on the request and response POJOs of
+ * {@linkplain sirius.web.controller.Route#isMappedPayload() mapped services}.
+ * <p>
+ * Request and response bodies of mapped services are expanded into fully nested {@code components/schemas} entries,
+ * referencing each other via {@code $ref}. Self-referential types are handled gracefully.
+ * <p>
+ * A generator instance is stateful (it collects the referenced component schemas while building the paths) and must
+ * therefore not be reused across multiple documents. Create a fresh instance per document instead.
+ */
+public class OpenApiGenerator {
+
+    private static final String OPENAPI_VERSION = "3.1.0";
+    private static final String DOCUMENT_VERSION = "1.0.0";
+    private static final String MEDIA_TYPE_JSON = "application/json";
+    private static final String MEDIA_TYPE_XML = "application/xml";
+
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_FORMAT = "format";
+    private static final String FIELD_ITEMS = "items";
+    private static final String FIELD_SCHEMA = "schema";
+    private static final String FIELD_CONTENT = "content";
+    private static final String FIELD_PROPERTIES = "properties";
+    private static final String FIELD_REQUIRED = "required";
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_EXAMPLE = "example";
+    private static final String FIELD_ADDITIONAL_PROPERTIES = "additionalProperties";
+
+    private static final Pattern PATH_PARAMETER_PATTERN = Pattern.compile(":(\\d+)");
+
+    private static final Set<Class<?>> INTEGER_TYPES =
+            Set.of(int.class, Integer.class, long.class, Long.class, short.class, Short.class, byte.class, Byte.class);
+
+    private static final String TYPE_OBJECT = "object";
+    private static final String TYPE_ARRAY = "array";
+    private static final String TYPE_STRING = "string";
+    private static final String TYPE_INTEGER = "integer";
+    private static final String TYPE_NUMBER = "number";
+    private static final String TYPE_BOOLEAN = "boolean";
+
+    private final Map<String, ObjectNode> componentSchemas = new LinkedHashMap<>();
+    private final Map<String, Type> typesBySchemaName = new HashMap<>();
+    private final Map<Type, String> schemaNamesByType = new HashMap<>();
+
+    /**
+     * Generates the OpenAPI document for the given API.
+     *
+     * @param api the API to describe
+     * @return the OpenAPI document as JSON object
+     */
+    public ObjectNode generate(PublicApiInfo api) {
+        ObjectNode document = Json.createObject();
+        document.put("openapi", OPENAPI_VERSION);
+        document.set("info", buildInfo(api));
+
+        // The paths are built first, as this collects the referenced component schemas as a side effect.
+        ObjectNode paths = buildPaths(api);
+        document.set("paths", paths);
+
+        if (!componentSchemas.isEmpty()) {
+            ObjectNode components = Json.createObject();
+            ObjectNode schemas = Json.createObject();
+            componentSchemas.forEach(schemas::set);
+            components.set("schemas", schemas);
+            document.set("components", components);
+        }
+
+        return document;
+    }
+
+    /**
+     * Builds the OpenAPI schema node for the given Java type.
+     * <p>
+     * Complex POJOs are represented as a {@code $ref} pointing into {@link #getComponentSchemas()}, which is populated
+     * as a side effect. This mirrors the schema generation used while building a whole document and is primarily useful
+     * to describe a single request or response type in isolation.
+     *
+     * @param type the type to describe
+     * @return the schema node, either an inline schema or a {@code $ref} to a component schema
+     */
+    public ObjectNode schemaForType(Type type) {
+        return schemaFor(type, new HashMap<>());
+    }
+
+    /**
+     * Returns the component schemas collected while generating a document or resolving individual
+     * {@linkplain #schemaForType(Type) types}.
+     *
+     * @return the collected component schemas keyed by their schema name
+     */
+    public Map<String, ObjectNode> getComponentSchemas() {
+        return Collections.unmodifiableMap(componentSchemas);
+    }
+
+    private ObjectNode buildInfo(PublicApiInfo api) {
+        ObjectNode info = Json.createObject();
+        info.put("title", api.getLabel());
+        info.put("version", DOCUMENT_VERSION);
+        if (Strings.isFilled(api.getDescription())) {
+            info.put(FIELD_DESCRIPTION, api.getDescription());
+        }
+        return info;
+    }
+
+    private ObjectNode buildPaths(PublicApiInfo api) {
+        ObjectNode paths = Json.createObject();
+        for (PublicApiSectionInfo section : api.getSections()) {
+            for (PublicServiceInfo service : section.getServices()) {
+                addService(paths, section, service);
+            }
+        }
+        return paths;
+    }
+
+    private void addService(ObjectNode paths, PublicApiSectionInfo section, PublicServiceInfo service) {
+        String path = determineOpenApiPath(service);
+        ObjectNode pathItem;
+        if (paths.get(path) instanceof ObjectNode existingPathItem) {
+            pathItem = existingPathItem;
+        } else {
+            pathItem = Json.createObject();
+            paths.set(path, pathItem);
+        }
+
+        ObjectNode operation = Json.createObject();
+        operation.put("operationId", buildOperationId(service));
+        if (Strings.isFilled(service.getLabel())) {
+            operation.put("summary", service.getLabel());
+        }
+        if (Strings.isFilled(service.getDescription())) {
+            operation.put(FIELD_DESCRIPTION, service.getDescription());
+        }
+        if (service.isDeprecated()) {
+            operation.put("deprecated", true);
+        }
+        if (Strings.isFilled(section.getLabel())) {
+            operation.set("tags", Json.createArray().add(section.getLabel()));
+        }
+
+        ArrayNode parameters = buildParameters(service);
+        if (!parameters.isEmpty()) {
+            operation.set("parameters", parameters);
+        }
+
+        ObjectNode requestBody = buildRequestBody(service);
+        if (requestBody != null) {
+            operation.set("requestBody", requestBody);
+        }
+
+        operation.set("responses", buildResponses(service));
+
+        pathItem.set(service.getHttpMethod().name().toLowerCase(), operation);
+    }
+
+    private String buildOperationId(PublicServiceInfo service) {
+        return service.getHttpMethod().name().toLowerCase() + determineOpenApiPath(service).replaceAll("[^a-zA-Z0-9]+",
+                                                                                                       "-");
+    }
+
+    private ArrayNode buildParameters(PublicServiceInfo service) {
+        ArrayNode parameters = Json.createArray();
+        service.getPathComponents().forEach(parameter -> parameters.add(mapParameter(parameter, true)));
+        collectImplicitPathParameters(service, parameters);
+        service.getParameters().forEach(parameter -> parameters.add(mapParameter(parameter, false)));
+        return parameters;
+    }
+
+    private String determineOpenApiPath(PublicServiceInfo service) {
+        Matcher matcher = PATH_PARAMETER_PATTERN.matcher(service.getUri());
+        StringBuilder path = new StringBuilder();
+        while (matcher.find()) {
+            String name = pathParameterName(service, matcher.group(1));
+            matcher.appendReplacement(path, Matcher.quoteReplacement("{" + name + "}"));
+        }
+        matcher.appendTail(path);
+        return path.toString();
+    }
+
+    private String pathParameterName(PublicServiceInfo service, String index) {
+        int parameterIndex = Integer.parseInt(index) - 1;
+        return parameterIndex < service.getPathComponents().size() ?
+               service.getPathComponents().get(parameterIndex).name() :
+               "parameter" + index;
+    }
+
+    private void collectImplicitPathParameters(PublicServiceInfo service, ArrayNode parameters) {
+        Matcher matcher = PATH_PARAMETER_PATTERN.matcher(service.getUri());
+        while (matcher.find()) {
+            String name = pathParameterName(service, matcher.group(1));
+            boolean alreadyDocumented =
+                    service.getPathComponents().stream().anyMatch(parameter -> name.equals(parameter.name()));
+            if (!alreadyDocumented) {
+                ObjectNode parameter = Json.createObject();
+                parameter.put("name", name);
+                parameter.put("in", "path");
+                parameter.put(FIELD_REQUIRED, true);
+                ObjectNode schema = Json.createObject();
+                schema.put(FIELD_TYPE, TYPE_STRING);
+                parameter.set(FIELD_SCHEMA, schema);
+                parameters.add(parameter);
+            }
+        }
+    }
+
+    private ObjectNode mapParameter(Parameter parameter, boolean forcePath) {
+        ObjectNode node = Json.createObject();
+        node.put("name", parameter.name());
+        node.put("in", forcePath ? "path" : mapParameterLocation(parameter.in()));
+        node.put(FIELD_REQUIRED, forcePath || parameter.required());
+        if (Strings.isFilled(parameter.description())) {
+            node.put(FIELD_DESCRIPTION, NLS.smartGet(parameter.description()));
+        }
+
+        ObjectNode schema = Json.createObject();
+        Schema parameterSchema = parameter.schema();
+        schema.put(FIELD_TYPE, Strings.isFilled(parameterSchema.type()) ? parameterSchema.type() : TYPE_STRING);
+        if (Strings.isFilled(parameterSchema.format())) {
+            schema.put(FIELD_FORMAT, parameterSchema.format());
+        }
+        node.set(FIELD_SCHEMA, schema);
+
+        if (Strings.isFilled(parameter.example())) {
+            node.set(FIELD_EXAMPLE, typedExample(schema.path(FIELD_TYPE).asText(), parameter.example()));
+        }
+        return node;
+    }
+
+    private String mapParameterLocation(ParameterIn location) {
+        return switch (location) {
+            case PATH -> "path";
+            case HEADER -> "header";
+            case COOKIE -> "cookie";
+            default -> "query";
+        };
+    }
+
+    @Nullable
+    private ObjectNode buildRequestBody(PublicServiceInfo service) {
+        if (!service.getRequestBodies().isEmpty()) {
+            return mapAnnotatedRequestBody(service.getRequestBodies().getFirst());
+        }
+        if (service.getInputType() == null) {
+            return null;
+        }
+
+        ObjectNode requestBody = Json.createObject();
+        requestBody.put(FIELD_REQUIRED, true);
+        ObjectNode content = Json.createObject();
+        ObjectNode mediaType = Json.createObject();
+        mediaType.set(FIELD_SCHEMA, schemaFor(service.getInputType(), new HashMap<>()));
+        content.set(mediaTypeFor(service), mediaType);
+        requestBody.set(FIELD_CONTENT, content);
+        return requestBody;
+    }
+
+    private ObjectNode mapAnnotatedRequestBody(RequestBody annotation) {
+        ObjectNode requestBody = Json.createObject();
+        if (Strings.isFilled(annotation.description())) {
+            requestBody.put(FIELD_DESCRIPTION, NLS.smartGet(annotation.description()));
+        }
+        requestBody.put(FIELD_REQUIRED, annotation.required());
+        ObjectNode content = mapAnnotatedContent(annotation.content());
+        if (content != null) {
+            requestBody.set(FIELD_CONTENT, content);
+        }
+        return requestBody;
+    }
+
+    private ObjectNode buildResponses(PublicServiceInfo service) {
+        ObjectNode responses = Json.createObject();
+        if (!service.getResponses().isEmpty()) {
+            service.getResponses()
+                   .forEach(response -> responses.set(response.responseCode(), mapAnnotatedResponse(response)));
+            return responses;
+        }
+
+        ObjectNode okResponse = Json.createObject();
+        okResponse.put(FIELD_DESCRIPTION, "Successful response");
+        if (service.getOutputType() != null) {
+            ObjectNode content = Json.createObject();
+            ObjectNode mediaType = Json.createObject();
+            mediaType.set(FIELD_SCHEMA, schemaFor(service.getOutputType(), new HashMap<>()));
+            content.set(mediaTypeFor(service), mediaType);
+            okResponse.set(FIELD_CONTENT, content);
+        }
+        responses.set("200", okResponse);
+        return responses;
+    }
+
+    private ObjectNode mapAnnotatedResponse(ApiResponse response) {
+        ObjectNode node = Json.createObject();
+        node.put(FIELD_DESCRIPTION,
+                 Strings.isFilled(response.description()) ? NLS.smartGet(response.description()) : "");
+        ObjectNode content = mapAnnotatedContent(response.content());
+        if (content != null) {
+            node.set(FIELD_CONTENT, content);
+        }
+        return node;
+    }
+
+    @Nullable
+    private ObjectNode mapAnnotatedContent(Content[] contents) {
+        ObjectNode content = Json.createObject();
+        for (Content entry : contents) {
+            if (Strings.isFilled(entry.mediaType())) {
+                ObjectNode mediaType = Json.createObject();
+                ObjectNode schema = mapAnnotatedSchema(entry.schema());
+                if (schema != null) {
+                    mediaType.set(FIELD_SCHEMA, schema);
+                }
+                ObjectNode examples = mapAnnotatedExamples(entry.examples());
+                if (examples != null) {
+                    mediaType.set("examples", examples);
+                }
+                ObjectNode encoding = mapAnnotatedEncoding(entry.encoding());
+                if (encoding != null) {
+                    mediaType.set("encoding", encoding);
+                }
+                content.set(entry.mediaType(), mediaType);
+            }
+        }
+        return content.isEmpty() ? null : content;
+    }
+
+    @Nullable
+    private ObjectNode mapAnnotatedEncoding(Encoding[] encodings) {
+        if (encodings.length == 0) {
+            return null;
+        }
+
+        ObjectNode result = Json.createObject();
+        for (Encoding encoding : encodings) {
+            if (Strings.isEmpty(encoding.name())) {
+                continue;
+            }
+            ObjectNode value = Json.createObject();
+            if (Strings.isFilled(encoding.contentType())) {
+                value.put("contentType", encoding.contentType());
+            }
+            if (Strings.isFilled(encoding.style())) {
+                value.put("style", encoding.style());
+            }
+            if (encoding.explode()) {
+                value.put("explode", true);
+            }
+            if (encoding.allowReserved()) {
+                value.put("allowReserved", true);
+            }
+            ObjectNode headers = mapEncodingHeaders(encoding.headers());
+            if (headers != null) {
+                value.set("headers", headers);
+            }
+            result.set(encoding.name(), value);
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    @Nullable
+    private ObjectNode mapEncodingHeaders(Header[] headers) {
+        if (headers.length == 0) {
+            return null;
+        }
+
+        ObjectNode result = Json.createObject();
+        for (Header header : headers) {
+            if (Strings.isEmpty(header.name())) {
+                continue;
+            }
+            ObjectNode value = Json.createObject();
+            if (Strings.isFilled(header.description())) {
+                value.put(FIELD_DESCRIPTION, NLS.smartGet(header.description()));
+            }
+            ObjectNode schema = mapAnnotatedSchema(header.schema());
+            if (schema != null) {
+                value.set(FIELD_SCHEMA, schema);
+            }
+            result.set(header.name(), value);
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    @Nullable
+    private ObjectNode mapAnnotatedSchema(Schema annotation) {
+        if (Strings.isFilled(annotation.ref())) {
+            ObjectNode schema = Json.createObject();
+            schema.put("$ref", annotation.ref());
+            return schema;
+        }
+        if (annotation.implementation() == Void.class && Strings.isEmpty(annotation.type())) {
+            return null;
+        }
+
+        ObjectNode schema = annotation.implementation() == Void.class ?
+                            Json.createObject() :
+                            schemaFor(annotation.implementation(), new HashMap<>());
+        applySchemaAnnotation(schema, annotation);
+        return schema;
+    }
+
+    @Nullable
+    private ObjectNode mapAnnotatedExamples(ExampleObject[] exampleObjects) {
+        if (exampleObjects.length == 0) {
+            return null;
+        }
+
+        ObjectNode examples = Json.createObject();
+        for (int index = 0; index < exampleObjects.length; index++) {
+            ExampleObject example = exampleObjects[index];
+            String name = Strings.isFilled(example.name()) ? example.name() : FIELD_EXAMPLE + (index + 1);
+            ObjectNode exampleNode = Json.createObject();
+            if (Strings.isFilled(example.summary())) {
+                exampleNode.put("summary", example.summary());
+            }
+            if (Strings.isFilled(example.description())) {
+                exampleNode.put(FIELD_DESCRIPTION, example.description());
+            }
+            if (Strings.isFilled(example.externalValue())) {
+                exampleNode.put("externalValue", example.externalValue());
+            } else if (Strings.isFilled(example.value())) {
+                exampleNode.set("value", parseExampleValue(example.value()));
+            }
+            examples.set(name, exampleNode);
+        }
+        return examples;
+    }
+
+    private JsonNode parseExampleValue(String value) {
+        try {
+            return Json.MAPPER.readTree(value);
+        } catch (Exception _) {
+            return Json.MAPPER.getNodeFactory().textNode(value);
+        }
+    }
+
+    private String mediaTypeFor(PublicServiceInfo service) {
+        return service.determineEffectiveFormat() == Format.XML ? MEDIA_TYPE_XML : MEDIA_TYPE_JSON;
+    }
+
+    /**
+     * Builds the OpenAPI schema for the given type.
+     * <p>
+     * Leaf types (primitives, strings, enums, temporal types, ...) are described inline. Collections and maps are
+     * described as {@code array} respectively {@code object} with typed items. Complex POJOs are registered as a named
+     * {@code components/schemas} entry and referenced via {@code $ref}.
+     */
+    private ObjectNode schemaFor(Type type, Map<TypeVariable<?>, Type> typeVariables) {
+        Type resolvedType = SchemaReflection.resolveType(type, typeVariables);
+        Class<?> rawType = SchemaReflection.determineRawType(resolvedType);
+        if (rawType == null) {
+            return objectSchema();
+        }
+
+        if (rawType.isArray() || Collection.class.isAssignableFrom(rawType)) {
+            ObjectNode schema = Json.createObject();
+            schema.put(FIELD_TYPE, TYPE_ARRAY);
+            schema.set(FIELD_ITEMS,
+                       schemaFor(SchemaReflection.determineCollectionElementType(resolvedType), typeVariables));
+            return schema;
+        }
+        if (Map.class.isAssignableFrom(rawType)) {
+            ObjectNode schema = Json.createObject();
+            schema.put(FIELD_TYPE, TYPE_OBJECT);
+            schema.set(FIELD_ADDITIONAL_PROPERTIES,
+                       schemaFor(SchemaReflection.determineMapValueType(resolvedType), typeVariables));
+            return schema;
+        }
+        if (SchemaReflection.isLeafType(rawType)) {
+            return leafSchema(rawType);
+        }
+
+        String schemaName = registerComponentSchema(resolvedType, rawType, typeVariables);
+        ObjectNode reference = Json.createObject();
+        reference.put("$ref", "#/components/schemas/" + schemaName);
+        return reference;
+    }
+
+    private String registerComponentSchema(Type resolvedType,
+                                           Class<?> rawType,
+                                           Map<TypeVariable<?>, Type> typeVariables) {
+        String schemaName = determineSchemaName(resolvedType, rawType);
+        if (!componentSchemas.containsKey(schemaName)) {
+            buildComponentSchema(schemaName, resolvedType, typeVariables);
+        }
+        return schemaName;
+    }
+
+    private void buildComponentSchema(String schemaName, Type resolvedType, Map<TypeVariable<?>, Type> typeVariables) {
+        // Reserve the entry before recursing into the fields, so self-referential types terminate.
+        ObjectNode schema = Json.createObject();
+        componentSchemas.put(schemaName, schema);
+        typesBySchemaName.put(schemaName, resolvedType);
+        schemaNamesByType.put(resolvedType, schemaName);
+
+        schema.put(FIELD_TYPE, TYPE_OBJECT);
+        ObjectNode properties = Json.createObject();
+        ArrayNode required = Json.createArray();
+        collectProperties(resolvedType, typeVariables, properties, required);
+        if (!properties.isEmpty()) {
+            schema.set(FIELD_PROPERTIES, properties);
+        }
+        if (!required.isEmpty()) {
+            schema.set(FIELD_REQUIRED, required);
+        }
+    }
+
+    private String determineSchemaName(Type resolvedType, Class<?> rawType) {
+        String existingName = schemaNamesByType.get(resolvedType);
+        if (existingName != null) {
+            return existingName;
+        }
+
+        String simpleName = rawType.getSimpleName();
+        if (!(resolvedType instanceof ParameterizedType) && !typesBySchemaName.containsKey(simpleName)) {
+            return simpleName;
+        }
+        return resolvedType.getTypeName().replaceAll("[^A-Za-z0-9]+", "_");
+    }
+
+    private void collectProperties(Type type,
+                                   Map<TypeVariable<?>, Type> typeVariables,
+                                   ObjectNode properties,
+                                   ArrayNode required) {
+        Class<?> rawType = SchemaReflection.determineRawType(type);
+        if (rawType == null || SchemaReflection.isLeafType(rawType)) {
+            return;
+        }
+
+        Map<TypeVariable<?>, Type> nestedTypeVariables =
+                SchemaReflection.resolveTypeVariables(type, rawType, typeVariables);
+
+        collectProperties(rawType.getGenericSuperclass(), nestedTypeVariables, properties, required);
+
+        for (Field field : rawType.getDeclaredFields()) {
+            Schema fieldSchema = field.getAnnotation(Schema.class);
+            if (fieldSchema == null) {
+                continue;
+            }
+            String fieldName = Strings.isFilled(fieldSchema.name()) ? fieldSchema.name() : field.getName();
+            Type fieldType = SchemaReflection.resolveType(field.getGenericType(), nestedTypeVariables);
+            ObjectNode propertySchema = schemaFor(fieldType, nestedTypeVariables);
+            applySchemaAnnotation(propertySchema, fieldSchema);
+            properties.set(fieldName, propertySchema);
+            if (isRequired(fieldSchema)) {
+                required.add(fieldName);
+            }
+        }
+    }
+
+    private void applySchemaAnnotation(ObjectNode schema, Schema annotation) {
+        // OpenAPI 3.1 allows annotation keywords next to a $ref, so descriptions on referenced schemas are kept.
+        if (Strings.isFilled(annotation.type()) && !schema.has("$ref")) {
+            schema.put(FIELD_TYPE, annotation.type());
+        }
+        if (Strings.isFilled(annotation.format()) && !schema.has("$ref")) {
+            schema.put(FIELD_FORMAT, annotation.format());
+        }
+        if (Strings.isFilled(annotation.description())) {
+            schema.put(FIELD_DESCRIPTION, NLS.smartGet(annotation.description()));
+        }
+        if (Strings.isFilled(annotation.example())) {
+            putExample(schema, annotation.example());
+        }
+    }
+
+    private void putExample(ObjectNode schema, String example) {
+        schema.set(FIELD_EXAMPLE, typedExample(schema.path(FIELD_TYPE).asText(), example));
+    }
+
+    private JsonNode typedExample(String type, String example) {
+        return switch (type) {
+            case TYPE_INTEGER -> {
+                try {
+                    yield Json.MAPPER.getNodeFactory().numberNode(Long.parseLong(example));
+                } catch (NumberFormatException _) {
+                    yield Json.MAPPER.getNodeFactory().textNode(example);
+                }
+            }
+            case TYPE_NUMBER -> {
+                try {
+                    yield Json.MAPPER.getNodeFactory().numberNode(Double.parseDouble(example));
+                } catch (NumberFormatException _) {
+                    yield Json.MAPPER.getNodeFactory().textNode(example);
+                }
+            }
+            case TYPE_BOOLEAN -> Json.MAPPER.getNodeFactory().booleanNode(Boolean.parseBoolean(example));
+            default -> Json.MAPPER.getNodeFactory().textNode(example);
+        };
+    }
+
+    private ObjectNode leafSchema(Class<?> rawType) {
+        if (rawType.isEnum()) {
+            return enumSchema(rawType);
+        }
+        if (isIntegerType(rawType)) {
+            return integerSchema(rawType);
+        }
+
+        ObjectNode schema = Json.createObject();
+        if (rawType == boolean.class || rawType == Boolean.class) {
+            schema.put(FIELD_TYPE, TYPE_BOOLEAN);
+            return schema;
+        }
+        if (Number.class.isAssignableFrom(rawType) || rawType.isPrimitive() && rawType != char.class) {
+            schema.put(FIELD_TYPE, TYPE_NUMBER);
+            return schema;
+        }
+        if (Temporal.class.isAssignableFrom(rawType)) {
+            schema.put(FIELD_TYPE, TYPE_STRING);
+            schema.put(FIELD_FORMAT, rawType == LocalDate.class ? "date" : "date-time");
+            return schema;
+        }
+        schema.put(FIELD_TYPE, TYPE_STRING);
+        return schema;
+    }
+
+    private ObjectNode enumSchema(Class<?> rawType) {
+        ObjectNode schema = Json.createObject();
+        schema.put(FIELD_TYPE, TYPE_STRING);
+        ArrayNode enumValues = Json.createArray();
+        for (Object constant : rawType.getEnumConstants()) {
+            enumValues.add(((Enum<?>) constant).name());
+        }
+        schema.set("enum", enumValues);
+        return schema;
+    }
+
+    private ObjectNode integerSchema(Class<?> rawType) {
+        ObjectNode schema = Json.createObject();
+        schema.put(FIELD_TYPE, TYPE_INTEGER);
+        if (rawType == long.class || rawType == Long.class) {
+            schema.put(FIELD_FORMAT, "int64");
+        } else if (rawType == int.class || rawType == Integer.class) {
+            schema.put(FIELD_FORMAT, "int32");
+        }
+        return schema;
+    }
+
+    private boolean isIntegerType(Class<?> rawType) {
+        return INTEGER_TYPES.contains(rawType) || BigInteger.class.isAssignableFrom(rawType);
+    }
+
+    private ObjectNode objectSchema() {
+        ObjectNode schema = Json.createObject();
+        schema.put(FIELD_TYPE, TYPE_OBJECT);
+        return schema;
+    }
+
+    @SuppressWarnings("deprecation")
+    private boolean isRequired(Schema schema) {
+        return schema.requiredMode() == Schema.RequiredMode.REQUIRED || schema.required();
+    }
+}

--- a/src/main/java/sirius/web/services/PublicServiceInfo.java
+++ b/src/main/java/sirius/web/services/PublicServiceInfo.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.kernel.nls.NLS;
@@ -50,19 +51,29 @@ public class PublicServiceInfo {
     private final List<Parameter> serviceParameters = new ArrayList<>();
     private final List<RequestBody> requestBodies = new ArrayList<>();
     private final List<ApiResponse> responses = new ArrayList<>();
+    private final List<SchemaFieldInfo> inputSchema = new ArrayList<>();
+    private final List<SchemaFieldInfo> outputSchema = new ArrayList<>();
+    private final Class<?> inputType;
+    private final java.lang.reflect.Type outputType;
     private final String anchor;
 
     private static final Pattern URI_PARAMETER_PATTERN = Pattern.compile("\\{([^}]*?)}");
 
+    @SuppressWarnings("squid:S00107")
+    @Explain("The service metadata is naturally wide and only assembled internally by PublicServices")
     protected PublicServiceInfo(PublicService info,
                                 Routed routed,
                                 boolean deprecated,
                                 Operation operation,
                                 List<Parameter> serviceParameters,
                                 List<RequestBody> requestBodies,
-                                List<ApiResponse> responses) {
+                                List<ApiResponse> responses,
+                                Class<?> inputType,
+                                java.lang.reflect.Type outputType) {
         this.info = info;
         this.routed = routed;
+        this.inputType = inputType;
+        this.outputType = outputType;
         this.uri = Strings.isFilled(info.path()) ? info.path() : routed.value();
         this.formattedUri = formatUri(this.uri);
         this.deprecated = deprecated;
@@ -93,6 +104,15 @@ public class PublicServiceInfo {
 
         this.requestBodies.addAll(requestBodies);
         this.responses.addAll(responses);
+
+        // Auto-derive the request/response documentation from the input/output POJOs of a mapped service, but only
+        // if no explicit @RequestBody / @ApiResponse annotations have been provided.
+        if (this.requestBodies.isEmpty()) {
+            this.inputSchema.addAll(SchemaFieldInfo.forType(inputType));
+        }
+        if (this.responses.isEmpty()) {
+            this.outputSchema.addAll(SchemaFieldInfo.forType(outputType));
+        }
     }
 
     /**
@@ -194,6 +214,51 @@ public class PublicServiceInfo {
 
     public List<ApiResponse> getResponses() {
         return Collections.unmodifiableList(responses);
+    }
+
+    /**
+     * Returns the auto-derived description of the request body for a mapped service.
+     *
+     * @return the fields of the input POJO or an empty list if the service has no mapped request body
+     */
+    public List<SchemaFieldInfo> getInputSchema() {
+        return Collections.unmodifiableList(inputSchema);
+    }
+
+    /**
+     * Returns the auto-derived description of the response body for a mapped service.
+     *
+     * @return the fields of the output POJO or an empty list if the service has no mapped response body
+     */
+    public List<SchemaFieldInfo> getOutputSchema() {
+        return Collections.unmodifiableList(outputSchema);
+    }
+
+    /**
+     * Returns the Java type of the mapped request body, if any.
+     * <p>
+     * This is the POJO which is bound from the request payload of a
+     * {@linkplain sirius.web.controller.Route#isMappedPayload() mapped service} and is used to generate a machine
+     * readable schema (e.g. OpenAPI).
+     *
+     * @return the input type of a mapped service, or <tt>null</tt> if this service has no mapped request body
+     */
+    @Nullable
+    public Class<?> getInputType() {
+        return inputType;
+    }
+
+    /**
+     * Returns the Java type which is effectively serialized as response of a mapped service.
+     * <p>
+     * For methods returning a {@link sirius.kernel.async.Promise} this is the contained type argument. This is used to
+     * generate a machine readable schema (e.g. OpenAPI).
+     *
+     * @return the output type of a mapped service, or <tt>null</tt> if this service has no mapped response body
+     */
+    @Nullable
+    public java.lang.reflect.Type getOutputType() {
+        return outputType;
     }
 
     public String getLabel() {

--- a/src/main/java/sirius/web/services/PublicServices.java
+++ b/src/main/java/sirius/web/services/PublicServices.java
@@ -18,12 +18,16 @@ import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.async.Promise;
 import sirius.kernel.settings.Extension;
 import sirius.web.controller.ControllerDispatcher;
 import sirius.web.controller.Routed;
+import sirius.web.controller.Route;
 import sirius.web.http.WebServer;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,11 +67,12 @@ public class PublicServices {
 
     private List<PublicApiInfo> discoverPublicServices() {
         List<PublicApiInfo> modifiableApis = new ArrayList<>();
-        controllerDispatcher.getRoutes().forEach(route -> recordPublicService(route.getMethod(), modifiableApis));
+        controllerDispatcher.getRoutes().forEach(route -> recordPublicService(route, modifiableApis));
         return modifiableApis;
     }
 
-    private void recordPublicService(Method route, List<PublicApiInfo> modifiableApis) {
+    private void recordPublicService(Route compiledRoute, List<PublicApiInfo> modifiableApis) {
+        Method route = compiledRoute.getMethod();
         Routed routed = route.getAnnotation(Routed.class);
         if (routed == null) {
             return;
@@ -98,7 +103,9 @@ public class PublicServices {
                                                                                     ApiResponse.class)))
                                                                     .sorted(Comparator.comparingInt(apiResponse -> Integer.parseInt(
                                                                             apiResponse.responseCode())))
-                                                                    .toList());
+                                                                    .toList(),
+                                                              compiledRoute.getInputType(),
+                                                              determineOutputType(compiledRoute));
         PublicApiInfo apiInfo = modifiableApis.stream()
                                               .filter(api -> Strings.areEqual(api.getApiName(),
                                                                               publicService.apiName()))
@@ -111,6 +118,29 @@ public class PublicServices {
                                           .thenComparing(PublicApiInfo::getApiName));
         }
         apiInfo.addService(serviceInfo);
+    }
+
+    /**
+     * Determines the type which is effectively serialized as response of a mapped service.
+     * <p>
+     * For methods which return a {@link Promise} the contained type argument is used, otherwise the plain return type
+     * is used. Legacy (non-mapped) services stream their response via a StructuredOutput, so their return type does
+     * not describe the response and <tt>null</tt> is returned.
+     */
+    private Type determineOutputType(Route compiledRoute) {
+        if (!compiledRoute.isMappedPayload()) {
+            return null;
+        }
+        Method route = compiledRoute.getMethod();
+        Type genericReturnType = route.getGenericReturnType();
+        if (genericReturnType instanceof ParameterizedType parameterizedType
+            && Promise.class.isAssignableFrom(route.getReturnType())) {
+            Type[] typeArguments = parameterizedType.getActualTypeArguments();
+            if (typeArguments.length == 1) {
+                return typeArguments[0];
+            }
+        }
+        return genericReturnType;
     }
 
     private List<Parameter> collectSharedApiParameters(Method route) {

--- a/src/main/java/sirius/web/services/SchemaFieldInfo.java
+++ b/src/main/java/sirius/web/services/SchemaFieldInfo.java
@@ -1,0 +1,208 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.services;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import sirius.kernel.commons.Strings;
+import sirius.kernel.nls.NLS;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Describes a single field of an input or output POJO of a {@linkplain PublicService mapped service}.
+ * <p>
+ * The information is derived from the {@link Schema} annotations placed on the fields of the respective POJO and is
+ * used to automatically document {@linkplain sirius.web.controller.Route#isMappedPayload() mapped} services.
+ *
+ * @see PublicServiceInfo#getInputSchema()
+ * @see PublicServiceInfo#getOutputSchema()
+ */
+public class SchemaFieldInfo {
+
+    private final String name;
+    private final String type;
+    private final boolean required;
+    private final String description;
+    private final String example;
+
+    private SchemaFieldInfo(String name, String type, boolean required, String description, String example) {
+        this.name = name;
+        this.type = type;
+        this.required = required;
+        this.description = description;
+        this.example = example;
+    }
+
+    /**
+     * Introspects the given type and derives a field description for each field which carries a {@link Schema} annotation.
+     * Nested POJOs and collection elements are recursively expanded using dotted field names.
+     *
+     * @param type the type to introspect, may be <tt>null</tt>
+     * @return the list of described fields, possibly empty
+     */
+    public static List<SchemaFieldInfo> forType(@Nullable Type type) {
+        if (type == null) {
+            return List.of();
+        }
+
+        List<SchemaFieldInfo> fields = new ArrayList<>();
+        collectFields(type, "", new HashMap<>(), new HashSet<>(), fields);
+        return fields;
+    }
+
+    private static void collectFields(Type type,
+                                      String prefix,
+                                      Map<TypeVariable<?>, Type> typeVariables,
+                                      Set<Class<?>> typesOnPath,
+                                      List<SchemaFieldInfo> fields) {
+        Type resolvedType = SchemaReflection.resolveType(type, typeVariables);
+        Class<?> rawType = SchemaReflection.determineRawType(resolvedType);
+        if (rawType == null) {
+            return;
+        }
+        if (rawType.isArray() || Collection.class.isAssignableFrom(rawType)) {
+            collectFields(SchemaReflection.determineCollectionElementType(resolvedType),
+                          prefix,
+                          typeVariables,
+                          typesOnPath,
+                          fields);
+            return;
+        }
+        if (Map.class.isAssignableFrom(rawType)) {
+            collectFields(SchemaReflection.determineMapValueType(resolvedType),
+                          prefix,
+                          typeVariables,
+                          typesOnPath,
+                          fields);
+            return;
+        }
+        if (SchemaReflection.isLeafType(rawType)) {
+            return;
+        }
+        if (!typesOnPath.add(rawType)) {
+            return;
+        }
+
+        Map<TypeVariable<?>, Type> nestedTypeVariables =
+                SchemaReflection.resolveTypeVariables(resolvedType, rawType, typeVariables);
+
+        collectFields(rawType.getGenericSuperclass(), prefix, nestedTypeVariables, typesOnPath, fields);
+        for (Field field : rawType.getDeclaredFields()) {
+            Schema schema = field.getAnnotation(Schema.class);
+            if (schema == null) {
+                continue;
+            }
+
+            Type fieldType = SchemaReflection.resolveType(field.getGenericType(), nestedTypeVariables);
+            String fieldName = prefix + (Strings.isFilled(schema.name()) ? schema.name() : field.getName());
+            fields.add(describeField(fieldName, fieldType, schema, nestedTypeVariables));
+            collectNestedFields(fieldType, fieldName, nestedTypeVariables, typesOnPath, fields);
+        }
+        typesOnPath.remove(rawType);
+    }
+
+    private static void collectNestedFields(Type type,
+                                            String fieldName,
+                                            Map<TypeVariable<?>, Type> typeVariables,
+                                            Set<Class<?>> typesOnPath,
+                                            List<SchemaFieldInfo> fields) {
+        Class<?> rawType = SchemaReflection.determineRawType(type);
+        if (rawType == null) {
+            return;
+        }
+        if (rawType.isArray() || Collection.class.isAssignableFrom(rawType)) {
+            collectFields(SchemaReflection.determineCollectionElementType(type),
+                          fieldName + "[].",
+                          typeVariables,
+                          typesOnPath,
+                          fields);
+        } else if (Map.class.isAssignableFrom(rawType)) {
+            collectFields(SchemaReflection.determineMapValueType(type),
+                          fieldName + "[].",
+                          typeVariables,
+                          typesOnPath,
+                          fields);
+        } else if (!SchemaReflection.isLeafType(rawType)) {
+            collectFields(type, fieldName + ".", typeVariables, typesOnPath, fields);
+        }
+    }
+
+    private static SchemaFieldInfo describeField(String fieldName,
+                                                 Type fieldType,
+                                                 Schema schema,
+                                                 Map<TypeVariable<?>, Type> typeVariables) {
+        String typeName = Strings.isFilled(schema.type()) ? schema.type() : determineTypeName(fieldType, typeVariables);
+        return new SchemaFieldInfo(fieldName,
+                                   typeName,
+                                   isRequired(schema),
+                                   NLS.smartGet(schema.description()),
+                                   schema.example());
+    }
+
+    private static String determineTypeName(Type type, Map<TypeVariable<?>, Type> typeVariables) {
+        // Resolve on every recursion level, so type variables nested in type arguments (e.g. the T in List<T>)
+        // are bound as well.
+        Type resolvedType = SchemaReflection.resolveType(type, typeVariables);
+        if (resolvedType instanceof GenericArrayType arrayType) {
+            return determineTypeName(arrayType.getGenericComponentType(), typeVariables) + "[]";
+        }
+        if (resolvedType instanceof ParameterizedType parameterizedType) {
+            String typeArguments = Arrays.stream(parameterizedType.getActualTypeArguments())
+                                         .map(argument -> determineTypeName(argument, typeVariables))
+                                         .collect(Collectors.joining(", "));
+            return determineTypeName(parameterizedType.getRawType(), typeVariables) + "<" + typeArguments + ">";
+        }
+        if (resolvedType instanceof Class<?> clazz) {
+            if (clazz.isArray()) {
+                return determineTypeName(clazz.getComponentType(), typeVariables) + "[]";
+            }
+            return clazz.getSimpleName();
+        }
+        return resolvedType.getTypeName();
+    }
+
+    @SuppressWarnings("deprecation")
+    private static boolean isRequired(Schema schema) {
+        return schema.requiredMode() == Schema.RequiredMode.REQUIRED || schema.required();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getExample() {
+        return example;
+    }
+}

--- a/src/main/java/sirius/web/services/SchemaReflection.java
+++ b/src/main/java/sirius/web/services/SchemaReflection.java
@@ -1,0 +1,151 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.services;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides the reflection helpers used to introspect the request and response POJOs of
+ * {@linkplain sirius.web.controller.Route#isMappedPayload() mapped services}.
+ * <p>
+ * Both the human-readable field listing ({@link SchemaFieldInfo}) and the machine-readable OpenAPI schema
+ * ({@link OpenApiGenerator}) walk the same generic type graph. These helpers resolve type variables, unwrap
+ * collections and maps and decide which types are treated as leaves (and are therefore not expanded any further).
+ */
+public final class SchemaReflection {
+
+    private SchemaReflection() {
+    }
+
+    /**
+     * Resolves type variables and wildcards against the given bindings.
+     *
+     * @param type          the type to resolve
+     * @param typeVariables the known bindings of type variables to actual types
+     * @return the resolved type, or {@link Object} if it cannot be resolved
+     */
+    public static Type resolveType(Type type, Map<TypeVariable<?>, Type> typeVariables) {
+        if (type instanceof TypeVariable<?> typeVariable) {
+            return typeVariables.getOrDefault(typeVariable, Object.class);
+        }
+        if (type instanceof WildcardType wildcardType) {
+            Type[] upperBounds = wildcardType.getUpperBounds();
+            return upperBounds.length == 1 ? resolveType(upperBounds[0], typeVariables) : Object.class;
+        }
+        return type;
+    }
+
+    /**
+     * Resolves the bindings of the type variables declared by the given raw type against its actual type arguments.
+     * <p>
+     * This is used to carry generic information down while walking a type graph, e.g. to resolve the {@code T} in a
+     * {@code Response<T>} to its actual type argument.
+     *
+     * @param type          the (possibly parameterized) type to inspect
+     * @param rawType       the raw class of the given type
+     * @param typeVariables the currently known bindings
+     * @return a new map containing the given bindings plus the ones declared by the given type
+     */
+    public static Map<TypeVariable<?>, Type> resolveTypeVariables(Type type,
+                                                                  Class<?> rawType,
+                                                                  Map<TypeVariable<?>, Type> typeVariables) {
+        Map<TypeVariable<?>, Type> nestedTypeVariables = new HashMap<>(typeVariables);
+        if (type instanceof ParameterizedType parameterizedType) {
+            TypeVariable<?>[] variables = rawType.getTypeParameters();
+            Type[] arguments = parameterizedType.getActualTypeArguments();
+            for (int index = 0; index < Math.min(variables.length, arguments.length); index++) {
+                nestedTypeVariables.put(variables[index], resolveType(arguments[index], typeVariables));
+            }
+        }
+        return nestedTypeVariables;
+    }
+
+    /**
+     * Determines the raw class of the given type.
+     *
+     * @param type the type to inspect
+     * @return the raw class, or <tt>null</tt> if it cannot be determined
+     */
+    @Nullable
+    public static Class<?> determineRawType(Type type) {
+        if (type instanceof Class<?> clazz) {
+            return clazz;
+        }
+        if (type instanceof ParameterizedType parameterizedType
+            && parameterizedType.getRawType() instanceof Class<?> rawType) {
+            return rawType;
+        }
+        if (type instanceof GenericArrayType) {
+            return Object[].class;
+        }
+        return null;
+    }
+
+    /**
+     * Determines the element type of an array or {@link Collection} type.
+     *
+     * @param type the array or collection type
+     * @return the element type, or {@link Object} if it cannot be determined
+     */
+    public static Type determineCollectionElementType(Type type) {
+        if (type instanceof GenericArrayType arrayType) {
+            return arrayType.getGenericComponentType();
+        }
+        Class<?> rawType = determineRawType(type);
+        if (rawType != null && rawType.isArray()) {
+            return rawType.getComponentType();
+        }
+        return determineTypeArgument(type, 0);
+    }
+
+    /**
+     * Determines the value type of a {@link Map} type.
+     *
+     * @param type the map type
+     * @return the value type, or {@link Object} if it cannot be determined
+     */
+    public static Type determineMapValueType(Type type) {
+        return determineTypeArgument(type, 1);
+    }
+
+    private static Type determineTypeArgument(Type type, int index) {
+        if (type instanceof ParameterizedType parameterizedType
+            && parameterizedType.getActualTypeArguments().length > index) {
+            return parameterizedType.getActualTypeArguments()[index];
+        }
+        return Object.class;
+    }
+
+    /**
+     * Determines whether the given type is a leaf which must not be expanded into individual fields.
+     * <p>
+     * Leaves are primitives, enums, numbers, character sequences and all types from the {@code java.} packages.
+     *
+     * @param type the type to check
+     * @return <tt>true</tt> if the type is a leaf, <tt>false</tt> otherwise
+     */
+    public static boolean isLeafType(Class<?> type) {
+        return type.isPrimitive()
+               || type.isEnum()
+               || type.isArray() && isLeafType(type.getComponentType())
+               || Number.class.isAssignableFrom(type)
+               || CharSequence.class.isAssignableFrom(type)
+               || Boolean.class.equals(type)
+               || Character.class.equals(type)
+               || type.getPackageName().startsWith("java.");
+    }
+}

--- a/src/main/resources/default/templates/system/api.html.pasta
+++ b/src/main/resources/default/templates/system/api.html.pasta
@@ -18,6 +18,11 @@
                     <t:dot color="green">Active</t:dot>
                 </i:else>
             </i:if>
+            <i:block name="additionalActions">
+                <t:dropdownItem icon="fa-solid fa-file-arrow-down fa-fw"
+                                label="Download OpenAPI json"
+                                url="@apply('/system/api/%s/openapi.json', api.getApiName())"/>
+            </i:block>
         </t:pageHeader>
     </i:block>
 

--- a/src/main/resources/default/templates/system/api/service-request-bodies.html.pasta
+++ b/src/main/resources/default/templates/system/api/service-request-bodies.html.pasta
@@ -1,5 +1,39 @@
 <i:arg type="sirius.web.services.PublicServiceInfo" name="service"/>
 
+<i:if test="!service.getInputSchema().isEmpty()">
+    <div class="mt-4">
+        <h5>Request Body</h5>
+        <table class="table table-hover" style="table-layout: fixed">
+            <thead>
+            <tr>
+                <th>Field</th>
+                <th>Type</th>
+                <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            <i:for type="sirius.web.services.SchemaFieldInfo" var="field" items="service.getInputSchema()">
+                <tr>
+                    <td>
+                        <code>@field.getName()</code>
+                        <i:if test="field.isRequired()">
+                            <t:fullTag color="red" class="align-text-top ms-1">required</t:fullTag>
+                        </i:if>
+                    </td>
+                    <td><code>@field.getType()</code></td>
+                    <td>
+                        <span><i:raw>@expandMessage(smartTranslate(field.getDescription()))</i:raw></span>
+                        <i:if test="@isFilled(field.getExample())">
+                            <div class="mt-2"><strong>Example:</strong> <code>@field.getExample()</code></div>
+                        </i:if>
+                    </td>
+                </tr>
+            </i:for>
+            </tbody>
+        </table>
+    </div>
+</i:if>
+
 <i:if test="!service.getRequestBodies().isEmpty()">
     <div class="mt-4">
         <h5>Requests</h5>

--- a/src/main/resources/default/templates/system/api/service-responses.html.pasta
+++ b/src/main/resources/default/templates/system/api/service-responses.html.pasta
@@ -1,5 +1,39 @@
 <i:arg type="sirius.web.services.PublicServiceInfo" name="service"/>
 
+<i:if test="!service.getOutputSchema().isEmpty()">
+    <div class="mt-4">
+        <h5>Response Body</h5>
+        <table class="table table-hover" style="table-layout: fixed">
+            <thead>
+            <tr>
+                <th>Field</th>
+                <th>Type</th>
+                <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            <i:for type="sirius.web.services.SchemaFieldInfo" var="field" items="service.getOutputSchema()">
+                <tr>
+                    <td>
+                        <code>@field.getName()</code>
+                        <i:if test="field.isRequired()">
+                            <t:fullTag color="red" class="align-text-top ms-1">required</t:fullTag>
+                        </i:if>
+                    </td>
+                    <td><code>@field.getType()</code></td>
+                    <td>
+                        <span><i:raw>@expandMessage(smartTranslate(field.getDescription()))</i:raw></span>
+                        <i:if test="@isFilled(field.getExample())">
+                            <div class="mt-2"><strong>Example:</strong> <code>@field.getExample()</code></div>
+                        </i:if>
+                    </td>
+                </tr>
+            </i:for>
+            </tbody>
+        </table>
+    </div>
+</i:if>
+
 <i:if test="!service.getResponses().isEmpty()">
     <div class="mt-4">
         <h5>Responses</h5>

--- a/src/test/java/sirius/web/controller/GreetInput.java
+++ b/src/test/java/sirius/web/controller/GreetInput.java
@@ -1,0 +1,30 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Example input POJO for a {@linkplain sirius.web.services.PublicService mapped} service used by the tests.
+ */
+public class GreetInput {
+
+    @Schema(description = "The name of the person to greet",
+            example = "World",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/sirius/web/controller/GreetResult.java
+++ b/src/test/java/sirius/web/controller/GreetResult.java
@@ -1,0 +1,35 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.controller;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Example output POJO for a {@linkplain sirius.web.services.PublicService mapped} service used by the tests.
+ */
+public class GreetResult {
+
+    @Schema(description = "The computed greeting", example = "Hello World")
+    private String greeting;
+
+    public GreetResult() {
+    }
+
+    public GreetResult(String greeting) {
+        this.greeting = greeting;
+    }
+
+    public String getGreeting() {
+        return greeting;
+    }
+
+    public void setGreeting(String greeting) {
+        this.greeting = greeting;
+    }
+}

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -12,11 +12,13 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.CookieHeaderNames;
 import sirius.kernel.async.Future;
+import sirius.kernel.async.Promise;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.Streams;
 import sirius.kernel.commons.Wait;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.web.http.CSRFHelper;
 import sirius.web.http.InputStreamHandler;
@@ -313,6 +315,35 @@ public class TestController extends BasicController {
         });
     }
 
+    @InternalService
+    @Routed(value = "/test/mapped/greet", skipCsrfValidation = true)
+    public GreetResult mappedGreet(WebContext webContext, GreetInput input) {
+        return new GreetResult("Hello " + input.getName());
+    }
+
+    @InternalService
+    @Routed("/test/mapped/echo/:1")
+    public GreetResult mappedEcho(WebContext webContext, String value) {
+        return new GreetResult(value);
+    }
+
+    @InternalService
+    @Routed(value = "/test/mapped/async", skipCsrfValidation = true)
+    public Promise<GreetResult> mappedAsyncGreet(WebContext webContext, GreetInput input) {
+        Promise<GreetResult> promise = new Promise<>();
+        tasks.defaultExecutor().start(() -> {
+            Wait.millis(100);
+            promise.success(new GreetResult("Hello " + input.getName()));
+        });
+        return promise;
+    }
+
+    @InternalService
+    @Routed(value = "/test/mapped/fail", skipCsrfValidation = true)
+    public GreetResult mappedFail(WebContext webContext, GreetInput input) {
+        throw Exceptions.createHandled().withDirectMessage("Intentional failure for " + input.getName()).handle();
+    }
+
     @Routed("/test/session-test")
     public void sessionTest(WebContext webContext) {
         webContext.setSessionValue("test1", "test");
@@ -325,7 +356,9 @@ public class TestController extends BasicController {
     public void sessionTestRead(WebContext webContext) {
         webContext.respondWith()
                   .direct(HttpResponseStatus.OK,
-                          "test1=" + webContext.getSessionValue("test1").asString("<none>") + "&test2="
+                          "test1="
+                          + webContext.getSessionValue("test1").asString("<none>")
+                          + "&test2="
                           + webContext.getSessionValue("test2").asString("<none>"));
     }
 
@@ -349,7 +382,8 @@ public class TestController extends BasicController {
         webContext.respondWith().direct(HttpResponseStatus.OK, "POST OK");
     }
 
-    @Routed(value = "/test/restricted-methods", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
+    @Routed(value = "/test/restricted-methods",
+            methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
             skipCsrfValidation = true)
     public void getAndPostOnlyTest(WebContext webContext) {
         webContext.respondWith().direct(HttpResponseStatus.OK, "GET/POST OK");
@@ -372,9 +406,8 @@ public class TestController extends BasicController {
             preDispatchable = true,
             skipCsrfValidation = true)
     @InternalService
-    public void postOnlyPredispatchTest(WebContext webContext,
-                                        JSONStructuredOutput output,
-                                        InputStreamHandler upload) throws IOException {
+    public void postOnlyPredispatchTest(WebContext webContext, JSONStructuredOutput output, InputStreamHandler upload)
+            throws IOException {
         try (upload) {
             Streams.exhaust(upload);
             output.property("status", "POST OK");
@@ -397,7 +430,8 @@ public class TestController extends BasicController {
         }
     }
 
-    @Routed(value = "/test/restricted-methods-api", methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
+    @Routed(value = "/test/restricted-methods-api",
+            methods = {HttpMethod.GET, HttpMethod.POST, HttpMethod.POST},
             skipCsrfValidation = true)
     @InternalService
     public void getAndPostOnlyTest(WebContext webContext, JSONStructuredOutput output) {

--- a/src/test/kotlin/sirius/web/service/MappedServiceTest.kt
+++ b/src/test/kotlin/sirius/web/service/MappedServiceTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+@file:Suppress("DANGEROUS_CHARACTERS")
+
+package sirius.web.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Json
+import sirius.kernel.commons.Streams
+import sirius.web.controller.GreetInput
+import sirius.web.controller.GreetResult
+import sirius.web.controller.TestController
+import java.net.HttpURLConnection
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the mapped input/output service mechanism (request body deserialized into a POJO, result serialized directly)
+ * as implemented for [GreetInput], [GreetResult] and the matching routes in [TestController].
+ */
+@ExtendWith(SiriusExtension::class)
+class MappedServiceTest {
+
+    private fun call(
+        uri: String,
+        body: String? = null,
+        method: String = if (body == null) "GET" else "POST"
+    ): Triple<Int, String, String?> {
+        val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = method
+        if (body != null) {
+            connection.doOutput = true
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.outputStream.use { it.write(body.toByteArray(StandardCharsets.UTF_8)) }
+        }
+        val status = connection.responseCode
+        val stream = if (status >= 400) connection.errorStream else connection.inputStream
+        val data = String(Streams.toByteArray(stream), StandardCharsets.UTF_8)
+        return Triple(status, data, connection.getHeaderField("content-type"))
+    }
+
+    @Test
+    fun `mapped service deserializes the request body and serializes the result without envelope`() {
+        val (status, data, contentType) = call("/test/mapped/greet", """{"name": "World"}""")
+
+        assertEquals(HttpURLConnection.HTTP_OK, status)
+        assertEquals("application/json;charset=UTF-8", contentType)
+        // The result POJO is serialized directly - there is no success/error envelope.
+        assertEquals("""{"greeting":"Hello World"}""", data)
+        assertFalse(data.contains("success"))
+    }
+
+    @Test
+    fun `mapped service without a request body binds path parameters`() {
+        val (status, data, _) = call("/test/mapped/echo/Hello")
+
+        assertEquals(HttpURLConnection.HTTP_OK, status)
+        assertEquals("Hello", Json.parseObject(data).get("greeting").asText())
+    }
+
+    @Test
+    fun `mapped service supports asynchronous results via a Promise`() {
+        val (status, data, _) = call("/test/mapped/async", """{"name": "Async"}""")
+
+        assertEquals(HttpURLConnection.HTTP_OK, status)
+        assertEquals("Hello Async", Json.parseObject(data).get("greeting").asText())
+    }
+
+    @Test
+    fun `a failing mapped service yields a proper JSON error`() {
+        val (status, data, _) = call("/test/mapped/fail", """{"name": "World"}""")
+
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, status)
+        val json = Json.parseObject(data)
+        assertFalse(json.get("success").asBoolean())
+        assertTrue(json.get("error").asBoolean())
+        assertTrue(json.get("message").asText().contains("World"))
+    }
+
+    @Test
+    fun `legacy streaming services still wrap their result in an envelope`() {
+        val (status, data, _) = call("/test/json?test=Hello_World")
+
+        assertEquals(HttpURLConnection.HTTP_OK, status)
+        // Regression: the legacy StructuredOutput path keeps the success/error envelope.
+        assertEquals("""{"success":true,"error":false,"test":"Hello_World"}""", data)
+    }
+}

--- a/src/test/kotlin/sirius/web/service/OpenApiGeneratorTest.kt
+++ b/src/test/kotlin/sirius/web/service/OpenApiGeneratorTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+@file:Suppress("DANGEROUS_CHARACTERS")
+
+package sirius.web.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.swagger.v3.oas.annotations.media.Schema
+import sirius.web.services.OpenApiGenerator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests the nested schema generation of the [OpenApiGenerator] used to build downloadable OpenAPI documents.
+ */
+class OpenApiGeneratorTest {
+
+    @Test
+    fun `describes complex types as component schemas referenced via ref`() {
+        val generator = OpenApiGenerator()
+
+        val root = generator.schemaForType(SearchResponse::class.java)
+
+        assertEquals("#/components/schemas/SearchResponse", ref(root))
+
+        val schemas = generator.componentSchemas
+        assertEquals(true, schemas.containsKey("SearchResponse"))
+        assertEquals(true, schemas.containsKey("SearchItem"))
+
+        val properties = schemas["SearchResponse"]!!.get("properties")
+        assertEquals("integer", properties.get("totalHits").get("type").asText())
+        assertEquals("boolean", properties.get("hasMore").get("type").asText())
+
+        assertEquals("array", properties.get("items").get("type").asText())
+        assertEquals("#/components/schemas/SearchItem", ref(properties.get("items").get("items")))
+
+        assertEquals("object", properties.get("itemsById").get("type").asText())
+        assertEquals("#/components/schemas/SearchItem", ref(properties.get("itemsById").get("additionalProperties")))
+    }
+
+    @Test
+    fun `maps primitives, enums and required fields`() {
+        val generator = OpenApiGenerator()
+
+        generator.schemaForType(SearchResponse::class.java)
+        val itemSchema = generator.componentSchemas["SearchItem"]!!
+        val itemProperties = itemSchema.get("properties")
+
+        assertEquals("number", itemProperties.get("price").get("type").asText())
+        assertEquals("Item price", itemProperties.get("price").get("description").asText())
+
+        val availability = itemProperties.get("availability")
+        assertEquals("string", availability.get("type").asText())
+        assertEquals(listOf("IN_STOCK", "OUT_OF_STOCK"), availability.get("enum").map { it.asText() })
+
+        assertEquals(listOf("code"), itemSchema.get("required").map { it.asText() })
+    }
+
+    @Test
+    fun `terminates recursion for self-referential types`() {
+        val generator = OpenApiGenerator()
+
+        generator.schemaForType(TreeNode::class.java)
+        val nodeSchema = generator.componentSchemas["TreeNode"]!!
+
+        assertEquals("#/components/schemas/TreeNode", ref(nodeSchema.get("properties").get("children").get("items")))
+    }
+
+    @Test
+    fun `uses distinct component names for generic type arguments`() {
+        val generator = OpenApiGenerator()
+
+        generator.schemaForType(GenericResponses::class.java)
+
+        val schemas = generator.componentSchemas
+        val pages = schemas.filterKeys { it.contains("Page") }
+        assertEquals(3, pages.size)
+        assertEquals(3, pages.values.map { ref(it.get("properties").get("items").get("items")) }.toSet().size)
+    }
+
+    @Test
+    fun `writes numeric Schema examples as JSON numbers`() {
+        val generator = OpenApiGenerator()
+
+        generator.schemaForType(NumericExample::class.java)
+
+        val example = generator.componentSchemas["NumericExample"]!!
+            .get("properties")
+            .get("page")
+            .get("example")
+        assertEquals(true, example.isIntegralNumber)
+        assertEquals(1, example.intValue())
+    }
+
+    private fun ref(node: JsonNode): String = node.get("\$ref").asText()
+
+    @Suppress("unused")
+    private enum class Availability { IN_STOCK, OUT_OF_STOCK }
+
+    @Suppress("unused")
+    private class SearchItem(
+        @field:Schema(description = "Item code", requiredMode = Schema.RequiredMode.REQUIRED)
+        val code: String,
+        @field:Schema(description = "Item price")
+        val price: Double,
+        @field:Schema(description = "Availability")
+        val availability: Availability
+    )
+
+    @Suppress("unused")
+    private class SearchResponse(
+        @field:Schema(description = "Total number of hits")
+        val totalHits: Int,
+        @field:Schema(description = "Whether more results are available")
+        val hasMore: Boolean,
+        @field:Schema(description = "The result items")
+        val items: List<SearchItem>,
+        @field:Schema(description = "The result items by identifier")
+        val itemsById: Map<String, SearchItem>
+    )
+
+    @Suppress("unused")
+    private class TreeNode(
+        @field:Schema(description = "Display name")
+        val name: String,
+        @field:Schema(description = "Child nodes")
+        val children: List<TreeNode>
+    )
+
+    @Suppress("unused")
+    private class GenericResponses(
+        @field:Schema val articles: Page<Article>,
+        @field:Schema val customers: Page<Customer>,
+        @field:Schema val orders: Page<Order>
+    )
+
+    @Suppress("unused")
+    private class Page<T>(
+        @field:Schema val items: List<T>
+    )
+
+    @Suppress("unused")
+    private class Article(@field:Schema val id: String)
+
+    @Suppress("unused")
+    private class Customer(@field:Schema val id: String)
+
+    @Suppress("unused")
+    private class Order(@field:Schema val id: String)
+
+    @Suppress("unused")
+    private class NumericExample(
+        @field:Schema(example = "1") val page: Int
+    )
+}

--- a/src/test/kotlin/sirius/web/service/SchemaFieldInfoTest.kt
+++ b/src/test/kotlin/sirius/web/service/SchemaFieldInfoTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+@file:Suppress("DANGEROUS_CHARACTERS")
+
+package sirius.web.service
+
+import io.swagger.v3.oas.annotations.media.Schema
+import sirius.web.controller.GreetInput
+import sirius.web.controller.GreetResult
+import sirius.web.services.SchemaFieldInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import java.lang.reflect.Type
+
+/**
+ * Tests the introspection of [SchemaFieldInfo] used to auto-document mapped services.
+ */
+class SchemaFieldInfoTest {
+
+    @Test
+    fun `derives required field information from Schema annotations`() {
+        val fields = SchemaFieldInfo.forType(GreetInput::class.java)
+
+        assertEquals(1, fields.size)
+        val name = fields.first()
+        assertEquals("name", name.name)
+        assertEquals("String", name.type)
+        assertTrue(name.isRequired)
+        assertEquals("The name of the person to greet", name.description)
+        assertEquals("World", name.example)
+    }
+
+    @Test
+    fun `treats optional fields as not required`() {
+        val fields = SchemaFieldInfo.forType(GreetResult::class.java)
+
+        assertEquals(1, fields.size)
+        assertEquals("greeting", fields.first().name)
+        assertFalse(fields.first().isRequired)
+    }
+
+    @Test
+    fun `returns an empty list for null or annotation-less types`() {
+        assertTrue(SchemaFieldInfo.forType(null).isEmpty())
+        assertTrue(SchemaFieldInfo.forType(String::class.java).isEmpty())
+    }
+
+    @Test
+    fun `recursively documents annotated nested fields and collection elements`() {
+        val fields = SchemaFieldInfo.forType(NestedResponse::class.java)
+
+        assertEquals(listOf("items", "items[].code", "itemsById", "itemsById[].code", "page"), fields.map { it.name })
+        assertEquals("List<NestedItem>", fields[0].type)
+        assertEquals("String", fields[1].type)
+        assertEquals("Map<String, NestedItem>", fields[2].type)
+    }
+
+    @Test
+    fun `stops recursion for self-referential types`() {
+        val fields = SchemaFieldInfo.forType(RecursiveResponse::class.java)
+
+        assertEquals(listOf("name", "child"), fields.map { it.name })
+    }
+
+    @Test
+    fun `binds type variables declared by a generic superclass`() {
+        val fields = SchemaFieldInfo.forType(TypedListResponse::class.java)
+
+        assertEquals(listOf("items", "items[].code"), fields.map { it.name })
+        assertEquals("List<NestedItem>", fields.first().type)
+    }
+
+    @Test
+    fun `documents elements of top-level collections`() {
+        val fields = SchemaFieldInfo.forType(topLevelItemsType())
+
+        assertEquals(listOf("code"), fields.map { it.name })
+        assertEquals("String", fields.first().type)
+    }
+
+    private fun topLevelItemsType(): Type = TopLevelCollection::class.java.getDeclaredField("items").genericType
+
+    // The fixture properties are only read via reflection by SchemaFieldInfo, hence the unused suppression.
+
+    @Suppress("unused")
+    private class NestedResponse(
+        @field:Schema(description = "Result items")
+        val items: List<NestedItem>,
+        @field:Schema(description = "Result items by identifier")
+        val itemsById: Map<String, NestedItem>,
+        @field:Schema(description = "Current page")
+        val page: Int
+    )
+
+    @Suppress("unused")
+    private class NestedItem(
+        @field:Schema(description = "Item code")
+        val code: String
+    )
+
+    @Suppress("unused")
+    private class RecursiveResponse(
+        @field:Schema(description = "Display name")
+        val name: String,
+        @field:Schema(description = "Child response")
+        val child: RecursiveResponse?
+    )
+
+    private class TopLevelCollection {
+        @Suppress("unused")
+        lateinit var items: List<NestedItem>
+    }
+
+    @Suppress("unused")
+    private open class GenericBaseResponse<T>(
+        @field:Schema(description = "Result items")
+        val items: List<T>
+    )
+
+    private class TypedListResponse(items: List<NestedItem>) : GenericBaseResponse<NestedItem>(items)
+}


### PR DESCRIPTION
### Description

Adds support for **mapped request/response payloads** in JSON services: a `@Routed` service method can now receive the request body as a POJO parameter and return a result object (or `Promise`/`Future`) which is serialized directly into the JSON response — no more manual `JSONStructuredOutput` plumbing:

```java
@InternalService
@Routed("/greet")
public GreetResult greet(WebContext webContext, GreetInput input) {
    return new GreetResult("Hello " + input.getName());
}
```

How it works:

- A JSON route without a leading JSONStructuredOutput parameter is treated as a mapped service. The request body POJO is detected via the body-only binding rule (the method declares exactly one parameter more than the route has path parameters) and is bound right after the WebContext.
- The new ApiPayloadCodec SPI performs the Jackson-based (de-)serialization. The result is serialized before the response is opened, so serialization failures still produce a proper JSON error envelope instead of an empty 200. Async services returning Promise/Future are supported; their serialization errors are routed through handleFailure as well.
- Invalid signatures fail fast at route compile time with explanatory messages: simple value types / collections / arrays as body, POJOs in path parameter positions and body POJOs on pre-dispatchable routes are all rejected on startup instead of failing per request.
- The /system/api explorer auto-documents the input/output POJOs of mapped services (via @Schema field annotations, including nested POJOs, collections and generic superclasses) as request/response body tables — unless explicit @RequestBody/@ApiResponse annotations are present, which take precedence.
- Each public API can now be exported as an OpenAPI 3.1 document via a download action on /system/api (/system/api/:name/openapi.json), deriving paths, parameters and components/schemas (with $refs, self-referential and generic types handled) from the same metadata.

No breaking changes: legacy streaming services (JSONStructuredOutput / XMLStructuredOutput as second parameter) keep working unchanged and keep their manually annotated documentation. XML mapped payloads are rejected at compile time until an XML codec exists.

The PR is organized in 8 self-contained commits (codec → route validation → dispatcher → tests → schema introspection → explorer docs → OpenAPI generator → download endpoint) — reviewing commit by commit is recommended.

Additional Notes

- This PR fixes or works on following ticket(s): SE-15156
- Currently only Json is supported. If required XML can be implemented as a separate codec later. 

Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & best practices
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.