### PR TITLE
Serves the timing API as an InternalService

### DIFF
--- a/src/main/java/sirius/web/health/SystemController.java
+++ b/src/main/java/sirius/web/health/SystemController.java
@@ -34,6 +34,7 @@ import sirius.web.http.WebContext;
 import sirius.web.http.WebServer;
 import sirius.web.security.Permission;
 import sirius.web.services.Format;
+import sirius.web.services.InternalService;
 import sirius.web.services.JSONStructuredOutput;
 import sirius.web.services.PublicService;
 
@@ -359,12 +360,12 @@ public class SystemController extends BasicController {
      * Provides the recorded micro timings as JSON.
      *
      * @param webContext the current request
+     * @param output     the JSON output the timings are written to
      */
     @Routed("/system/timing/api")
     @Permission(PERMISSION_SYSTEM_TIMING)
-    public void timingApi(WebContext webContext) {
-        JSONStructuredOutput output = webContext.respondWith().json();
-        output.beginResult();
+    @InternalService
+    public void timingApi(WebContext webContext, JSONStructuredOutput output) {
         output.beginArray("timings");
         for (Microtiming.Timing timing : Microtiming.getTimings()) {
             output.beginObject("timing");
@@ -375,6 +376,5 @@ public class SystemController extends BasicController {
             output.endObject();
         }
         output.endArray();
-        output.endResult();
     }
 }

--- a/src/main/resources/default/templates/system/timing.html.pasta
+++ b/src/main/resources/default/templates/system/timing.html.pasta
@@ -2,7 +2,11 @@
 <i:arg type="String" name="periodSinceReset"/>
 
 <t:page title="Microtiming">
-
+    <i:block name="head">
+        <script type="text/javascript">
+            @inlineResource("/assets/tycho/scripts/timing.js")
+        </script>
+    </i:block>
     <i:block name="breadcrumbs">
         <li><a href="/system/timing">Microtiming</a></li>
     </i:block>
@@ -78,8 +82,4 @@
     </template>
 
     <div id="timing-container"></div>
-
-    <script type="text/javascript">
-        @inlineResource("/assets/tycho/scripts/timing.js")
-    </script>
 </t:page>


### PR DESCRIPTION
### Description

Follow-up to the review feedback on the already merged microtiming PR
(#1679).

- The `/system/timing/api` route now uses `@InternalService` instead of building the JSON response by hand. This guarantees that the result is framed with a proper begin and end and that errors are serialized into the same JSON envelope, rather than being returned as an HTML error page that the client-side script cannot process.

- Additionally, the inlined timing script is moved into the
`<i:block name="head">` block to follow the established template
convention (see `user-account.html.pasta`).

**No breaking changes.**

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1227](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1227)
- This PR is related to PR: (#1679)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
