### PR TITLE
Fixes overflowing token labels in token-autocomplete

### DIFF
--- a/src/main/resources/default/assets/tycho/libs/token-autocomplete/token-autocomplete.css
+++ b/src/main/resources/default/assets/tycho/libs/token-autocomplete/token-autocomplete.css
@@ -21,6 +21,7 @@
 
 .token-autocomplete-container .token-autocomplete-tokens {
     flex-grow: 1;
+    min-width: 0;
     display: inline-flex;
     flex-wrap: wrap;
 }
@@ -52,6 +53,7 @@
     pointer-events: none;
     display: flex;
     align-items: center;
+    max-width: 100%;
 }
 
 .token-autocomplete-container.token-autocomplete-readonly .token-autocomplete-token {


### PR DESCRIPTION
### Description
Before:
<img width="566" height="86" alt="image" src="https://github.com/user-attachments/assets/28972c34-058b-45b9-aecb-1e44d740f8a0" />

After:
<img width="266" height="92" alt="image" src="https://github.com/user-attachments/assets/feab304a-c88d-4e83-878c-6f2d696ece26" />

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12626](https://scireum.myjetbrains.com/youtrack/issue/OX-12626)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/13124

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
