### PR TITLE
Sorts timings by key and keeps them on disable

### DIFF
--- a/src/main/java/sirius/web/health/SystemController.java
+++ b/src/main/java/sirius/web/health/SystemController.java
@@ -377,10 +377,10 @@ public class SystemController extends BasicController {
      * @param webContext the current request, expecting an <tt>enable</tt> flag
      * @param output     the JSON output the resulting state is written to
      */
-    @Routed("/system/timing/toggle")
+    @Routed("/system/timing/change")
     @Permission(PERMISSION_SYSTEM_TIMING)
     @InternalService
-    public void timingToggle(WebContext webContext, JSONStructuredOutput output) {
+    public void timingChange(WebContext webContext, JSONStructuredOutput output) {
         Microtiming.setEnabled(webContext.get("enable").asBoolean());
         output.property("enabled", Microtiming.isEnabled());
     }

--- a/src/main/java/sirius/web/health/SystemController.java
+++ b/src/main/java/sirius/web/health/SystemController.java
@@ -29,6 +29,7 @@ import sirius.kernel.health.metrics.MetricState;
 import sirius.kernel.health.metrics.Metrics;
 import sirius.kernel.nls.NLS;
 import sirius.web.controller.BasicController;
+import sirius.web.controller.HttpMethod;
 import sirius.web.controller.Routed;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebServer;
@@ -374,14 +375,15 @@ public class SystemController extends BasicController {
     /**
      * Enables or disables the micro timing without reloading the page.
      *
-     * @param webContext the current request, expecting an <tt>enable</tt> flag
+     * @param webContext the current request
      * @param output     the JSON output the resulting state is written to
+     * @param state      the desired state, either <tt>enable</tt> or <tt>disable</tt>
      */
-    @Routed("/system/timing/change")
+    @Routed(value = "/system/timing/:1", methods = HttpMethod.POST)
     @Permission(PERMISSION_SYSTEM_TIMING)
     @InternalService
-    public void timingChange(WebContext webContext, JSONStructuredOutput output) {
-        Microtiming.setEnabled(webContext.get("enable").asBoolean());
+    public void timingChange(WebContext webContext, JSONStructuredOutput output, String state) {
+        Microtiming.setEnabled("enable".equals(state));
         output.property("enabled", Microtiming.isEnabled());
     }
 }

--- a/src/main/java/sirius/web/health/SystemController.java
+++ b/src/main/java/sirius/web/health/SystemController.java
@@ -340,13 +340,6 @@ public class SystemController extends BasicController {
     @Routed("/system/timing")
     @Permission(PERMISSION_SYSTEM_TIMING)
     public void timing(WebContext webContext) {
-        if (webContext.hasParameter("enable")) {
-            Microtiming.setEnabled(true);
-        }
-        if (webContext.hasParameter("disable")) {
-            Microtiming.setEnabled(false);
-        }
-
         String periodSinceReset =
                 NLS.convertDuration(Duration.ofMillis(System.currentTimeMillis() - Microtiming.getLastReset()),
                                     true,
@@ -376,5 +369,19 @@ public class SystemController extends BasicController {
             output.endObject();
         }
         output.endArray();
+    }
+
+    /**
+     * Enables or disables the micro timing without reloading the page.
+     *
+     * @param webContext the current request, expecting an <tt>enable</tt> flag
+     * @param output     the JSON output the resulting state is written to
+     */
+    @Routed("/system/timing/toggle")
+    @Permission(PERMISSION_SYSTEM_TIMING)
+    @InternalService
+    public void timingToggle(WebContext webContext, JSONStructuredOutput output) {
+        Microtiming.setEnabled(webContext.get("enable").asBoolean());
+        output.property("enabled", Microtiming.isEnabled());
     }
 }

--- a/src/main/resources/default/assets/tycho/scripts/timing.js
+++ b/src/main/resources/default/assets/tycho/scripts/timing.js
@@ -151,7 +151,7 @@ sirius.ready(() => {
     // Enables/disables the micro timing without reloading the page.
     function toggleTiming() {
         const enable = _toggleButton.dataset.enabled !== 'true';
-        sirius.getJSON('/system/timing/toggle', {enable: enable})
+        sirius.getJSON('/system/timing/change', {enable: enable})
             .then((data) => {
                 updateToggleUI(data.enabled);
                 if (data.enabled) {
@@ -166,7 +166,6 @@ sirius.ready(() => {
     // Reflects the new enabled state on the button and the status dot (without touching the table).
     function updateToggleUI(enabled) {
         _toggleButton.dataset.enabled = enabled;
-        // Replace the inner icon so FontAwesome re-renders it (changing only the class would not redraw the SVG).
         _toggleIcon.innerHTML = '<i class="fa-solid ' + (enabled ? 'fa-minus' : 'fa-plus') + '"></i>';
         _toggleLabel.textContent = enabled ? 'Disable' : 'Enable';
         _statusActive.classList.toggle('d-none', !enabled);

--- a/src/main/resources/default/assets/tycho/scripts/timing.js
+++ b/src/main/resources/default/assets/tycho/scripts/timing.js
@@ -12,6 +12,11 @@ sirius.ready(() => {
     const _searchInput = document.getElementById('timing-filter');
     const _searchButton = document.getElementById('timing-search');
     const _reloadButton = document.getElementById('timing-reload');
+    const _toggleButton = document.getElementById('timing-toggle');
+    const _toggleIcon = document.getElementById('timing-toggle-icon');
+    const _toggleLabel = document.getElementById('timing-toggle-label');
+    const _statusActive = document.getElementById('timing-status-active');
+    const _statusInactive = document.getElementById('timing-status-inactive');
 
     let rows = [];
 
@@ -36,7 +41,9 @@ sirius.ready(() => {
                 return entries;
             }
             return [...entries].sort((a, b) => {
-                const comparison = a[state.key] - b[state.key];
+                const valueA = a[state.key];
+                const valueB = b[state.key];
+                const comparison = typeof valueA === 'string' ? valueA.localeCompare(valueB) : valueA - valueB;
                 return state.ascending ? comparison : -comparison;
             });
         },
@@ -100,6 +107,10 @@ sirius.ready(() => {
 
         _container.innerHTML = '';
         groups.forEach((entries, category) => {
+            if (!sorting.state[category]) {
+                sorting.state[category] = {key: 'key', ascending: true};
+            }
+
             const sorted = sorting.apply(category, entries);
 
             const _card = _cardTemplate.content.cloneNode(true);
@@ -130,6 +141,39 @@ sirius.ready(() => {
             });
     }
 
+    // Reload only fetches while collecting; when disabled it would wipe the frozen data, so it does nothing.
+    function reload() {
+        if (_toggleButton.dataset.enabled === 'true') {
+            loadData();
+        }
+    }
+
+    // Enables/disables the micro timing without reloading the page.
+    function toggleTiming() {
+        const enable = _toggleButton.dataset.enabled !== 'true';
+        sirius.getJSON('/system/timing/toggle', {enable: enable})
+            .then((data) => {
+                updateToggleUI(data.enabled);
+                if (data.enabled) {
+                    loadData();
+                }
+            })
+            .catch((error) => {
+                console.error('Could not toggle timing:', error);
+            });
+    }
+
+    // Reflects the new enabled state on the button and the status dot (without touching the table).
+    function updateToggleUI(enabled) {
+        _toggleButton.dataset.enabled = enabled;
+        // Replace the inner icon so FontAwesome re-renders it (changing only the class would not redraw the SVG).
+        _toggleIcon.innerHTML = '<i class="fa-solid ' + (enabled ? 'fa-minus' : 'fa-plus') + '"></i>';
+        _toggleLabel.textContent = enabled ? 'Disable' : 'Enable';
+        _statusActive.classList.toggle('d-none', !enabled);
+        _statusInactive.classList.toggle('d-none', enabled);
+        _reloadButton.classList.toggle('disabled', !enabled);
+    }
+
     // Sorting: clicking or pressing Enter/Space on a sortable column header toggles the sort order for its category.
     function toggleSortFor(_header) {
         sorting.toggle(_header.dataset.category, _header.dataset.sort);
@@ -156,11 +200,12 @@ sirius.ready(() => {
         toggleSortFor(_header);
     });
 
-    // Search is triggered explicitly via the Enter key or the search icon (no live search).
     sirius.addEnterListener(_searchInput, render);
     sirius.addClickOrEnterListener(_searchButton, render);
 
-    sirius.addClickOrEnterListener(_reloadButton, loadData);
+    sirius.addClickOrEnterListener(_reloadButton, reload);
+    _reloadButton.classList.toggle('disabled', _toggleButton.dataset.enabled !== 'true');
+    sirius.addClickOrEnterListener(_toggleButton, toggleTiming);
 
     loadData();
 });

--- a/src/main/resources/default/assets/tycho/scripts/timing.js
+++ b/src/main/resources/default/assets/tycho/scripts/timing.js
@@ -13,6 +13,7 @@ sirius.ready(() => {
     const _searchButton = document.getElementById('timing-search');
     const _reloadButton = document.getElementById('timing-reload');
     const _toggleButton = document.getElementById('timing-toggle');
+    const _csrfToken = document.getElementById('timing-csrf-token');
     const _toggleIcon = document.getElementById('timing-toggle-icon');
     const _toggleLabel = document.getElementById('timing-toggle-label');
     const _statusActive = document.getElementById('timing-status-active');
@@ -151,7 +152,7 @@ sirius.ready(() => {
     // Enables/disables the micro timing without reloading the page.
     function toggleTiming() {
         const enable = _toggleButton.dataset.enabled !== 'true';
-        sirius.getJSON('/system/timing/change', {enable: enable})
+        sirius.postJSON('/system/timing/' + (enable ? 'enable' : 'disable'), {CSRFToken: _csrfToken.value})
             .then((data) => {
                 updateToggleUI(data.enabled);
                 if (data.enabled) {

--- a/src/main/resources/default/templates/system/timing.html.pasta
+++ b/src/main/resources/default/templates/system/timing.html.pasta
@@ -13,13 +13,13 @@
 
     <i:block name="page-header">
         <t:pageHeader title="Microtiming">
-            <i:if test="enabled">
+            <span id="timing-status-active" class="@if(!enabled) { d-none }">
                 <t:dot color="green">Active</t:dot>
                 <t:inlineInfo label="Collecting for">@periodSinceReset</t:inlineInfo>
-                <i:else>
-                    <t:dot color="gray">Inactive</t:dot>
-                </i:else>
-            </i:if>
+            </span>
+            <span id="timing-status-inactive" class="@if(enabled) { d-none }">
+                <t:dot color="gray">Inactive</t:dot>
+            </span>
         </t:pageHeader>
     </i:block>
 
@@ -32,23 +32,20 @@
                                placeholder="@i18n('NLS.searchkey')"/>
                         <span class="input-group-text" id="timing-search" role="button" tabindex="0" aria-label="Search"
                               style="cursor: pointer;">
-                             <i class="fa-solid fa-magnifying-glass"></i>
+                            <i class="fa-solid fa-magnifying-glass"></i>
                         </span>
                     </div>
                 </div>
                 <div class="col flex-grow-0 d-flex justify-content-end text-nowrap">
-                    <i:if test="enabled">
-                        <a href="/system/timing?disable=true" class="btn btn-outline-primary">
-                            <i class="fa-solid fa-minus"></i>
-                            <span class="d-none d-md-inline-block">Disable</span>
-                        </a>
-                        <i:else>
-                            <a href="/system/timing?enable=true" class="btn btn-outline-primary">
-                                <i class="fa-solid fa-plus"></i>
-                                <span class="d-none d-md-inline-block">Enable</span>
-                            </a>
-                        </i:else>
-                    </i:if>
+                    <a href="#" role="button" id="timing-toggle" class="btn btn-outline-primary"
+                       data-enabled="@enabled">
+                        <span id="timing-toggle-icon">
+                            <i class="fa-solid @if(enabled) { fa-minus } @if(!enabled) { fa-plus }"></i>
+                        </span>
+                        <span id="timing-toggle-label" class="d-none d-md-inline-block">
+                            <i:if test="enabled">Disable<i:else>Enable</i:else></i:if>
+                        </span>
+                    </a>
                     <a href="#" role="button" id="timing-reload" class="ms-2 btn btn-outline-secondary" title="Reload">
                         <i class="fa-solid fa-arrows-rotate"></i>
                     </a>
@@ -58,28 +55,30 @@
     </div>
 
     <template id="category-card-template">
-        <div class="card mb-4">
-            <div class="card-body">
-                <h5 class="card-title"></h5>
-                <table class="table table-hover" style="table-layout: fixed;">
-                    <thead>
-                    <tr>
-                        <th>Key</th>
-                        <th class="text-end text-nowrap" style="width: 100px; cursor: pointer;" role="button"
-                            tabindex="0" data-sort="count">
-                            Calls <i class="fa-solid fa-sort text-muted"></i>
-                        </th>
-                        <th class="text-end text-nowrap" style="width: 130px; cursor: pointer;" role="button"
-                            tabindex="0" data-sort="averageMillis">
-                            Ø Duration<i class="fa-solid fa-sort text-muted"></i>
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h5 class="card-title"></h5>
+                    <table class="table table-hover" style="table-layout: fixed;">
+                        <thead>
+                        <tr>
+                            <th style="cursor: pointer;" role="button" tabindex="0" data-sort="key">
+                                Key <i class="fa-solid fa-sort text-muted"></i>
+                            </th>
+                            <th class="text-end text-nowrap" style="width: 100px; cursor: pointer;" role="button"
+                                tabindex="0" data-sort="count">
+                                Calls <i class="fa-solid fa-sort text-muted"></i>
+                            </th>
+                            <th class="text-end text-nowrap" style="width: 130px; cursor: pointer;" role="button"
+                                tabindex="0" data-sort="averageMillis">
+                                Ø Duration<i class="fa-solid fa-sort text-muted"></i>
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
-        </div>
-    </template>
+        </template>
 
-    <div id="timing-container"></div>
+        <div id="timing-container"></div>
 </t:page>

--- a/src/main/resources/default/templates/system/timing.html.pasta
+++ b/src/main/resources/default/templates/system/timing.html.pasta
@@ -49,36 +49,40 @@
                     <a href="#" role="button" id="timing-reload" class="ms-2 btn btn-outline-secondary" title="Reload">
                         <i class="fa-solid fa-arrows-rotate"></i>
                     </a>
+                    <input type="hidden"
+                           id="timing-csrf-token"
+                           name="CSRFToken"
+                           value="@part(sirius.web.http.CSRFHelper.class).getCSRFToken()"/>
                 </div>
             </div>
         </div>
     </div>
 
     <template id="category-card-template">
-            <div class="card mb-4">
-                <div class="card-body">
-                    <h5 class="card-title"></h5>
-                    <table class="table table-hover" style="table-layout: fixed;">
-                        <thead>
-                        <tr>
-                            <th style="cursor: pointer;" role="button" tabindex="0" data-sort="key">
-                                Key <i class="fa-solid fa-sort text-muted"></i>
-                            </th>
-                            <th class="text-end text-nowrap" style="width: 100px; cursor: pointer;" role="button"
-                                tabindex="0" data-sort="count">
-                                Calls <i class="fa-solid fa-sort text-muted"></i>
-                            </th>
-                            <th class="text-end text-nowrap" style="width: 130px; cursor: pointer;" role="button"
-                                tabindex="0" data-sort="averageMillis">
-                                Ø Duration<i class="fa-solid fa-sort text-muted"></i>
-                            </th>
-                        </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title"></h5>
+                <table class="table table-hover" style="table-layout: fixed;">
+                    <thead>
+                    <tr>
+                        <th style="cursor: pointer;" role="button" tabindex="0" data-sort="key">
+                            Key <i class="fa-solid fa-sort text-muted"></i>
+                        </th>
+                        <th class="text-end text-nowrap" style="width: 100px; cursor: pointer;" role="button"
+                            tabindex="0" data-sort="count">
+                            Calls <i class="fa-solid fa-sort text-muted"></i>
+                        </th>
+                        <th class="text-end text-nowrap" style="width: 130px; cursor: pointer;" role="button"
+                            tabindex="0" data-sort="averageMillis">
+                            Ø Duration<i class="fa-solid fa-sort text-muted"></i>
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
             </div>
-        </template>
+        </div>
+    </template>
 
-        <div id="timing-container"></div>
+    <div id="timing-container"></div>
 </t:page>


### PR DESCRIPTION
### Description

Improves the /system/timing page (usability from the verify feedback):

- Sorting: the tables now default to an alphabetical sort by key, and
  the "Key" column is sortable ascending/descending (in addition to
  "Calls" and "Ø Duration"). Sorting works client-side on the JSON data.
- Disable keeps the data: Enable/Disable now toggle micro timing via a
  new `/system/timing/toggle` AJAX endpoint instead of reloading the
  page. The currently displayed timings stay visible on Disable;
  Enable fetches fresh data.
- Reload is a no-op (and greyed out) while disabled, so it cannot wipe
  the frozen view.

Removed the now-redundant `?enable`/`?disable` handling in
SystemController#timing, since `/toggle` is the single toggle path now.

No breaking changes for users. Dev note: the URLs
`/system/timing?enable=true` / `?disable=true` no longer toggle.

**View**
<img width="1912" height="621" alt="image" src="https://github.com/user-attachments/assets/173cca98-24c7-4041-bbac-b79374467520" />

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1227](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1227)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1679

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
