### PR TITLE
Add sendPostRequest option to datacard

### DIFF
--- a/src/main/resources/default/taglib/t/datacard.html.pasta
+++ b/src/main/resources/default/taglib/t/datacard.html.pasta
@@ -21,6 +21,8 @@
        name="fullHeight"
        default="true"
        description="Determines if the card will fill the whole column, adding h-100 to the card classes"/>
+<i:arg type="boolean" name="sendPostRequest" default="false"
+       description="Whether to send a POST request (including a CSRF token) instead of a GET request when the card is clicked"/>
 
 <i:pragma name="description">
     Renders a data centric card which has a title an optional subtitle and body contents.
@@ -68,7 +70,15 @@
                     <i:render name="body"/>
 
                     <i:if test="isFilled(link)">
-                        <a href="@link" class="stretched-link"></a>
+                        <i:if test="sendPostRequest">
+                            <form method="post" action="@link" class="d-contents">
+                                <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
+                                <button type="submit" class="stretched-link border-0 bg-transparent p-0"></button>
+                            </form>
+                            <i:else>
+                                <a href="@link" class="stretched-link"></a>
+                            </i:else>
+                        </i:if>
                     </i:if>
                 </div>
 

--- a/src/main/resources/default/taglib/t/datacard.html.pasta
+++ b/src/main/resources/default/taglib/t/datacard.html.pasta
@@ -73,10 +73,10 @@
                         <i:if test="sendPostRequest">
                             <form method="post" action="@link" class="d-contents">
                                 <input name="CSRFToken" value="@part(CSRFHelper.class).getCSRFToken()" type="hidden"/>
-                                <button type="submit" class="stretched-link border-0 bg-transparent p-0"></button>
+                                <button type="submit" class="stretched-link border-0 bg-transparent p-0" aria-label="@title" title="@title"></button>
                             </form>
                             <i:else>
-                                <a href="@link" class="stretched-link"></a>
+                                <a href="@link" class="stretched-link" aria-label="@title" title="@title"></a>
                             </i:else>
                         </i:if>
                     </i:if>


### PR DESCRIPTION
### Description

- Adds optional `sendPostRequest` attribute to `t:datacard` for CSRF-protected POST navigation on card click

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1242](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1242)
- This PR is related to PR: https://github.com/scireum/sirius-biz/pull/2377

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
