### PR TITLE
Removes deprecated Routed#jsonCall mechanism

### DIFF
--- a/src/main/java/sirius/web/ErrorCodeException.java
+++ b/src/main/java/sirius/web/ErrorCodeException.java
@@ -13,7 +13,6 @@ import sirius.kernel.commons.Tuple;
 import sirius.kernel.health.ExceptionHint;
 import sirius.kernel.health.HandledException;
 import sirius.web.controller.Controller;
-import sirius.web.controller.Routed;
 
 import java.io.Serial;
 import java.util.Collections;
@@ -21,7 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Can be thrown in {@link sirius.web.services.StructuredService}s or in JSON calls ({@link Routed#jsonCall()}).
+ * Can be thrown in {@link sirius.web.services.StructuredService}s.
  * <p>
  * Adds an additional "code" property to the JSON result which contains the given code. Also the given message
  * is directly reported without any translation or logging.

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -103,7 +103,7 @@ public class Route {
                                      method.getDeclaringClass().getName(),
                                      method.getName());
 
-        determineAPIFormat(method, routed, result);
+        determineAPIFormat(method, result);
         determineSubScope(method, result);
         createMethodHandle(method, result);
 
@@ -179,16 +179,13 @@ public class Route {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    private static void determineAPIFormat(Method method, Routed routed, Route result) {
+    private static void determineAPIFormat(Method method, Route result) {
         if (method.isAnnotationPresent(PublicService.class)) {
             PublicService publicServiceAnnotation = method.getAnnotation(PublicService.class);
             result.enforceMaintenanceMode = publicServiceAnnotation.enforceMaintenanceMode();
             result.format = publicServiceAnnotation.format();
         } else if (method.isAnnotationPresent(InternalService.class)) {
             result.format = method.getAnnotation(InternalService.class).format();
-        } else if (routed.jsonCall()) {
-            result.format = Format.JSON;
         }
     }
 

--- a/src/main/java/sirius/web/controller/Routed.java
+++ b/src/main/java/sirius/web/controller/Routed.java
@@ -73,32 +73,6 @@ public @interface Routed {
     boolean preDispatchable() default false;
 
     /**
-     * Determines if the annotated method is used to generate a JSON response.
-     * <p>
-     * This can be used to handle AJAX requests directly within a controller. In such simple cases if is often
-     * feasible to keep the logic in one place (controller) instead for creating a {@link
-     * sirius.web.services.StructuredService}.
-     * <p>
-     * A method having <tt>jsonCall</tt> set to <tt>true</tt> has to accept
-     * {@link sirius.web.services.JSONStructuredOutput} as 2nd parameter. This parameter is filled with a
-     * pre-initialized output writer, which has {@link JSONStructuredOutput#beginResult()} and {@link
-     * JSONStructuredOutput#endResult()} automatically called.
-     * <p>
-     * Also the properties <tt>success</tt> and <tt>error</tt> are automatically filled. In case on an exception
-     * within the controller method, a result with <tt>success</tt>, <tt>errro</tt> and <tt>message</tt> is
-     * automatically created.
-     * <p>
-     * <b>Note:</b> If implementing method does fork a new thread and pass the given output along,
-     * the method must return a {@link sirius.kernel.async.Promise} or {@link sirius.kernel.async.Future}
-     * so that the dispatcher knowns when the generated output is complete.
-     * </p>
-     *
-     * @return <tt>true</tt> if the method is used to create a JSON response for an AJAX call, <tt>false</tt> otherwise
-     * @deprecated Use {@link InternalService} or {@link PublicService}
-     */
-    @Deprecated(since = "2021/07/01") boolean jsonCall() default false;
-
-    /**
      * Determines the HTTP methods supported by the route. By default, all methods are supported.
      * <p>
      * Note that OPTIONS is intentionally not part of the default list: it is handled centrally by the

--- a/src/main/java/sirius/web/services/StructuredService.java
+++ b/src/main/java/sirius/web/services/StructuredService.java
@@ -12,7 +12,6 @@ import sirius.kernel.async.CallContext;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.xml.StructuredOutput;
 import sirius.web.controller.Controller;
-import sirius.web.controller.Routed;
 
 /**
  * Provides a service which can be called via the HTTP interface and generate a structured output encoded as JSON or
@@ -22,9 +21,6 @@ import sirius.web.controller.Routed;
  * provided with a name, which also defines the URL of the service.
  * <p>
  * The generated output can be either JSON or XML, which is completely handled by the framework.
- * <p>
- * Note: Simple AJAX calls using JSON can also be realized using the controller framework. See {@link
- * Routed#jsonCall()} for further information.
  *
  * @deprecated the whole StructuredService framework has been deprecated.
  */


### PR DESCRIPTION
### Description

Removes the deprecated `Routed#jsonCall` mechanism entirely. The attribute
in `Routed`, its dispatcher branch in `Route` (including the now unused
`routed` parameter of `determineAPIFormat` and the `@SuppressWarnings`)
and the remaining Javadoc references in `StructuredService` and
`ErrorCodeException` are deleted.

All former callers now use `@InternalService`, so JSON responses have a
single, well-defined entry point.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1226](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1226) 

### Checklist

- [ ] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
