### PR TITLE
Make CORS `Access-Control-Allow-Origin` resolution extensible via `Interceptor`

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -31,7 +31,7 @@ import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.xml.StructuredOutput;
 import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginHelper;
+import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.http.CSRFHelper;
 import sirius.web.http.Firewall;
 import sirius.web.http.InputStreamHandler;
@@ -107,7 +107,7 @@ public class ControllerDispatcher implements WebDispatcher {
     private CSRFHelper csrfHelper;
 
     @Part
-    private CorsAllowOriginHelper corsOriginHelper;
+    private CorsAllowOriginResolver corsOriginResolver;
 
     @Part
     @Nullable
@@ -307,14 +307,14 @@ public class ControllerDispatcher implements WebDispatcher {
      * <p>
      * The stored origin can then be used in order to set the {@code Access-Control-Allow-Origin} header in the
      * response in the relevant places by using
-     * {@link CorsAllowOriginHelper#applyResolvedOriginHeader(Response)}.
+     * {@link CorsAllowOriginResolver#applyResolvedOriginHeader(Response)}.
      * </p>
      *
      * <p>
      * <b>Note:</b> The strategy is only resolved and stored when {@code webContext.isCorsEnabled()} is set for the
      * request's scope - in that case the interceptors decide based on the routes matching the URI (falling back to a
      * {@link AllowedOrigin.MatchRequest} reflecting the request's origin if none does). If it is not set,
-     * {@link CorsAllowOriginHelper#tryResolveAndStoreOrigin(WebContext, java.util.function.Supplier)} stores nothing
+     * {@link CorsAllowOriginResolver#tryResolveAndStoreOrigin(WebContext, java.util.function.Supplier)} stores nothing
      * (and does not even consult the interceptors), so no CORS headers are emitted.
      * </p>
      *
@@ -322,7 +322,7 @@ public class ControllerDispatcher implements WebDispatcher {
      * @param uri        the effective request URI
      */
     private void determineAndStoreAllowedOriginForUri(WebContext webContext, String uri) {
-        corsOriginHelper.tryResolveAndStoreOrigin(webContext, () -> {
+        corsOriginResolver.tryResolveAndStoreOrigin(webContext, () -> {
             Collection<Route> routes = collectMatchingRoutes(webContext, uri);
             return determineAllowedOriginForRoutes(webContext, routes);
         });
@@ -445,7 +445,7 @@ public class ControllerDispatcher implements WebDispatcher {
             response.setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, allowedMethods)
                     .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS,
                                requestedHeaders == null ? "" : requestedHeaders);
-            corsOriginHelper.applyResolvedOriginHeader(response);
+            corsOriginResolver.applyResolvedOriginHeader(response);
         }
 
         response.status(HttpResponseStatus.OK);

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -237,7 +237,14 @@ public class ControllerDispatcher implements WebDispatcher {
         // preferred allowed origin and store it in the WebContext.
         // It may then be used in the different relevant places: In this class in order to answer preflight requests
         // and OPTIONS requests, as well as the Response class to attach it to all remaining responses.
-        determineAndStoreAllowedOriginForUri(webContext, uri);
+        //
+        // The preferred origin is only attempted to resolve if the request is a preflight request or an `Origin` header
+        // has been sent by the client.
+        // No such header means the browser won't verify CORS for the given request, so we can omit the extra steps and
+        // iterations to resolve it.
+        if (isCorsPreflightRequest(webContext) || Strings.isFilled(webContext.getHeader(HttpHeaderNames.ORIGIN))) {
+            determineAndStoreAllowedOriginForUri(webContext, uri);
+        }
 
         // A genuine CORS preflight request must always be answered centrally with a method list derived from the
         // routes registered for this path. It must never reach any business logic - not even a controller which
@@ -300,47 +307,48 @@ public class ControllerDispatcher implements WebDispatcher {
      * <p>
      * The stored origin can then be used in order to set the {@code Access-Control-Allow-Origin} header in the
      * response in the relevant places by using
-     * {@link CorsAllowOriginHelper#applyHeaderFromWebContext(WebContext, Response)}.
+     * {@link CorsAllowOriginHelper#applyResolvedOriginHeader(Response)}.
      * </p>
      *
      * <p>
-     * <b>Note:</b> If {@code WebContext.isCorsAllowAll()} is set, a {@link AllowedOrigin.MatchRequest} is used.
-     * Otherwise, the interceptors decide based on the routes matching the URI.
+     * <b>Note:</b> The strategy is only resolved and stored when {@code webContext.isCorsAllowAll()} is set for the
+     * request's scope - in that case the interceptors decide based on the routes matching the URI (falling back to a
+     * {@link AllowedOrigin.MatchRequest} reflecting the request's origin if none does). If it is not set,
+     * {@link CorsAllowOriginHelper#tryResolveAndStoreOrigin(WebContext, java.util.function.Supplier)} stores nothing
+     * (and does not even consult the interceptors), so no CORS headers are emitted.
      * </p>
      *
      * @param webContext the current request
      * @param uri        the effective request URI
      */
     private void determineAndStoreAllowedOriginForUri(WebContext webContext, String uri) {
-        Collection<Route> routes = collectMatchingRoutes(webContext, uri);
-
-        Optional<AllowedOrigin> origin = WebContext.isCorsAllowAll() ?
-                                         Optional.of(new AllowedOrigin.MatchRequest()) :
-                                         determineAllowedOriginForRoutes(webContext, routes);
-
-        origin.ifPresentOrElse(actual -> corsOriginHelper.tryResolveOriginAndStoreInWebContext(webContext, actual),
-                               () -> LOG.WARN("CORS: No allowed origin could be determined for '%s'!", uri, routes));
+        corsOriginHelper.tryResolveAndStoreOrigin(webContext, () -> {
+            Collection<Route> routes = collectMatchingRoutes(webContext, uri);
+            return determineAllowedOriginForRoutes(webContext, routes);
+        });
     }
 
     /**
      * Asks the interceptors to determine the {@link AllowedOrigin} for the given routes.
      * <p>
      * The first interceptor returning a non-empty result via
-     * {@link Interceptor#determineAllowedCorsOrigin(WebContext, Collection)} wins.
+     * {@link Interceptor#determineAllowedCorsOrigin(WebContext, Collection)} wins. If no interceptor makes a decision,
+     * a {@link AllowedOrigin.MatchRequest} is used as fallback, reflecting the origin of the current request.
      * </p>
      *
      * @param webContext the current request
      * @param routes     the routes matching the requested URI
-     * @return the preferred CORS allowed origin, or an empty optional if none could be determined
+     * @return the CORS allowed origin as decided by the first interceptor making a decision, or a
+     * {@link AllowedOrigin.MatchRequest} if none does
      */
-    private Optional<AllowedOrigin> determineAllowedOriginForRoutes(WebContext webContext, Collection<Route> routes) {
+    private AllowedOrigin determineAllowedOriginForRoutes(WebContext webContext, Collection<Route> routes) {
         for (var interceptor : interceptors) {
             Optional<AllowedOrigin> origin = interceptor.determineAllowedCorsOrigin(webContext, routes);
             if (origin.isPresent()) {
-                return origin;
+                return origin.get();
             }
         }
-        return Optional.empty();
+        return new AllowedOrigin.MatchRequest();
     }
 
     /**
@@ -351,9 +359,7 @@ public class ControllerDispatcher implements WebDispatcher {
      * @return the routes matching the URI
      */
     private Collection<Route> collectMatchingRoutes(WebContext webContext, String uri) {
-        return getRoutes().stream()
-                          .filter(route -> route.matches(webContext, uri, route.isPreDispatchable()) != Route.NO_MATCH)
-                          .collect(Collectors.toSet());
+        return getRoutes().stream().filter(route -> route.matchesUri(uri)).collect(Collectors.toSet());
     }
 
     /**
@@ -439,7 +445,7 @@ public class ControllerDispatcher implements WebDispatcher {
             response.setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, allowedMethods)
                     .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS,
                                requestedHeaders == null ? "" : requestedHeaders);
-            corsOriginHelper.applyHeaderFromWebContext(webContext, response);
+            corsOriginHelper.applyResolvedOriginHeader(response);
         }
 
         response.status(HttpResponseStatus.OK);

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -311,7 +311,7 @@ public class ControllerDispatcher implements WebDispatcher {
      * </p>
      *
      * <p>
-     * <b>Note:</b> The strategy is only resolved and stored when {@code webContext.isCorsAllowAll()} is set for the
+     * <b>Note:</b> The strategy is only resolved and stored when {@code webContext.isCorsEnabled()} is set for the
      * request's scope - in that case the interceptors decide based on the routes matching the URI (falling back to a
      * {@link AllowedOrigin.MatchRequest} reflecting the request's origin if none does). If it is not set,
      * {@link CorsAllowOriginHelper#tryResolveAndStoreOrigin(WebContext, java.util.function.Supplier)} stores nothing

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -30,6 +30,8 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
 import sirius.kernel.xml.StructuredOutput;
+import sirius.web.cors.AllowedOrigin;
+import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.http.CSRFHelper;
 import sirius.web.http.Firewall;
 import sirius.web.http.InputStreamHandler;
@@ -103,6 +105,9 @@ public class ControllerDispatcher implements WebDispatcher {
 
     @Part
     private CSRFHelper csrfHelper;
+
+    @Part
+    private CorsAllowOriginHelper corsOriginHelper;
 
     @Part
     @Nullable
@@ -228,6 +233,12 @@ public class ControllerDispatcher implements WebDispatcher {
     public DispatchDecision dispatch(WebContext webContext) throws Exception {
         String uri = determineEffectiveURI(webContext);
 
+        // In order to be able to send a CORS `Access-Control-Allow-Origin` header, we determine the
+        // preferred allowed origin and store it in the WebContext.
+        // It may then be used in the different relevant places: In this class in order to answer preflight requests
+        // and OPTIONS requests, as well as the Response class to attach it to all remaining responses.
+        determineAndStoreAllowedOriginForUri(webContext, uri);
+
         // A genuine CORS preflight request must always be answered centrally with a method list derived from the
         // routes registered for this path. It must never reach any business logic - not even a controller which
         // explicitly handles OPTIONS - so we intercept it before matching the routes below.
@@ -280,6 +291,69 @@ public class ControllerDispatcher implements WebDispatcher {
         }
 
         return DispatchDecision.CONTINUE;
+    }
+
+    /**
+     * Determines the {@link AllowedOrigin} for the given URI and stores the resolved CORS origin in the request's
+     * {@link WebContext}.
+     *
+     * <p>
+     * The stored origin can then be used in order to set the {@code Access-Control-Allow-Origin} header in the
+     * response in the relevant places by using
+     * {@link CorsAllowOriginHelper#applyHeaderFromWebContext(WebContext, Response)}.
+     * </p>
+     *
+     * <p>
+     * <b>Note:</b> If {@code WebContext.isCorsAllowAll()} is set, a {@link AllowedOrigin.MatchRequest} is used.
+     * Otherwise, the interceptors decide based on the routes matching the URI.
+     * </p>
+     *
+     * @param webContext the current request
+     * @param uri        the effective request URI
+     */
+    private void determineAndStoreAllowedOriginForUri(WebContext webContext, String uri) {
+        Collection<Route> routes = collectMatchingRoutes(webContext, uri);
+
+        Optional<AllowedOrigin> origin = WebContext.isCorsAllowAll() ?
+                                         Optional.of(new AllowedOrigin.MatchRequest()) :
+                                         determineAllowedOriginForRoutes(webContext, routes);
+
+        origin.ifPresentOrElse(actual -> corsOriginHelper.tryResolveOriginAndStoreInWebContext(webContext, actual),
+                               () -> LOG.WARN("CORS: No allowed origin could be determined for '%s'!", uri, routes));
+    }
+
+    /**
+     * Asks the interceptors to determine the {@link AllowedOrigin} for the given routes.
+     * <p>
+     * The first interceptor returning a non-empty result via
+     * {@link Interceptor#determineAllowedCorsOrigin(WebContext, Collection)} wins.
+     * </p>
+     *
+     * @param webContext the current request
+     * @param routes     the routes matching the requested URI
+     * @return the preferred CORS allowed origin, or an empty optional if none could be determined
+     */
+    private Optional<AllowedOrigin> determineAllowedOriginForRoutes(WebContext webContext, Collection<Route> routes) {
+        for (var interceptor : interceptors) {
+            Optional<AllowedOrigin> origin = interceptor.determineAllowedCorsOrigin(webContext, routes);
+            if (origin.isPresent()) {
+                return origin;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Collects all routes matching the given URI, regardless of their HTTP method.
+     *
+     * @param webContext the current request
+     * @param uri        the effective request URI
+     * @return the routes matching the URI
+     */
+    private Collection<Route> collectMatchingRoutes(WebContext webContext, String uri) {
+        return getRoutes().stream()
+                          .filter(route -> route.matches(webContext, uri, route.isPreDispatchable()) != Route.NO_MATCH)
+                          .collect(Collectors.toSet());
     }
 
     /**
@@ -365,6 +439,7 @@ public class ControllerDispatcher implements WebDispatcher {
             response.setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, allowedMethods)
                     .setHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS,
                                requestedHeaders == null ? "" : requestedHeaders);
+            corsOriginHelper.applyHeaderFromWebContext(webContext, response);
         }
 
         response.status(HttpResponseStatus.OK);

--- a/src/main/java/sirius/web/controller/Interceptor.java
+++ b/src/main/java/sirius/web/controller/Interceptor.java
@@ -114,8 +114,8 @@ public interface Interceptor extends Priorized {
      * </p>
      *
      * <p>
-     * Please note that {@code corsAllowAll} acts as a master switch: this method is only consulted when
-     * {@link WebContext#isCorsAllowAll()} returns {@code true} for the request's scope. If CORS handling is disabled,
+     * Please note that {@code enableCors} acts as a master switch: this method is only consulted when
+     * {@link WebContext#isCorsEnabled()} returns {@code true} for the request's scope. If CORS handling is disabled,
      * no origin is resolved at all and this method is not invoked.
      * </p>
      *

--- a/src/main/java/sirius/web/controller/Interceptor.java
+++ b/src/main/java/sirius/web/controller/Interceptor.java
@@ -108,20 +108,23 @@ public interface Interceptor extends Priorized {
      * </p>
      *
      * <p>
-     * By <b>default</b>, this method returns an {@link AllowedOrigin.MatchRequest} which will resolve to the origin of
-     * the current request.
+     * By <b>default</b>, this method returns an empty optional, signalling that this interceptor does not make a
+     * decision. If no interceptor decides on a strategy, the {@link ControllerDispatcher} falls back to an
+     * {@link AllowedOrigin.MatchRequest}, which resolves to the origin of the current request.
      * </p>
      *
      * <p>
-     * Please note that the {@link ControllerDispatcher} will ignore this choice if {@link WebContext#isCorsAllowAll()}
-     * returns {@code true}!
+     * Please note that {@code corsAllowAll} acts as a master switch: this method is only consulted when
+     * {@link WebContext#isCorsAllowAll()} returns {@code true} for the request's scope. If CORS handling is disabled,
+     * no origin is resolved at all and this method is not invoked.
      * </p>
      *
      * @param webContext the current request
      * @param routes     the routes matching the uri that has been called
-     * @return the preferred CORS allowed origin strategy
+     * @return the preferred CORS allowed origin strategy, or an empty optional if this interceptor does not make a
+     * decision
      */
     default Optional<AllowedOrigin> determineAllowedCorsOrigin(WebContext webContext, Collection<Route> routes) {
-        return Optional.of(new AllowedOrigin.MatchRequest());
+        return Optional.empty();
     }
 }

--- a/src/main/java/sirius/web/controller/Interceptor.java
+++ b/src/main/java/sirius/web/controller/Interceptor.java
@@ -9,7 +9,11 @@
 package sirius.web.controller;
 
 import sirius.kernel.di.std.Priorized;
+import sirius.web.cors.AllowedOrigin;
 import sirius.web.http.WebContext;
+
+import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Can be used to intercept calls to controllers ({@link Controller})
@@ -83,4 +87,41 @@ public interface Interceptor extends Priorized {
      * @return <tt>true</tt> if the route should be executed, <tt>false</tt> otherwise
      */
     boolean shouldExecuteRoute(WebContext webContext, Route route);
+
+    /**
+     * Tries to determine which CORS origins should be allowed for the given collection of {@link Route}s.
+     *
+     * <p>
+     * In order to determine the correct allowed origin for a given endpoint, this method is invoked with the current
+     * WebContext and the collection of routes matching the called URI.
+     * The interceptor may then inspect the routes and answer in one of two different ways:
+     * <ol>
+     *     <li>By returning the preferred origin</li>
+     *     <li>By returning an empty optional to signal it is not able to make a decision.</li>
+     * </ol>
+     * </p>
+     *
+     * <p>
+     * Instead of returning the raw origin directly, the choice is represented in form of a subclass of the sealed
+     * {@link AllowedOrigin} interface. The caller must then handle it accordingly, e.g. by resolving to the concrete
+     * origin.
+     * </p>
+     *
+     * <p>
+     * By <b>default</b>, this method returns an {@link AllowedOrigin.MatchRequest} which will resolve to the origin of
+     * the current request.
+     * </p>
+     *
+     * <p>
+     * Please note that the {@link ControllerDispatcher} will ignore this choice if {@link WebContext#isCorsAllowAll()}
+     * returns {@code true}!
+     * </p>
+     *
+     * @param webContext the current request
+     * @param routes     the routes matching the uri that has been called
+     * @return the preferred CORS allowed origin strategy
+     */
+    default Optional<AllowedOrigin> determineAllowedCorsOrigin(WebContext webContext, Collection<Route> routes) {
+        return Optional.of(new AllowedOrigin.MatchRequest());
+    }
 }

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -412,6 +412,25 @@ public class Route {
     }
 
     /**
+     * Determines if this route matches the current request based on the request URI but <b>does not have any
+     * side effects</b>.
+     * <p>
+     * This method is used to determine if a route matches a given URI without extracting any parameters or setting any
+     * attributes in the {@link WebContext}. It is useful for scenarios where you want to check if a route exists for a
+     * given URI without actually invoking it or modifying the context.
+     * Use {@link #matches(WebContext, String, boolean)} if you want to extract parameters and set attributes in the
+     * context.
+     * </p>
+     *
+     * @param requestedUri the requested URI
+     * @return {@code true} if the Route's pattern matches the given URI, {@code false} otherwise
+     */
+    protected boolean matchesUri(String requestedUri) {
+        Matcher matcher = pattern.matcher(requestedUri);
+        return matcher.matches();
+    }
+
+    /**
      * Determines if this route matches the HTTP method of the current request.
      * <p>
      * Note that this method is not included in {@link #matches(WebContext, String, boolean)} as we want to distinguish

--- a/src/main/java/sirius/web/cors/AllowedOrigin.java
+++ b/src/main/java/sirius/web/cors/AllowedOrigin.java
@@ -1,0 +1,56 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.cors;
+
+import sirius.web.controller.Interceptor;
+import sirius.web.http.WebContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Defines the different types of allowed origins an {@code Access-Control-Allow-Origin} HTTP header may hold.
+ * <p>
+ * Subclasses of this interface are returned by
+ * {@link Interceptor#determineAllowedCorsOrigin(WebContext, Collection)} to define the allowed origins for a
+ * given route.
+ * </p>
+ */
+public sealed interface AllowedOrigin
+        permits AllowedOrigin.MatchRequest, AllowedOrigin.Specific, AllowedOrigin.Wildcard {
+
+    /**
+     * The {@code Access-Control-Allow-Origin} header should be set to the origin of the request.
+     */
+    record MatchRequest() implements AllowedOrigin {
+    }
+
+    /**
+     * The {@code Access-Control-Allow-Origin} header should be set to the origin of the request
+     * <b>if it is in the provided collection of allowed origins</b>.
+     * <p>
+     * If it is not, the server should respond accordingly: e.g. by <i>not</i> setting the header at all, resulting in
+     * a client-side CORS error.
+     * </p>
+     *
+     * @param origins the allowed origins
+     */
+    record Specific(Collection<String> origins) implements AllowedOrigin {
+        public Specific(String... origins) {
+            this(Arrays.stream(origins).collect(Collectors.toSet()));
+        }
+    }
+
+    /**
+     * The {@code Access-Control-Allow-Origin} header should be set to allow all origins (wildcard).
+     */
+    record Wildcard() implements AllowedOrigin {
+    }
+}

--- a/src/main/java/sirius/web/cors/AllowedOrigin.java
+++ b/src/main/java/sirius/web/cors/AllowedOrigin.java
@@ -28,28 +28,45 @@ public sealed interface AllowedOrigin
 
     /**
      * The {@code Access-Control-Allow-Origin} header should be set to the origin of the request.
+     * <p>
+     * Note that for security reasons the {@code Access-Control-Allow-Credentials} header will <b>not be set</b>  in
+     * this case. Reflecting the request's {@code Origin} while allowing credentials behaves essentially like a wildcard
+     * with allowed credentials - which is forbidden and opens an attack vector for cross-site data theft.
+     * </p>
      */
     record MatchRequest() implements AllowedOrigin {
     }
 
     /**
      * The {@code Access-Control-Allow-Origin} header should be set to the origin of the request
-     * <b>if it is in the provided collection of allowed origins</b>.
+     * if it is in the provided collection of allowed origins.
      * <p>
      * If it is not, the server should respond accordingly: e.g. by <i>not</i> setting the header at all, resulting in
      * a client-side CORS error.
      * </p>
+     * <p>
+     * Note that the {@code Access-Control-Allow-Credentials: true} header will be sent {@code true} if
+     * {@code allowCredentials} is set to {@code true}.
+     * By default, a value of {@code false} should be preferred, unless the specified origins explicitly need to send
+     * cookies.
+     * </p>
      *
-     * @param origins the allowed origins
+     * @param allowCredentials if set to {@code true}, the {@code Access-Control-Allow-Credentials} header will be set
+     *                         to {@code true}
+     * @param origins          the allowed origins
      */
-    record Specific(Collection<String> origins) implements AllowedOrigin {
-        public Specific(String... origins) {
-            this(Arrays.stream(origins).collect(Collectors.toSet()));
+    record Specific(boolean allowCredentials, Collection<String> origins) implements AllowedOrigin {
+        public Specific(boolean allowCredentials, String... origins) {
+            this(allowCredentials, Arrays.stream(origins).collect(Collectors.toSet()));
         }
     }
 
     /**
      * The {@code Access-Control-Allow-Origin} header should be set to allow all origins (wildcard).
+     * <p>
+     * Note that the {@code Access-Control-Allow-Credentials} header will <b>not be set</b>  in this case for security
+     * reasons (the combination if wildcard and allowed credentials is explicitly forbidden by the CORS standard).
+     * </p>
      */
     record Wildcard() implements AllowedOrigin {
     }

--- a/src/main/java/sirius/web/cors/CorsAllowOriginHelper.java
+++ b/src/main/java/sirius/web/cors/CorsAllowOriginHelper.java
@@ -35,9 +35,9 @@ public class CorsAllowOriginHelper {
      * Stores the given strategy in the request's {@link CorsContext} and, if it resolves to a concrete origin for the
      * current request, stores that resolved origin as well.
      * <p>
-     * If automatic CORS handling is disabled for the request's scope (i.e. {@link WebContext#isCorsAllowAll()} returns
+     * If automatic CORS handling is disabled for the request's scope (i.e. {@link WebContext#isCorsEnabled()} returns
      * {@code false}), this method does nothing: neither the strategy nor a resolved origin is stored, so no CORS
-     * headers are emitted for the request. {@code corsAllowAll} therefore acts as a master switch for the whole CORS
+     * headers are emitted for the request. {@code enableCors} therefore acts as a master switch for the whole CORS
      * handling.
      * </p>
      * <p>
@@ -48,7 +48,7 @@ public class CorsAllowOriginHelper {
      * </p>
      * <p>
      * <b>Note on performance:</b> The supplier is only invoked when CORS handling is enabled, so an expensive
-     * strategy computation (e.g. consulting interceptors) is deferred and skipped entirely when {@code corsAllowAll}
+     * strategy computation (e.g. consulting interceptors) is deferred and skipped entirely when {@code enableCors}
      * is disabled. Statically known strategies may be passed directly via the overloaded variant of this method.
      * </p>
      *
@@ -56,8 +56,8 @@ public class CorsAllowOriginHelper {
      * @param allowedOriginSupplier  supplies the allowed origin strategy to resolve and store
      */
     public void tryResolveAndStoreOrigin(WebContext webContext, Supplier<AllowedOrigin> allowedOriginSupplier) {
-        // If `corsAllowAll` is disabled, we explicitly do not want to handle anything CORS.
-        if (!webContext.isCorsAllowAll()) {
+        // If `enableCors` is disabled, we explicitly do not want to handle anything CORS.
+        if (!webContext.isCorsEnabled()) {
             return;
         }
 
@@ -73,7 +73,7 @@ public class CorsAllowOriginHelper {
      * <p>
      * <b>Note on performance:</b> The origin is only considered when CORS handling is enabled, so an expensive
      * strategy computation (e.g. consulting interceptors) should be deferred via
-     * {@link #tryResolveAndStoreOrigin(WebContext, Supplier)} so it can be skipped entirely when {@code corsAllowAll}
+     * {@link #tryResolveAndStoreOrigin(WebContext, Supplier)} so it can be skipped entirely when {@code enableCors}
      * is disabled!
      * </p>
      *

--- a/src/main/java/sirius/web/cors/CorsAllowOriginHelper.java
+++ b/src/main/java/sirius/web/cors/CorsAllowOriginHelper.java
@@ -14,91 +14,143 @@ import sirius.kernel.di.std.Register;
 import sirius.web.http.Response;
 import sirius.web.http.WebContext;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 /**
  * Resolves the effective {@code Access-Control-Allow-Origin} for a request and applies it to the response.
  * <p>
  * An {@link AllowedOrigin} (as determined by the {@link sirius.web.controller.Interceptor interceptors}) describes the
  * <i>strategy</i> for the header. This helper turns that strategy into a concrete origin for the current request,
- * stores it in the {@link WebContext}, and later writes it to the response as the actual CORS header.
+ * stores it in the request scoped {@link CorsContext}, and later writes it to the response as the actual CORS header.
  * </p>
  */
 @Register(classes = CorsAllowOriginHelper.class)
 public class CorsAllowOriginHelper {
 
-    private static final String ATTRIBUTE_CORS_ORIGIN = "sirius_corsAllowOrigin";
-
     /**
-     * Resolves the concrete origin for the given strategy and, if one is applicable, stores it in the request.
+     * Stores the given strategy in the request's {@link CorsContext} and, if it resolves to a concrete origin for the
+     * current request, stores that resolved origin as well.
      * <p>
-     * If the strategy resolves to no origin (e.g. an {@link AllowedOrigin.Specific} whose collection does not contain
-     * the request's origin), nothing is stored and no CORS header will be emitted.
+     * If automatic CORS handling is disabled for the request's scope (i.e. {@link WebContext#isCorsAllowAll()} returns
+     * {@code false}), this method does nothing: neither the strategy nor a resolved origin is stored, so no CORS
+     * headers are emitted for the request. {@code corsAllowAll} therefore acts as a master switch for the whole CORS
+     * handling.
+     * </p>
+     * <p>
+     * Otherwise the strategy is recorded (so that e.g. the {@code Vary} header can be derived later), while the concrete
+     * origin is only stored if the strategy resolves to one. If the strategy resolves to no origin (e.g. an
+     * {@link AllowedOrigin.Specific} whose collection does not contain the request's origin), no resolved origin is
+     * stored and no {@code Access-Control-Allow-Origin} header will be emitted.
+     * </p>
+     * <p>
+     * <b>Note on performance:</b> The supplier is only invoked when CORS handling is enabled, so an expensive
+     * strategy computation (e.g. consulting interceptors) is deferred and skipped entirely when {@code corsAllowAll}
+     * is disabled. Statically known strategies may be passed directly via the overloaded variant of this method.
      * </p>
      *
-     * @param webContext the current request
-     * @param origin     the allowed origin strategy to resolve
+     * @param webContext             the current request
+     * @param allowedOriginSupplier  supplies the allowed origin strategy to resolve and store
      */
-    public void tryResolveOriginAndStoreInWebContext(WebContext webContext, AllowedOrigin origin) {
-        tryResolveOrigin(webContext, origin).ifPresent(resolvedOrigin -> {
-            storeOriginInWebContext(webContext, resolvedOrigin);
-        });
+    public void tryResolveAndStoreOrigin(WebContext webContext, Supplier<AllowedOrigin> allowedOriginSupplier) {
+        // If `corsAllowAll` is disabled, we explicitly do not want to handle anything CORS.
+        if (!webContext.isCorsAllowAll()) {
+            return;
+        }
+
+        var corsContext = CorsContext.get();
+        var origin = allowedOriginSupplier.get();
+
+        corsContext.setConfiguredOrigin(origin);
+        tryResolveOrigin(webContext, origin).ifPresent(corsContext::setResolvedOrigin);
     }
 
     /**
-     * Applies the previously resolved CORS origin to the given {@link Response} as an
+     * Convenience overload of {@link #tryResolveAndStoreOrigin(WebContext, Supplier)} for a statically known strategy.
+     * <p>
+     * <b>Note on performance:</b> The origin is only considered when CORS handling is enabled, so an expensive
+     * strategy computation (e.g. consulting interceptors) should be deferred via
+     * {@link #tryResolveAndStoreOrigin(WebContext, Supplier)} so it can be skipped entirely when {@code corsAllowAll}
+     * is disabled!
+     * </p>
+     *
+     * @param webContext            the current request
+     * @param origin     the allowed origin strategy to resolve and store
+     */
+    public void tryResolveAndStoreOrigin(WebContext webContext, AllowedOrigin origin) {
+        tryResolveAndStoreOrigin(webContext, () -> origin);
+    }
+
+    /**
+     * Returns the strategy configured for the current request via {@link #tryResolveAndStoreOrigin(WebContext,
+     * AllowedOrigin)}, if any.
+     *
+     * @return the configured {@link AllowedOrigin} strategy, or an empty optional if none has been stored for the
+     * current request
+     */
+    public Optional<AllowedOrigin> getConfiguredOrigin() {
+        return CorsContext.get().getConfiguredOrigin();
+    }
+
+    /**
+     * Applies the origin resolved for the current request to the given {@link Response} as an
      * {@code Access-Control-Allow-Origin} header.
      * <p>
-     * If no origin has been resolved and stored for the current request, no header is set.
+     * If no origin has been resolved for the current request, no header is set.
      * </p>
      *
-     * @param webContext the current request
-     * @param response   the response to set the header on
+     * @param response the response to set the header on
+     * @return {@code true} if a resolved origin was applied, {@code false} if none had been resolved for the request
      */
-    public void applyHeaderFromWebContext(WebContext webContext, Response response) {
-        applyHeaderFromWebContext(webContext, response::setHeader);
+    public boolean applyResolvedOriginHeader(Response response) {
+        return applyResolvedOriginHeader(response::setHeader);
     }
 
     /**
-     * Applies the previously resolved CORS origin to the given {@link HttpResponse} as an
+     * Applies the origin resolved for the current request to the given {@link HttpResponse} as an
      * {@code Access-Control-Allow-Origin} header.
      * <p>
-     * If no origin has been resolved and stored for the current request, no header is set.
+     * If no origin has been resolved for the current request, no header is set.
      * </p>
      *
-     * @param webContext the current request
-     * @param response   the response to set the header on
+     * @param response the response to set the header on
+     * @return {@code true} if a resolved origin was applied, {@code false} if none had been resolved for the request
      */
-    public void applyHeaderFromWebContext(WebContext webContext, HttpResponse response) {
-        applyHeaderFromWebContext(webContext, response.headers()::set);
+    public boolean applyResolvedOriginHeader(HttpResponse response) {
+        return applyResolvedOriginHeader(response.headers()::set);
     }
 
-    private void applyHeaderFromWebContext(WebContext webContext, BiFunction<CharSequence, CharSequence, ?> setHeader) {
-        getOriginFromWebContext(webContext).ifPresent(origin -> {
+    private boolean applyResolvedOriginHeader(BiFunction<CharSequence, CharSequence, ?> setHeader) {
+        Optional<String> resolvedOrigin = CorsContext.get().getResolvedOrigin();
+        resolvedOrigin.ifPresent(origin -> {
             setHeader.apply(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         });
+        return resolvedOrigin.isPresent();
     }
 
     private Optional<String> tryResolveOrigin(WebContext webContext, AllowedOrigin origin) {
-        String requestOrigin = webContext.getHeader(HttpHeaderNames.ORIGIN);
+        @Nullable String requestOrigin = webContext.getHeader(HttpHeaderNames.ORIGIN);
+
         return switch (origin) {
+            // Using `Optional.ofNullable()` implicitly handles cases where no `Origin` header is available (e.g.
+            // due to the browser not sending it for same-origin requests). Returning an empty optional results in no
+            // header being set, which is the expected behavior in such a case.
             case AllowedOrigin.MatchRequest _ -> Optional.ofNullable(requestOrigin);
             case AllowedOrigin.Specific specific -> resolveMultipleAllowedOrigins(specific.origins(), requestOrigin);
             case AllowedOrigin.Wildcard _ -> Optional.of("*");
         };
     }
 
-    private Optional<String> resolveMultipleAllowedOrigins(Collection<String> origins, String requestOrigin) {
+    private Optional<String> resolveMultipleAllowedOrigins(Collection<String> origins, @Nullable String requestOrigin) {
+        if (requestOrigin == null) {
+            return Optional.empty();
+        }
+
+        // If the request origin is not in the list of allowed origins, we return an empty Optional in order to
+        // reject the request (an empty optional results in no header being set).
         return origins.contains(requestOrigin) ? Optional.of(requestOrigin) : Optional.empty();
-    }
-
-    private void storeOriginInWebContext(WebContext webContext, String origin) {
-        webContext.setAttribute(ATTRIBUTE_CORS_ORIGIN, origin);
-    }
-
-    private Optional<String> getOriginFromWebContext(WebContext webContext) {
-        return webContext.safeGet(ATTRIBUTE_CORS_ORIGIN).asOptionalString();
     }
 }

--- a/src/main/java/sirius/web/cors/CorsAllowOriginHelper.java
+++ b/src/main/java/sirius/web/cors/CorsAllowOriginHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.cors;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponse;
+import sirius.kernel.di.std.Register;
+import sirius.web.http.Response;
+import sirius.web.http.WebContext;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Resolves the effective {@code Access-Control-Allow-Origin} for a request and applies it to the response.
+ * <p>
+ * An {@link AllowedOrigin} (as determined by the {@link sirius.web.controller.Interceptor interceptors}) describes the
+ * <i>strategy</i> for the header. This helper turns that strategy into a concrete origin for the current request,
+ * stores it in the {@link WebContext}, and later writes it to the response as the actual CORS header.
+ * </p>
+ */
+@Register(classes = CorsAllowOriginHelper.class)
+public class CorsAllowOriginHelper {
+
+    private static final String ATTRIBUTE_CORS_ORIGIN = "sirius_corsAllowOrigin";
+
+    /**
+     * Resolves the concrete origin for the given strategy and, if one is applicable, stores it in the request.
+     * <p>
+     * If the strategy resolves to no origin (e.g. an {@link AllowedOrigin.Specific} whose collection does not contain
+     * the request's origin), nothing is stored and no CORS header will be emitted.
+     * </p>
+     *
+     * @param webContext the current request
+     * @param origin     the allowed origin strategy to resolve
+     */
+    public void tryResolveOriginAndStoreInWebContext(WebContext webContext, AllowedOrigin origin) {
+        tryResolveOrigin(webContext, origin).ifPresent(resolvedOrigin -> {
+            storeOriginInWebContext(webContext, resolvedOrigin);
+        });
+    }
+
+    /**
+     * Applies the previously resolved CORS origin to the given {@link Response} as an
+     * {@code Access-Control-Allow-Origin} header.
+     * <p>
+     * If no origin has been resolved and stored for the current request, no header is set.
+     * </p>
+     *
+     * @param webContext the current request
+     * @param response   the response to set the header on
+     */
+    public void applyHeaderFromWebContext(WebContext webContext, Response response) {
+        applyHeaderFromWebContext(webContext, response::setHeader);
+    }
+
+    /**
+     * Applies the previously resolved CORS origin to the given {@link HttpResponse} as an
+     * {@code Access-Control-Allow-Origin} header.
+     * <p>
+     * If no origin has been resolved and stored for the current request, no header is set.
+     * </p>
+     *
+     * @param webContext the current request
+     * @param response   the response to set the header on
+     */
+    public void applyHeaderFromWebContext(WebContext webContext, HttpResponse response) {
+        applyHeaderFromWebContext(webContext, response.headers()::set);
+    }
+
+    private void applyHeaderFromWebContext(WebContext webContext, BiFunction<CharSequence, CharSequence, ?> setHeader) {
+        getOriginFromWebContext(webContext).ifPresent(origin -> {
+            setHeader.apply(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+        });
+    }
+
+    private Optional<String> tryResolveOrigin(WebContext webContext, AllowedOrigin origin) {
+        String requestOrigin = webContext.getHeader(HttpHeaderNames.ORIGIN);
+        return switch (origin) {
+            case AllowedOrigin.MatchRequest _ -> Optional.ofNullable(requestOrigin);
+            case AllowedOrigin.Specific specific -> resolveMultipleAllowedOrigins(specific.origins(), requestOrigin);
+            case AllowedOrigin.Wildcard _ -> Optional.of("*");
+        };
+    }
+
+    private Optional<String> resolveMultipleAllowedOrigins(Collection<String> origins, String requestOrigin) {
+        return origins.contains(requestOrigin) ? Optional.of(requestOrigin) : Optional.empty();
+    }
+
+    private void storeOriginInWebContext(WebContext webContext, String origin) {
+        webContext.setAttribute(ATTRIBUTE_CORS_ORIGIN, origin);
+    }
+
+    private Optional<String> getOriginFromWebContext(WebContext webContext) {
+        return webContext.safeGet(ATTRIBUTE_CORS_ORIGIN).asOptionalString();
+    }
+}

--- a/src/main/java/sirius/web/cors/CorsAllowOriginResolver.java
+++ b/src/main/java/sirius/web/cors/CorsAllowOriginResolver.java
@@ -27,6 +27,12 @@ import java.util.function.Supplier;
  * <i>strategy</i> for the header. This helper turns that strategy into a concrete origin for the current request,
  * stores it in the request scoped {@link CorsContext}, and later writes it to the response as the actual CORS header.
  * </p>
+ * <p>
+ * As a single request may pass through several dispatchers, each of which may attempt to resolve an origin, an
+ * origin may only be resolved once per request: the first successful call to
+ * {@link #tryResolveAndStoreOrigin(WebContext, Supplier)} wins and every subsequent call for the same request is
+ * silently ignored. This prevents a later dispatcher from weakening or overriding a decision that was already made.
+ * </p>
  */
 @Register(classes = CorsAllowOriginResolver.class)
 public class CorsAllowOriginResolver {
@@ -47,6 +53,12 @@ public class CorsAllowOriginResolver {
      * stored and no {@code Access-Control-Allow-Origin} header will be emitted.
      * </p>
      * <p>
+     * <b>Note on repeated invocation:</b> An origin may only be resolved once per request. If the {@link CorsContext}
+     * has already been {@linkplain CorsContext#isFinalized() finalized} - i.e. a previous call to this method already
+     * resolved an origin - this method does nothing, regardless of what the given {@code allowedOriginSupplier} would
+     * resolve to. This ensures that the first dispatcher/interceptor to resolve an origin wins.
+     * </p>
+     * <p>
      * <b>Note on performance:</b> The supplier is only invoked when CORS handling is enabled, so an expensive
      * strategy computation (e.g. consulting interceptors) is deferred and skipped entirely when {@code enableCors}
      * is disabled. Statically known strategies may be passed directly via the overloaded variant of this method.
@@ -62,10 +74,19 @@ public class CorsAllowOriginResolver {
         }
 
         var corsContext = CorsContext.get();
+
+        // If another part of the code has already determined an origin, we do not want to override it.
+        // This is important for cases where multiple dispatchers/interceptors have been executed and the first one
+        // should win. This way, it is impossible for the origin to be weakened by a later invocation.
+        if (corsContext.isFinalized()) {
+            return;
+        }
+
         var origin = allowedOriginSupplier.get();
 
         corsContext.setConfiguredOrigin(origin);
         tryResolveOrigin(webContext, origin).ifPresent(corsContext::setResolvedOrigin);
+        corsContext.markFinalized();
     }
 
     /**

--- a/src/main/java/sirius/web/cors/CorsAllowOriginResolver.java
+++ b/src/main/java/sirius/web/cors/CorsAllowOriginResolver.java
@@ -28,8 +28,8 @@ import java.util.function.Supplier;
  * stores it in the request scoped {@link CorsContext}, and later writes it to the response as the actual CORS header.
  * </p>
  */
-@Register(classes = CorsAllowOriginHelper.class)
-public class CorsAllowOriginHelper {
+@Register(classes = CorsAllowOriginResolver.class)
+public class CorsAllowOriginResolver {
 
     /**
      * Stores the given strategy in the request's {@link CorsContext} and, if it resolves to a concrete origin for the

--- a/src/main/java/sirius/web/cors/CorsContext.java
+++ b/src/main/java/sirius/web/cors/CorsContext.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 /**
  * Carries the CORS origin resolved for the current request as a {@link SubContext}.
  * <p>
- * {@link CorsAllowOriginHelper} determines the effective {@code Access-Control-Allow-Origin} early during dispatching
+ * {@link CorsAllowOriginResolver} determines the effective {@code Access-Control-Allow-Origin} early during dispatching
  * and stores it here, so that it can later be applied when the response is created - without having to thread it
  * through the call chain or resort to string keyed request attributes.
  */

--- a/src/main/java/sirius/web/cors/CorsContext.java
+++ b/src/main/java/sirius/web/cors/CorsContext.java
@@ -1,0 +1,87 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.cors;
+
+import sirius.kernel.async.CallContext;
+import sirius.kernel.async.SubContext;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * Carries the CORS origin resolved for the current request as a {@link SubContext}.
+ * <p>
+ * {@link CorsAllowOriginHelper} determines the effective {@code Access-Control-Allow-Origin} early during dispatching
+ * and stores it here, so that it can later be applied when the response is created - without having to thread it
+ * through the call chain or resort to string keyed request attributes.
+ */
+public class CorsContext implements SubContext {
+
+    @Nullable
+    private AllowedOrigin configuredOrigin;
+
+    @Nullable
+    private String resolvedOrigin;
+
+    /**
+     * Returns the {@link CorsContext} of the current request.
+     *
+     * @return the CORS context associated with the current {@link CallContext}
+     */
+    public static CorsContext get() {
+        return CallContext.getCurrent().getOrCreateSubContext(CorsContext.class);
+    }
+
+    /**
+     * Stores the CORS origin strategy configured for the current request.
+     *
+     * @param configuredOrigin the configured origin strategy to store
+     */
+    public void setConfiguredOrigin(@Nullable AllowedOrigin configuredOrigin) {
+        this.configuredOrigin = configuredOrigin;
+    }
+
+    /**
+     * Stores the origin resolved for the current request.
+     *
+     * @param resolvedOrigin the resolved origin to store
+     */
+    public void setResolvedOrigin(@Nullable String resolvedOrigin) {
+        this.resolvedOrigin = resolvedOrigin;
+    }
+
+    /**
+     * Returns the CORS origin strategy configured for the current request, if any.
+     *
+     * @return the configured origin strategy, or an empty optional if none has been configured yet
+     */
+    public Optional<AllowedOrigin> getConfiguredOrigin() {
+        return Optional.ofNullable(configuredOrigin);
+    }
+
+    /**
+     * Returns the origin resolved for the current request, if any.
+     *
+     * @return the resolved origin, or an empty optional if none has been resolved yet
+     */
+    public Optional<String> getResolvedOrigin() {
+        return Optional.ofNullable(resolvedOrigin);
+    }
+
+    @Override
+    public SubContext fork() {
+        // The resolved origin is valid for the whole request, hence it may be shared with forked sub tasks.
+        return this;
+    }
+
+    @Override
+    public void detach() {
+        // Nothing to detach.
+    }
+}

--- a/src/main/java/sirius/web/cors/CorsContext.java
+++ b/src/main/java/sirius/web/cors/CorsContext.java
@@ -20,8 +20,15 @@ import java.util.Optional;
  * {@link CorsAllowOriginResolver} determines the effective {@code Access-Control-Allow-Origin} early during dispatching
  * and stores it here, so that it can later be applied when the response is created - without having to thread it
  * through the call chain or resort to string keyed request attributes.
+ * <p>
+ * As several dispatchers/interceptors may be invoked for a single request, an origin may only ever be resolved once
+ * per request. Once this context is marked as {@linkplain #markFinalized() finalized}, {@link #setConfiguredOrigin(AllowedOrigin)}
+ * and {@link #setResolvedOrigin(String)} refuse any further modification. This guarantees that the first strategy to
+ * resolve an origin wins and can never be weakened or overridden by a later invocation.
  */
 public class CorsContext implements SubContext {
+
+    private boolean isFinalized = false;
 
     @Nullable
     private AllowedOrigin configuredOrigin;
@@ -39,11 +46,37 @@ public class CorsContext implements SubContext {
     }
 
     /**
+     * Marks this context as finalized, permanently locking in the currently stored origin.
+     * <p>
+     * Once finalized, {@link #setConfiguredOrigin(AllowedOrigin)} and {@link #setResolvedOrigin(String)} will throw
+     * an {@link IllegalStateException} instead of overriding the previously stored values. This is used to ensure
+     * that an origin can only be resolved once per request, so that later dispatchers/interceptors cannot weaken or
+     * override a decision that was already made.
+     */
+    public void markFinalized() {
+        isFinalized = true;
+    }
+
+    /**
+     * Determines whether this context has already been finalized.
+     *
+     * @return {@code true} if the origin for this request has already been resolved and finalized, {@code false}
+     * otherwise
+     */
+    public boolean isFinalized() {
+        return isFinalized;
+    }
+
+    /**
      * Stores the CORS origin strategy configured for the current request.
      *
      * @param configuredOrigin the configured origin strategy to store
+     * @throws IllegalStateException if the context has already been finalized
      */
     public void setConfiguredOrigin(@Nullable AllowedOrigin configuredOrigin) {
+        if (isFinalized) {
+            throw new IllegalStateException("Cannot modify finalized CORS context");
+        }
         this.configuredOrigin = configuredOrigin;
     }
 
@@ -51,8 +84,12 @@ public class CorsContext implements SubContext {
      * Stores the origin resolved for the current request.
      *
      * @param resolvedOrigin the resolved origin to store
+     * @throws IllegalStateException if the context has already been finalized
      */
     public void setResolvedOrigin(@Nullable String resolvedOrigin) {
+        if (isFinalized) {
+            throw new IllegalStateException("Cannot modify finalized CORS context");
+        }
         this.resolvedOrigin = resolvedOrigin;
     }
 

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -25,6 +25,8 @@ import sirius.kernel.settings.Extension;
 import sirius.pasta.noodle.compiler.CompileException;
 import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
+import sirius.web.cors.AllowedOrigin;
+import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.http.Response;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -73,6 +75,9 @@ public class AssetsDispatcher implements WebDispatcher {
     @ConfigValue("http.response.defaultStaticAssetTTL")
     private static Duration defaultStaticAssetTTL;
 
+    @Part
+    private static CorsAllowOriginHelper corsOriginHelper;
+
     private File cacheDirFile;
 
     @Part
@@ -92,6 +97,8 @@ public class AssetsDispatcher implements WebDispatcher {
                                                                                                     .method())) {
             return DispatchDecision.CONTINUE;
         }
+
+        corsOriginHelper.tryResolveAndStoreOrigin(webContext, new AllowedOrigin.Wildcard());
 
         String effectiveUrl = computeEffectiveURI(webContext);
 

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -26,7 +26,7 @@ import sirius.pasta.noodle.compiler.CompileException;
 import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginHelper;
+import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.http.Response;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -76,7 +76,7 @@ public class AssetsDispatcher implements WebDispatcher {
     private static Duration defaultStaticAssetTTL;
 
     @Part
-    private static CorsAllowOriginHelper corsOriginHelper;
+    private static CorsAllowOriginResolver corsOriginResolver;
 
     private File cacheDirFile;
 
@@ -98,7 +98,7 @@ public class AssetsDispatcher implements WebDispatcher {
             return DispatchDecision.CONTINUE;
         }
 
-        corsOriginHelper.tryResolveAndStoreOrigin(webContext, new AllowedOrigin.Wildcard());
+        corsOriginResolver.tryResolveAndStoreOrigin(webContext, new AllowedOrigin.Wildcard());
 
         String effectiveUrl = computeEffectiveURI(webContext);
 

--- a/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
@@ -12,8 +12,11 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.ConfigValue;
+import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.HandledException;
+import sirius.web.cors.AllowedOrigin;
+import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.http.MimeHelper;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -36,6 +39,9 @@ public class DefaultDispatcher implements WebDispatcher {
      */
     public static final String ATTRIBUTE_ORIGINAL_URI = "ORIGINAL_URI";
 
+    @Part
+    private static CorsAllowOriginHelper corsOriginHelper;
+
     @ConfigValue("http.robots.txt.enabled")
     private boolean serveRobots;
 
@@ -49,6 +55,8 @@ public class DefaultDispatcher implements WebDispatcher {
 
     @Override
     public DispatchDecision dispatch(WebContext webContext) throws Exception {
+        corsOriginHelper.tryResolveAndStoreOrigin(webContext, new AllowedOrigin.MatchRequest());
+
         Optional<HandledException> exception = webContext.checkParameterReadability();
         if (exception.isPresent()) {
             UserContext.getCurrentUser();

--- a/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
@@ -16,7 +16,7 @@ import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.HandledException;
 import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginHelper;
+import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.http.MimeHelper;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -40,7 +40,7 @@ public class DefaultDispatcher implements WebDispatcher {
     public static final String ATTRIBUTE_ORIGINAL_URI = "ORIGINAL_URI";
 
     @Part
-    private static CorsAllowOriginHelper corsOriginHelper;
+    private static CorsAllowOriginResolver corsOriginResolver;
 
     @ConfigValue("http.robots.txt.enabled")
     private boolean serveRobots;
@@ -55,7 +55,7 @@ public class DefaultDispatcher implements WebDispatcher {
 
     @Override
     public DispatchDecision dispatch(WebContext webContext) throws Exception {
-        corsOriginHelper.tryResolveAndStoreOrigin(webContext, new AllowedOrigin.MatchRequest());
+        corsOriginResolver.tryResolveAndStoreOrigin(webContext, new AllowedOrigin.MatchRequest());
 
         Optional<HandledException> exception = webContext.checkParameterReadability();
         if (exception.isPresent()) {

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -26,8 +26,6 @@ import sirius.pasta.noodle.compiler.CompileException;
 import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.web.controller.Message;
-import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.event.TemplateInvocationHandler;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -61,9 +59,6 @@ public class HelpDispatcher implements WebDispatcher {
     private static Duration defaultStaticAssetTTL;
 
     @Part
-    private static CorsAllowOriginResolver corsOriginResolver;
-
-    @Part
     private Resources resources;
 
     @Part
@@ -83,8 +78,6 @@ public class HelpDispatcher implements WebDispatcher {
             || !HttpMethod.GET.equals(ctx.getRequest().method())) {
             return DispatchDecision.CONTINUE;
         }
-
-        corsOriginResolver.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.Wildcard());
 
         ctx.enableTiming(HELP_PREFIX);
 

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -26,6 +26,8 @@ import sirius.pasta.noodle.compiler.CompileException;
 import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.web.controller.Message;
+import sirius.web.cors.AllowedOrigin;
+import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.event.TemplateInvocationHandler;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -59,6 +61,9 @@ public class HelpDispatcher implements WebDispatcher {
     private static Duration defaultStaticAssetTTL;
 
     @Part
+    private static CorsAllowOriginHelper corsOriginHelper;
+
+    @Part
     private Resources resources;
 
     @Part
@@ -78,6 +83,8 @@ public class HelpDispatcher implements WebDispatcher {
             || !HttpMethod.GET.equals(ctx.getRequest().method())) {
             return DispatchDecision.CONTINUE;
         }
+
+        corsOriginHelper.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.Wildcard());
 
         ctx.enableTiming(HELP_PREFIX);
 

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -27,7 +27,7 @@ import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.web.controller.Message;
 import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginHelper;
+import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.event.TemplateInvocationHandler;
 import sirius.web.http.WebContext;
 import sirius.web.http.WebDispatcher;
@@ -61,7 +61,7 @@ public class HelpDispatcher implements WebDispatcher {
     private static Duration defaultStaticAssetTTL;
 
     @Part
-    private static CorsAllowOriginHelper corsOriginHelper;
+    private static CorsAllowOriginResolver corsOriginResolver;
 
     @Part
     private Resources resources;
@@ -84,7 +84,7 @@ public class HelpDispatcher implements WebDispatcher {
             return DispatchDecision.CONTINUE;
         }
 
-        corsOriginHelper.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.Wildcard());
+        corsOriginResolver.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.Wildcard());
 
         ctx.enableTiming(HELP_PREFIX);
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -56,7 +56,7 @@ import sirius.pasta.tagliatelle.Template;
 import sirius.pasta.tagliatelle.rendering.GlobalRenderContext;
 import sirius.web.controller.PreserveErrorMessageTransformer;
 import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginHelper;
+import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
 import sirius.web.services.JSONStructuredOutput;
@@ -181,7 +181,7 @@ public class Response {
     private static Tagliatelle engine;
 
     @Part
-    private static CorsAllowOriginHelper corsOriginHelper;
+    private static CorsAllowOriginResolver corsOriginResolver;
 
     @ConfigValue("http.response.defaultClientCacheTTL")
     private static Duration defaultCacheDuration;
@@ -296,16 +296,16 @@ public class Response {
         // ignore them.
 
         if (!headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)) {
-            corsOriginHelper.applyResolvedOriginHeader(response);
+            corsOriginResolver.applyResolvedOriginHeader(response);
         }
 
         // Only set the `Access-Control-Allow-Credentials` header if credentials have explicitly been allowed by the
         // interceptor determining the origin:
 
-        var shouldAllowCredentials = corsOriginHelper.getConfiguredOrigin()
-                                                     .filter(origin -> origin instanceof AllowedOrigin.Specific)
-                                                     .map(origin -> ((AllowedOrigin.Specific) origin).allowCredentials())
-                                                     .orElse(false);
+        var shouldAllowCredentials = corsOriginResolver.getConfiguredOrigin()
+                                                       .filter(origin -> origin instanceof AllowedOrigin.Specific)
+                                                       .map(origin -> ((AllowedOrigin.Specific) origin).allowCredentials())
+                                                       .orElse(false);
 
         if (shouldAllowCredentials && !headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
             headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -321,8 +321,15 @@ public class Response {
         // avoid expensive evaluation of the origin for same-origin requests without an `Origin` header.
         // Also see `ControllerDispatcher#dispatch()`.
 
+        setOrAppendOriginToVaryHeader(headers);
+    }
+
+    private void setOrAppendOriginToVaryHeader(HttpHeaders headers) {
         if (!headers.contains(HttpHeaderNames.VARY)) {
-            headers.set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
+            headers.add(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
+        } else {
+            var current = headers.get(HttpHeaderNames.VARY);
+            headers.set(HttpHeaderNames.VARY, String.format("%s, %s", current, HttpHeaderNames.ORIGIN));
         }
     }
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -55,6 +55,7 @@ import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.pasta.tagliatelle.rendering.GlobalRenderContext;
 import sirius.web.controller.PreserveErrorMessageTransformer;
+import sirius.web.cors.AllowedOrigin;
 import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
@@ -283,13 +284,41 @@ public class Response {
     }
 
     private void setupCors(DefaultHttpResponse response) {
-        response.headers().set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
-
-        if (!response.headers().contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
-            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        // If `corsAllowAll` is disabled, we explicitly do not want to handle anything CORS.
+        if (!webContext.isCorsAllowAll()) {
+            return;
         }
 
-        corsOriginHelper.applyHeaderFromWebContext(webContext, response);
+        HttpHeaders headers = response.headers();
+
+        // Only apply CORS headers from the global helper if they have not been set manually before.
+        // Different `Dispatcher` implementations or code paths may set CORS headers themselves, and we should not
+        // ignore them.
+
+        if (!headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)) {
+            corsOriginHelper.applyResolvedOriginHeader(response);
+        }
+
+        // Only set the `Access-Control-Allow-Credentials` header if credentials have explicitly been allowed by the
+        // interceptor determining the origin:
+
+        var shouldAllowCredentials = corsOriginHelper.getConfiguredOrigin()
+                                                     .filter(origin -> origin instanceof AllowedOrigin.Specific)
+                                                     .map(origin -> ((AllowedOrigin.Specific) origin).allowCredentials())
+                                                     .orElse(false);
+
+        if (shouldAllowCredentials && !headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
+            headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        }
+
+        // Regardless whether the CORS origin has actually been resolved/applied, we must send a `Vary` header for all
+        // resources depending on the origin. For performance reasons we do always set the header, though, in order to
+        // avoid expensive evaluation of the origin for same-origin requests without an `Origin` header.
+        // Also see `ControllerDispatcher#dispatch()`.
+
+        if (!headers.contains(HttpHeaderNames.VARY)) {
+            headers.set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
+        }
     }
 
     private void setupCookies(DefaultHttpResponse response) {

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -300,14 +300,19 @@ public class Response {
         }
 
         // Only set the `Access-Control-Allow-Credentials` header if credentials have explicitly been allowed by the
-        // interceptor determining the origin:
+        // interceptor determining the origin, a respective header is present and the credentials header has not been
+        // set before:
 
-        var shouldAllowCredentials = corsOriginResolver.getConfiguredOrigin()
-                                                       .filter(origin -> origin instanceof AllowedOrigin.Specific)
-                                                       .map(origin -> ((AllowedOrigin.Specific) origin).allowCredentials())
-                                                       .orElse(false);
+        var strategyAllowsCredentials = corsOriginResolver.getConfiguredOrigin()
+                                                          .filter(origin -> origin instanceof AllowedOrigin.Specific)
+                                                          .map(origin -> ((AllowedOrigin.Specific) origin).allowCredentials())
+                                                          .orElse(false);
 
-        if (shouldAllowCredentials && !headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
+        var shouldSetAllowCredentialsHeader = strategyAllowsCredentials
+                                              && headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)
+                                              && !headers.contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS);
+
+        if (shouldSetAllowCredentialsHeader) {
             headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
         }
 

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -55,6 +55,7 @@ import sirius.pasta.tagliatelle.Tagliatelle;
 import sirius.pasta.tagliatelle.Template;
 import sirius.pasta.tagliatelle.rendering.GlobalRenderContext;
 import sirius.web.controller.PreserveErrorMessageTransformer;
+import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.resources.Resource;
 import sirius.web.resources.Resources;
 import sirius.web.services.JSONStructuredOutput;
@@ -178,6 +179,9 @@ public class Response {
     @Part
     private static Tagliatelle engine;
 
+    @Part
+    private static CorsAllowOriginHelper corsOriginHelper;
+
     @ConfigValue("http.response.defaultClientCacheTTL")
     private static Duration defaultCacheDuration;
 
@@ -279,18 +283,13 @@ public class Response {
     }
 
     private void setupCors(DefaultHttpResponse response) {
-        if (!WebContext.isCorsAllowAll() || response.headers().contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)) {
-            return;
+        response.headers().set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
+
+        if (!response.headers().contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
+            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
         }
 
-        response.headers().set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
-        String requestedOrigin = webContext.getHeader(HttpHeaderNames.ORIGIN);
-        if (Strings.isFilled(requestedOrigin)) {
-            response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, requestedOrigin);
-            if (!response.headers().contains(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS)) {
-                response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
-            }
-        }
+        corsOriginHelper.applyHeaderFromWebContext(webContext, response);
     }
 
     private void setupCookies(DefaultHttpResponse response) {

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -284,8 +284,8 @@ public class Response {
     }
 
     private void setupCors(DefaultHttpResponse response) {
-        // If `corsAllowAll` is disabled, we explicitly do not want to handle anything CORS.
-        if (!webContext.isCorsAllowAll()) {
+        // If `enableCors` is disabled, we explicitly do not want to handle anything CORS.
+        if (!webContext.isCorsEnabled()) {
             return;
         }
 

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -449,14 +449,18 @@ public class WebContext implements SubContext {
     }
 
     /**
-     * Determines if automatic CORS handling is enabled for the current request scope.
+     * Determines if automatic CORS handling is enabled for the scope of this request.
      * <p>
-     * If the active security scope defines {@code http.corsAllowAll}, that value overrides the global setting.
+     * If the security scope defines {@code http.corsAllowAll}, that value overrides the global setting.
+     * <p>
+     * The scope is resolved via {@link UserContext#peekScope(WebContext)} and therefore <b>without installing it</b>.
+     * This permits reading the setting early during request handling (e.g. while determining the allowed CORS origin)
+     * without prematurely binding the scope and thereby discarding a manually installed user.
      *
      * @return {@code true} if automatic CORS handling should be applied, {@code false} otherwise
      */
-    public static boolean isCorsAllowAll() {
-        return UserContext.getCurrentScope().getSettings().get(CONFIG_KEY_CORS_ALLOW_ALL).asBoolean(corsAllowAll);
+    public boolean isCorsAllowAll() {
+        return UserContext.get().peekScope(this).getSettings().get(CONFIG_KEY_CORS_ALLOW_ALL).asBoolean(corsAllowAll);
     }
 
     /**
@@ -896,12 +900,12 @@ public class WebContext implements SubContext {
                 sessionPin)) {
             if (SESSION_CHECK.isFINE()) {
                 SESSION_CHECK.FINE("Session pin mismatch: %s (%s) vs. %s%n%s%n%s%nIP: %s",
-                                                 givenSessionPin,
-                                                 effectiveSessionPin,
-                                                 sessionPin,
-                                                 session,
-                                                 this,
-                                                 getRemoteIP());
+                                   givenSessionPin,
+                                   effectiveSessionPin,
+                                   sessionPin,
+                                   session,
+                                   this,
+                                   getRemoteIP());
             }
             clearSession();
         } else if (Strings.isEmpty(sessionPin) && Strings.isFilled(givenSessionPin)) {

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -98,7 +98,7 @@ public class WebContext implements SubContext {
     /**
      * Defines the config key for enabling the automatic CORS handling.
      */
-    public static final String CONFIG_KEY_CORS_ALLOW_ALL = "http.corsAllowAll";
+    public static final String CONFIG_KEY_ENABLE_CORS = "http.enableCors";
 
     private static final String HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
     private static final String PROTOCOL_HTTPS = "https";
@@ -405,8 +405,8 @@ public class WebContext implements SubContext {
     /**
      * Should the automatic CORS handling be done or not?
      */
-    @ConfigValue(CONFIG_KEY_CORS_ALLOW_ALL)
-    private static boolean corsAllowAll;
+    @ConfigValue(CONFIG_KEY_ENABLE_CORS)
+    private static boolean enableCors;
 
     /**
      * Should a Strict-Transport-Security header be sent?
@@ -451,7 +451,7 @@ public class WebContext implements SubContext {
     /**
      * Determines if automatic CORS handling is enabled for the scope of this request.
      * <p>
-     * If the security scope defines {@code http.corsAllowAll}, that value overrides the global setting.
+     * If the security scope defines {@code http.enableCors}, that value overrides the global setting.
      * <p>
      * The scope is resolved via {@link UserContext#peekScope(WebContext)} and therefore <b>without installing it</b>.
      * This permits reading the setting early during request handling (e.g. while determining the allowed CORS origin)
@@ -459,8 +459,8 @@ public class WebContext implements SubContext {
      *
      * @return {@code true} if automatic CORS handling should be applied, {@code false} otherwise
      */
-    public boolean isCorsAllowAll() {
-        return UserContext.get().peekScope(this).getSettings().get(CONFIG_KEY_CORS_ALLOW_ALL).asBoolean(corsAllowAll);
+    public boolean isCorsEnabled() {
+        return UserContext.get().peekScope(this).getSettings().get(CONFIG_KEY_ENABLE_CORS).asBoolean(enableCors);
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebDispatcher.java
+++ b/src/main/java/sirius/web/http/WebDispatcher.java
@@ -40,6 +40,12 @@ import sirius.kernel.di.std.Priorized;
  * absolutely no blocking operations must be performed. However, the returned <tt>Callback</tt> is executed in its own
  * thread and free of any constraints.
  * </p>
+ * <p>
+ * <b>Important note regarding CORS:</b> If a dispatcher is willing to handle CORS requests, it must set the required
+ * headers itself! There is no central handling of CORS headers except for
+ * {@link sirius.web.controller.ControllerDispatcher} which will handle CORS headers for all controllers and is
+ * extensible via the {@link sirius.web.controller.Interceptor} interface.
+ * </p>
  *
  * @see WebServerHandler
  */

--- a/src/main/java/sirius/web/http/WebDispatcher.java
+++ b/src/main/java/sirius/web/http/WebDispatcher.java
@@ -44,7 +44,9 @@ import sirius.kernel.di.std.Priorized;
  * <b>Important note regarding CORS:</b> If a dispatcher is willing to handle CORS requests, it must set the required
  * headers itself! There is no central handling of CORS headers except for
  * {@link sirius.web.controller.ControllerDispatcher} which will handle CORS headers for all controllers and is
- * extensible via the {@link sirius.web.controller.Interceptor} interface.
+ * extensible via the {@link sirius.web.controller.Interceptor} interface. Note that an origin may only be resolved
+ * once per request (see {@link sirius.web.cors.CorsAllowOriginResolver#tryResolveAndStoreOrigin}), so if multiple
+ * dispatchers attempt to resolve CORS origins for the same request, only the first one to succeed actually wins.
  * </p>
  *
  * @see WebServerHandler

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -580,6 +580,30 @@ public class UserContext implements SubContext {
         return currentScope;
     }
 
+    /**
+     * Determines the scope for the given request <b>without installing it</b>.
+     * <p>
+     * In contrast to {@link #getScope()}, this method does not call {@link #setCurrentScope(ScopeInfo)} and therefore
+     * has no side effects - most notably it does not reset an already installed {@link #getCurrentUser() current user}.
+     * It returns an already bound scope if present, otherwise it detects the scope via the {@link ScopeDetector}
+     * (falling back to {@link ScopeInfo#DEFAULT_SCOPE} if none is present) but leaves the context untouched.
+     * <p>
+     * This is useful to read scope specific settings early during request handling (e.g. the CORS configuration)
+     * without prematurely binding the scope and thereby discarding a user which was installed manually.
+     *
+     * @param webContext the request to detect the scope from
+     * @return the currently installed scope, the detected scope or {@link ScopeInfo#DEFAULT_SCOPE}
+     */
+    public ScopeInfo peekScope(WebContext webContext) {
+        if (currentScope != null) {
+            return currentScope;
+        }
+        if (detector != null && webContext != null && webContext.isValid()) {
+            return detector.detectScope(webContext);
+        }
+        return ScopeInfo.DEFAULT_SCOPE;
+    }
+
     @Override
     public SubContext fork() {
         // We return a copy which keeps the same user and scope - but which can be change independently.

--- a/src/main/java/sirius/web/services/ServiceDispatcher.java
+++ b/src/main/java/sirius/web/services/ServiceDispatcher.java
@@ -17,6 +17,8 @@ import sirius.kernel.commons.Tuple;
 import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
+import sirius.web.cors.AllowedOrigin;
+import sirius.web.cors.CorsAllowOriginHelper;
 import sirius.web.http.Firewall;
 import sirius.web.http.Limited;
 import sirius.web.http.Unlimited;
@@ -45,6 +47,9 @@ public class ServiceDispatcher implements WebDispatcher {
     private static final String SYSTEM_SERVICE = "SERVICE";
 
     @Part
+    private static CorsAllowOriginHelper corsOriginHelper;
+
+    @Part
     private GlobalContext gc;
 
     @Part
@@ -61,6 +66,9 @@ public class ServiceDispatcher implements WebDispatcher {
         if (!ctx.getRequestedURI().startsWith("/service/")) {
             return DispatchDecision.CONTINUE;
         }
+
+        corsOriginHelper.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.MatchRequest());
+
         // The real dispatching is put into its own method to support inlining of this check by the JIT
         return doDispatch(ctx);
     }

--- a/src/main/java/sirius/web/services/ServiceDispatcher.java
+++ b/src/main/java/sirius/web/services/ServiceDispatcher.java
@@ -67,8 +67,6 @@ public class ServiceDispatcher implements WebDispatcher {
             return DispatchDecision.CONTINUE;
         }
 
-        corsOriginResolver.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.MatchRequest());
-
         // The real dispatching is put into its own method to support inlining of this check by the JIT
         return doDispatch(ctx);
     }
@@ -80,8 +78,13 @@ public class ServiceDispatcher implements WebDispatcher {
         String uri = ctx.getRequestedURI();
         Tuple<ServiceCall, StructuredService> handler = parsePath(ctx, uri);
         if (handler.getSecond() == null) {
+            // No service handles this path, so the request is left to the remaining dispatchers. We must not resolve
+            // an origin here, as that would finalize it and thereby suppress the (potentially more restrictive)
+            // strategy which the ControllerDispatcher determines via the interceptors.
             return DispatchDecision.CONTINUE;
         }
+
+        corsOriginResolver.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.MatchRequest());
 
         invokeService(ctx, handler.getFirst(), handler.getSecond());
         return DispatchDecision.DONE;

--- a/src/main/java/sirius/web/services/ServiceDispatcher.java
+++ b/src/main/java/sirius/web/services/ServiceDispatcher.java
@@ -18,7 +18,7 @@ import sirius.kernel.di.GlobalContext;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
 import sirius.web.cors.AllowedOrigin;
-import sirius.web.cors.CorsAllowOriginHelper;
+import sirius.web.cors.CorsAllowOriginResolver;
 import sirius.web.http.Firewall;
 import sirius.web.http.Limited;
 import sirius.web.http.Unlimited;
@@ -47,7 +47,7 @@ public class ServiceDispatcher implements WebDispatcher {
     private static final String SYSTEM_SERVICE = "SERVICE";
 
     @Part
-    private static CorsAllowOriginHelper corsOriginHelper;
+    private static CorsAllowOriginResolver corsOriginResolver;
 
     @Part
     private GlobalContext gc;
@@ -67,7 +67,7 @@ public class ServiceDispatcher implements WebDispatcher {
             return DispatchDecision.CONTINUE;
         }
 
-        corsOriginHelper.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.MatchRequest());
+        corsOriginResolver.tryResolveAndStoreOrigin(ctx, new AllowedOrigin.MatchRequest());
 
         // The real dispatching is put into its own method to support inlining of this check by the JIT
         return doDispatch(ctx);

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -116,10 +116,12 @@ http {
     # - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     contentSecurityPolicy = ""
 
-    # Determines if all cors requests (preflight requests especially) should be accepted by the server
-    # automatically. If you need a more advanced behaviour, you probably want to implement a custom
-    # dispatcher. This can be overridden per security scope via scope config using http.corsAllowAll.
-    corsAllowAll = false
+    # Determines whether automatic CORS handling is enabled. When enabled, the appropriate
+    # `Access-Control-*` headers (including answers to preflight requests) are sent automatically;
+    # when disabled, no CORS headers are emitted at all. For fine-grained control over the allowed
+    # origins, register a custom Interceptor. This can be overridden per security scope via scope
+    # config using http.enableCors.
+    enableCors = false
 
     # Determines if POST requests should no longer be secured by enforcing valid CSRF tokens.
     # This should only be used (skipped) for testing (e.g. pen-testing) scenarios.

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -68,6 +68,13 @@ public class TestController extends BasicController {
                   .direct(HttpResponseStatus.OK, webContext.get("value").asString());
     }
 
+    @Routed("/test/vary")
+    public void varyTest(WebContext webContext) {
+        webContext.respondWith()
+                  .addHeader(HttpHeaderNames.VARY, HttpHeaderNames.ACCEPT_ENCODING)
+                  .direct(HttpResponseStatus.OK, "OK");
+    }
+
     @InternalService
     @Routed("/test/json")
     public void testJSON(WebContext webContext, JSONStructuredOutput out) {

--- a/src/test/java/sirius/web/http/TestCorsInterceptor.java
+++ b/src/test/java/sirius/web/http/TestCorsInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import sirius.kernel.di.std.Register;
+import sirius.web.controller.Interceptor;
+import sirius.web.controller.Route;
+import sirius.web.cors.AllowedOrigin;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * A test {@link Interceptor} which lets {@code CorsTest} control the {@link AllowedOrigin} strategy returned for a
+ * request over a real HTTP connection.
+ * <p>
+ * The strategy is controlled via the static {@link #allowedOrigin} field. A {@code null} value simulates an interceptor
+ * which cannot decide on a strategy (i.e. it returns an empty optional). As it is only consulted when
+ * {@code http.corsAllowAll} is disabled (see {@link TestCorsScopeDetector}), it does not interfere with requests using
+ * the globally enabled CORS handling.
+ */
+@Register(framework = "web.test-cors")
+public class TestCorsInterceptor implements Interceptor {
+
+    /**
+     * The strategy returned by {@link #determineAllowedCorsOrigin(WebContext, Collection)}, or {@code null} to signal
+     * that no decision can be made.
+     */
+    public static volatile AllowedOrigin allowedOrigin;
+
+    @Override
+    public boolean before(WebContext webContext, Route route) {
+        return false;
+    }
+
+    @Override
+    public boolean beforePermissionError(String permission, WebContext webContext, Route route) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldExecuteRoute(WebContext webContext, Route route) {
+        return true;
+    }
+
+    @Override
+    public Optional<AllowedOrigin> determineAllowedCorsOrigin(WebContext webContext, Collection<Route> routes) {
+        return Optional.ofNullable(allowedOrigin);
+    }
+}

--- a/src/test/java/sirius/web/http/TestCorsInterceptor.java
+++ b/src/test/java/sirius/web/http/TestCorsInterceptor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestCorsInterceptor.java
+++ b/src/test/java/sirius/web/http/TestCorsInterceptor.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * <p>
  * The strategy is controlled via the static {@link #allowedOrigin} field. A {@code null} value simulates an interceptor
  * which cannot decide on a strategy (i.e. it returns an empty optional). As it is only consulted when
- * {@code http.corsAllowAll} is disabled (see {@link TestCorsScopeDetector}), it does not interfere with requests using
+ * {@code http.enableCors} is disabled (see {@link TestCorsScopeDetector}), it does not interfere with requests using
  * the globally enabled CORS handling.
  */
 @Register(framework = "web.test-cors")

--- a/src/test/java/sirius/web/http/TestCorsScopeDetector.java
+++ b/src/test/java/sirius/web/http/TestCorsScopeDetector.java
@@ -1,0 +1,64 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import com.typesafe.config.ConfigFactory;
+import sirius.kernel.di.std.Register;
+import sirius.web.security.ScopeDetector;
+import sirius.web.security.ScopeInfo;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+/**
+ * A test {@link ScopeDetector} which allows {@code CorsTest} to disable the automatic CORS handling
+ * ({@code http.corsAllowAll}) for an individual request over a real HTTP connection.
+ * <p>
+ * Since the global test configuration enables {@code http.corsAllowAll}, the {@link sirius.web.controller.Interceptor}
+ * based CORS origin resolution would never be reached. Requests carrying the {@link #HEADER_DISABLE_CORS_ALL} header
+ * are therefore bound to a scope which overrides the setting to {@code false}. All other requests use the
+ * {@link ScopeInfo#DEFAULT_SCOPE} and hence keep the globally enabled handling.
+ */
+@Register(framework = "web.test-cors")
+public class TestCorsScopeDetector implements ScopeDetector {
+
+    /**
+     * Requests carrying this header are bound to a scope which disables automatic CORS handling.
+     */
+    public static final String HEADER_DISABLE_CORS_ALL = "X-Test-Disable-Cors-All";
+
+    private static final ScopeInfo CORS_RESTRICTED_SCOPE = new ScopeInfo("cors-restricted",
+                                                                         ScopeInfo.DEFAULT_SCOPE.getScopeType(),
+                                                                         "cors-restricted",
+                                                                         null,
+                                                                         scope -> ConfigFactory.parseString(
+                                                                                 "http.corsAllowAll = false"),
+                                                                         null);
+
+    @Nonnull
+    @Override
+    public ScopeInfo detectScope(@Nonnull WebContext request) {
+        if (request.getHeader(HEADER_DISABLE_CORS_ALL) != null) {
+            return CORS_RESTRICTED_SCOPE;
+        }
+        return ScopeInfo.DEFAULT_SCOPE;
+    }
+
+    @Nonnull
+    @Override
+    public ScopeInfo findScopeByName(@Nonnull String scopeName) {
+        return ScopeInfo.DEFAULT_SCOPE;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<ScopeInfo> findScopeById(@Nonnull String scopeId) {
+        return Optional.empty();
+    }
+}

--- a/src/test/java/sirius/web/http/TestCorsScopeDetector.java
+++ b/src/test/java/sirius/web/http/TestCorsScopeDetector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestCorsScopeDetector.java
+++ b/src/test/java/sirius/web/http/TestCorsScopeDetector.java
@@ -18,9 +18,9 @@ import java.util.Optional;
 
 /**
  * A test {@link ScopeDetector} which allows {@code CorsTest} to disable the automatic CORS handling
- * ({@code http.corsAllowAll}) for an individual request over a real HTTP connection.
+ * ({@code http.enableCors}) for an individual request over a real HTTP connection.
  * <p>
- * Since the global test configuration enables {@code http.corsAllowAll}, the {@link sirius.web.controller.Interceptor}
+ * Since the global test configuration enables {@code http.enableCors}, the {@link sirius.web.controller.Interceptor}
  * based CORS origin resolution would never be reached. Requests carrying the {@link #HEADER_DISABLE_CORS_ALL} header
  * are therefore bound to a scope which overrides the setting to {@code false}. All other requests use the
  * {@link ScopeInfo#DEFAULT_SCOPE} and hence keep the globally enabled handling.
@@ -38,7 +38,7 @@ public class TestCorsScopeDetector implements ScopeDetector {
                                                                          "cors-restricted",
                                                                          null,
                                                                          scope -> ConfigFactory.parseString(
-                                                                                 "http.corsAllowAll = false"),
+                                                                                 "http.enableCors = false"),
                                                                          null);
 
     @Nonnull

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -288,6 +288,18 @@ class CorsTest {
     }
 
     @Test
+    fun `given enableCors is enabled when the interceptor allows credentials for a Specific origin then a disallowed origin yields neither the origin nor the credentials header`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(true, specificAllowedOrigins)
+
+        val connection = sendGet("https://evil.example.com")
+
+        assertAll(
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())) },
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())) },
+        )
+    }
+
+    @Test
     fun `given enableCors is enabled when a preflight allows credentials for a Specific origin then origin and credentials headers are set`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(true, specificAllowedOrigins)
 

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -24,6 +24,7 @@ import sirius.web.cors.CorsAllowOriginResolver
 import sirius.web.cors.CorsContext
 import sirius.web.security.ScopeInfo
 import sirius.web.security.UserContext
+import sirius.web.security.UserInfo
 import java.net.HttpURLConnection
 import java.net.URI
 import kotlin.test.*
@@ -381,6 +382,41 @@ class CorsTest {
             { assertNotNull(vary) },
             { assertContains(vary.orEmpty(), HttpHeaderNames.ACCEPT_ENCODING.toString(), ignoreCase = true) },
             { assertContains(vary.orEmpty(), HttpHeaderNames.ORIGIN.toString(), ignoreCase = true) },
+        )
+    }
+
+    // --- Scope peeking (must not discard a manually installed user) ---
+
+    @Test
+    fun `a manually installed user survives the CORS origin resolution`() {
+        // Resolving the origin happens very early in `ControllerDispatcher#dispatch()` - before the routes are matched
+        // and their permissions are checked - and it needs the scope to evaluate `http.enableCors`. Reading the scope
+        // via `UserContext#getScope()` would *install* it, and `setCurrentScope()` resets the current user. A user
+        // installed manually (as tests and background jobs do) would therefore be discarded before the permission
+        // check ran, turning a legitimate request into a permission error. `WebContext#isCorsEnabled()` uses
+        // `UserContext#peekScope()` instead, which detects the scope without binding it.
+        UserContext.get().setCurrentUser(
+            UserInfo.Builder.createUser("test").withPermissions(setOf("permission-system-tags")).build()
+        )
+
+        val response = TestRequest.GET("/system/tags")
+            .addHeader(HttpHeaderNames.ORIGIN, "https://example.com")
+            .execute()
+
+        // Note that the assertions below must inspect the request's own `CallContext` (via `getCallContext()`): the
+        // pipeline dispatches on a forked task, so the `CorsContext` created while dispatching never appears in this
+        // thread's context. For the same reason the surviving user cannot be asserted directly - `UserContext#fork()`
+        // hands the forked task a *copy*, so this thread's user stays installed either way. The rendered page is the
+        // observable proof that the permission check inside the request still saw the user.
+        val corsContext = response.callContext.getOrCreateSubContext(CorsContext::class.java)
+
+        assertAll(
+            // The request must actually have gone through the CORS origin resolution, otherwise this test would
+            // silently degrade into a duplicate of `PermissionsRouteTest` and no longer guard the regression.
+            { assertEquals("https://example.com", corsContext.resolvedOrigin.orElse(null)) },
+            // The permission check must have passed, rendering the real page instead of an error page.
+            { assertEquals(TestResponse.ResponseType.TEMPLATE, response.type) },
+            { assertEquals("/templates/system/tags.html.pasta", response.templateName) },
         )
     }
 

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import sirius.kernel.SiriusExtension
 import sirius.web.cors.AllowedOrigin
@@ -24,17 +23,18 @@ import sirius.web.security.ScopeInfo
 import sirius.web.security.UserContext
 import java.net.HttpURLConnection
 import java.net.URI
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 /**
  * Tests the CORS handling of the web server.
  *
+ * `http.corsAllowAll` acts as a master switch: only when it is enabled for the request's scope are the interceptors
+ * consulted to determine the allowed origin (falling back to reflecting the request's `Origin`). When it is disabled,
+ * no CORS headers are emitted at all - not even if an interceptor would allow the origin.
+ *
  * Note: Some tests set the restricted `Origin:` header, requiring `-Dsun.net.http.allowRestrictedHeaders=true`. This is
- * enabled centrally in [SiriusExtension.beforeAll].
+ * enabled centrally in [SiriusExtension.beforeAll]. Requests carrying [TestCorsScopeDetector.HEADER_DISABLE_CORS_ALL]
+ * are bound to a scope which disables `corsAllowAll`.
  */
 @ExtendWith(SiriusExtension::class)
 class CorsTest {
@@ -46,9 +46,25 @@ class CorsTest {
         TestCorsInterceptor.allowedOrigin = null
     }
 
+    // --- corsAllowAll master switch ---
+
     @Test
     fun `given corsAllowAll is enabled when a request carries an origin then it is reflected as 'Access-Control-Allow-Origin'`() {
-        assertEquals("TEST", requestAllowedOrigin("TEST", disableCorsAll = false))
+        assertEquals("TEST", requestAllowedOrigin("TEST"))
+    }
+
+    @Test
+    fun `given corsAllowAll is disabled then no CORS headers are emitted even if an interceptor would allow the origin`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
+
+        val connection = sendGet("https://example.com", disableCorsAll = true)
+        val vary = connection.getHeaderField(HttpHeaderNames.VARY.toString())
+
+        assertAll(
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())) },
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())) },
+            { assertFalse(vary != null && vary.contains(HttpHeaderNames.ORIGIN.toString(), ignoreCase = true)) },
+        )
     }
 
     @Test
@@ -90,20 +106,28 @@ class CorsTest {
     @Test
     fun `given a scope overriding corsAllowAll to false when the global setting is enabled then automatic cors is disabled`() {
         UserContext.get().setCurrentScope(configuredScope("corsDisabled", false))
-        assertFalse(WebContext.isCorsAllowAll())
+        assertFalse(TestRequest.GET("/system/ok").isCorsAllowAll)
     }
 
     @Test
     fun `given a scope without a corsAllowAll override when the global setting is enabled then the global setting is used`() {
         UserContext.get().setCurrentScope(configuredScope("default", null))
-        assertTrue(WebContext.isCorsAllowAll())
+        assertTrue(TestRequest.GET("/system/ok").isCorsAllowAll)
+    }
+
+    // --- Allowed origin strategies (corsAllowAll enabled) ---
+
+    @Test
+    fun `given corsAllowAll is enabled when no interceptor decides on a strategy then the requested origin is reflected as fallback`() {
+        TestCorsInterceptor.allowedOrigin = null
+
+        assertEquals("https://example.com", requestAllowedOrigin("https://example.com"))
     }
 
     @ParameterizedTest
-    @NullSource
     @ValueSource(strings = ["https://example.com", "http://localhost:3000"])
-    fun `given corsAllowAll is disabled when the interceptor returns a Wildcard strategy then the asterisk is returned regardless of the requested origin`(
-        requestOrigin: String?
+    fun `given corsAllowAll is enabled when the interceptor returns a Wildcard strategy then the asterisk is returned regardless of the requested origin`(
+        requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
 
@@ -112,7 +136,7 @@ class CorsTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["https://example.com", "http://localhost:3000", "https://sub.domain.example.com:8443"])
-    fun `given corsAllowAll is disabled when the interceptor returns a MatchRequest strategy then the requested origin is reflected`(
+    fun `given corsAllowAll is enabled when the interceptor returns a MatchRequest strategy then the requested origin is reflected`(
         requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
@@ -122,49 +146,163 @@ class CorsTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["https://a.example.com", "https://b.example.com"])
-    fun `given corsAllowAll is disabled when the interceptor returns a Specific strategy then an allowed origin is reflected`(
+    fun `given corsAllowAll is enabled when the interceptor returns a Specific strategy then an allowed origin is reflected`(
         requestOrigin: String
     ) {
-        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(specificAllowedOrigins)
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
 
         assertEquals(requestOrigin, requestAllowedOrigin(requestOrigin))
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["HTTPS://A.EXAMPLE.COM", "https://evil.example.com"])
-    fun `given corsAllowAll is disabled when the interceptor returns a Specific strategy then a disallowed origin yields no 'Access-Control-Allow-Origin' header`(
+    fun `given corsAllowAll is enabled when the interceptor returns a Specific strategy then a disallowed origin yields no 'Access-Control-Allow-Origin' header`(
         requestOrigin: String
     ) {
-        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(specificAllowedOrigins)
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
 
         assertNull(requestAllowedOrigin(requestOrigin))
     }
 
-    @Test
-    fun `given corsAllowAll is enabled when the interceptor returns a restrictive strategy then it is ignored and the requested origin is reflected`() {
-        // The interceptor would only allow a different origin, but with corsAllowAll enabled (no scope override) the
-        // dispatcher uses MatchRequest and simply reflects the requested origin.
-        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(setOf("https://allowed.example.com"))
+    // --- Access-Control-Allow-Credentials (corsAllowAll enabled) ---
 
-        assertEquals("https://any.example.com", requestAllowedOrigin("https://any.example.com", disableCorsAll = false))
+    @ParameterizedTest
+    @ValueSource(strings = ["https://a.example.com", "https://b.example.com"])
+    fun `given corsAllowAll is enabled when the interceptor allows credentials for a Specific origin then the credentials header is set`(
+        requestOrigin: String
+    ) {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(true, specificAllowedOrigins)
+
+        val connection = sendGet(requestOrigin)
+
+        assertAll(
+            {
+                assertEquals(
+                    requestOrigin,
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+                )
+            },
+            {
+                assertEquals(
+                    "true",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())
+                )
+            },
+        )
     }
 
     @Test
-    fun `given corsAllowAll is disabled when the interceptor cannot decide on a strategy then no 'Access-Control-Allow-Origin' header is returned`() {
-        TestCorsInterceptor.allowedOrigin = null
+    fun `given corsAllowAll is enabled when the interceptor does not allow credentials for a Specific origin then no credentials header is set`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
 
-        assertNull(requestAllowedOrigin("https://example.com"))
+        val connection = sendGet("https://a.example.com")
+
+        assertAll(
+            {
+                assertEquals(
+                    "https://a.example.com",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+                )
+            },
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())) },
+        )
     }
 
     @Test
-    fun `given corsAllowAll is disabled when a preflight request is received then the interceptor strategy is honored`() {
-        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(specificAllowedOrigins)
+    fun `given corsAllowAll is enabled when the interceptor reflects the origin (MatchRequest) then no credentials header is set`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
 
-        val connection = sendPreflight(origin = "https://b.example.com", disableCorsAll = true)
+        val connection = sendGet("https://example.com")
 
-        assertEquals(
-            "https://b.example.com",
-            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+        assertAll(
+            {
+                assertEquals(
+                    "https://example.com",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+                )
+            },
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())) },
+        )
+    }
+
+    @Test
+    fun `given corsAllowAll is enabled when the interceptor allows any origin (Wildcard) then no credentials header is set`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
+
+        val connection = sendGet("https://example.com")
+
+        assertAll(
+            { assertEquals("*", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())) },
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())) },
+        )
+    }
+
+    @Test
+    fun `given corsAllowAll is enabled when a preflight allows credentials for a Specific origin then origin and credentials headers are set`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(true, specificAllowedOrigins)
+
+        val connection = sendPreflight(origin = "https://b.example.com")
+
+        assertAll(
+            {
+                assertEquals(
+                    "https://b.example.com",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+                )
+            },
+            {
+                assertEquals(
+                    "true",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `given corsAllowAll is enabled when a preflight does not allow credentials for a Specific origin then no credentials header is set`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
+
+        val connection = sendPreflight(origin = "https://b.example.com")
+
+        assertAll(
+            {
+                assertEquals(
+                    "https://b.example.com",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+                )
+            },
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString())) },
+        )
+    }
+
+    // --- Vary (corsAllowAll enabled) ---
+    //
+    // The `Vary` header is checked for the `Origin` token rather than exact equality, so unrelated entries (e.g.
+    // `Accept-Encoding` added by compression) do not affect the result.
+
+    @Test
+    fun `given corsAllowAll is enabled when the origin is reflected (MatchRequest) then Vary lists Origin`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
+
+        val vary = sendGet("https://example.com").getHeaderField(HttpHeaderNames.VARY.toString())
+        assertAll(
+            { assertNotNull(vary) },
+            { assertContains(vary.orEmpty(), HttpHeaderNames.ORIGIN.toString(), ignoreCase = true) },
+        )
+    }
+
+    @Test
+    fun `given corsAllowAll is enabled when a Specific origin is not allowed then Vary still lists Origin although no allow-origin header is returned`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
+
+        val connection = sendGet("https://evil.example.com")
+        val vary = connection.getHeaderField(HttpHeaderNames.VARY.toString())
+
+        assertAll(
+            { assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())) },
+            { assertNotNull(vary) },
+            { assertContains(vary.orEmpty(), HttpHeaderNames.ORIGIN.toString(), ignoreCase = true) },
         )
     }
 
@@ -181,12 +319,17 @@ class CorsTest {
     /**
      * Sends a GET request to `/system/ok` and returns the resulting `Access-Control-Allow-Origin` response header, or
      * `null` if none was set.
+     */
+    private fun requestAllowedOrigin(requestOrigin: String?, disableCorsAll: Boolean = false): String? =
+        sendGet(requestOrigin, disableCorsAll).getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+
+    /**
+     * Sends a GET request to `/system/ok` and returns the connection so that the response headers can be inspected.
      *
      * If [requestOrigin] is given, it is sent as the `Origin` header. If [disableCorsAll] is set, the request is bound
-     * (via [TestCorsScopeDetector]) to a scope which disables the global CORS handling, so that the
-     * [TestCorsInterceptor] strategy is used to resolve the allowed origin.
+     * (via [TestCorsScopeDetector]) to a scope which disables the automatic CORS handling.
      */
-    private fun requestAllowedOrigin(requestOrigin: String?, disableCorsAll: Boolean = true): String? {
+    private fun sendGet(requestOrigin: String?, disableCorsAll: Boolean = false): HttpURLConnection {
         val connection = URI("http://localhost:9999/system/ok").toURL().openConnection() as HttpURLConnection
         if (requestOrigin != null) {
             connection.addRequestProperty(HttpHeaderNames.ORIGIN.toString(), requestOrigin)
@@ -195,7 +338,7 @@ class CorsTest {
             connection.addRequestProperty(TestCorsScopeDetector.HEADER_DISABLE_CORS_ALL, "true")
         }
         connection.inputStream.close()
-        return connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+        return connection
     }
 
     /**
@@ -203,7 +346,7 @@ class CorsTest {
      * be inspected.
      *
      * If [disableCorsAll] is set, the request is bound (via [TestCorsScopeDetector]) to a scope which disables the
-     * global CORS handling, so that the [TestCorsInterceptor] strategy is used to resolve the allowed origin.
+     * automatic CORS handling.
      */
     private fun sendPreflight(
         origin: String,

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -368,6 +368,22 @@ class CorsTest {
         )
     }
 
+    @Test
+    fun `given enableCors is enabled when the route already set a Vary header then Origin is appended instead of overriding it`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
+
+        val connection = URI("http://localhost:9999/test/vary").toURL().openConnection() as HttpURLConnection
+        connection.addRequestProperty(HttpHeaderNames.ORIGIN.toString(), "https://example.com")
+        connection.inputStream.close()
+        val vary = connection.getHeaderField(HttpHeaderNames.VARY.toString())
+
+        assertAll(
+            { assertNotNull(vary) },
+            { assertContains(vary.orEmpty(), HttpHeaderNames.ACCEPT_ENCODING.toString(), ignoreCase = true) },
+            { assertContains(vary.orEmpty(), HttpHeaderNames.ORIGIN.toString(), ignoreCase = true) },
+        )
+    }
+
     companion object {
         @JvmStatic
         @Part

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -241,29 +241,6 @@ class CorsTest {
     }
 
     @Test
-    fun `given enableCors is enabled when the help system is requested then the requested origin is reflected`() {
-        // Note that the HelpDispatcher (+100) declares a `Wildcard`, but it is invoked after the ControllerDispatcher
-        // (+10), which already resolves an origin for every request carrying an `Origin` header. As only the first
-        // resolution counts, the `Wildcard` never takes effect for an actual CORS request and the requested origin is
-        // reflected instead. It only applies to requests without an `Origin` header - see the test below.
-        val connection = sendGetTo("/help", "https://example.com")
-
-        assertEquals(
-            "https://example.com",
-            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
-        )
-    }
-
-    @Test
-    fun `given enableCors is enabled when the help system is requested without an origin then the HelpDispatcher allows any origin`() {
-        // Without an `Origin` header the ControllerDispatcher skips the resolution entirely, so the HelpDispatcher is
-        // the first to resolve one and its `Wildcard` wins.
-        val connection = sendGetTo("/help", null)
-
-        assertEquals("*", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
-    }
-
-    @Test
     fun `given enableCors is enabled when an unknown path is requested then the requested origin is reflected`() {
         val connection = sendGetTo("/no-such-path", "https://example.com")
 

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -28,13 +28,13 @@ import kotlin.test.*
 /**
  * Tests the CORS handling of the web server.
  *
- * `http.corsAllowAll` acts as a master switch: only when it is enabled for the request's scope are the interceptors
+ * `http.enableCors` acts as a master switch: only when it is enabled for the request's scope are the interceptors
  * consulted to determine the allowed origin (falling back to reflecting the request's `Origin`). When it is disabled,
  * no CORS headers are emitted at all - not even if an interceptor would allow the origin.
  *
  * Note: Some tests set the restricted `Origin:` header, requiring `-Dsun.net.http.allowRestrictedHeaders=true`. This is
  * enabled centrally in [SiriusExtension.beforeAll]. Requests carrying [TestCorsScopeDetector.HEADER_DISABLE_CORS_ALL]
- * are bound to a scope which disables `corsAllowAll`.
+ * are bound to a scope which disables `enableCors`.
  */
 @ExtendWith(SiriusExtension::class)
 class CorsTest {
@@ -46,15 +46,15 @@ class CorsTest {
         TestCorsInterceptor.allowedOrigin = null
     }
 
-    // --- corsAllowAll master switch ---
+    // --- enableCors master switch ---
 
     @Test
-    fun `given corsAllowAll is enabled when a request carries an origin then it is reflected as 'Access-Control-Allow-Origin'`() {
+    fun `given enableCors is enabled when a request carries an origin then it is reflected as 'Access-Control-Allow-Origin'`() {
         assertEquals("TEST", requestAllowedOrigin("TEST"))
     }
 
     @Test
-    fun `given corsAllowAll is disabled then no CORS headers are emitted even if an interceptor would allow the origin`() {
+    fun `given enableCors is disabled then no CORS headers are emitted even if an interceptor would allow the origin`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
 
         val connection = sendGet("https://example.com", disableCorsAll = true)
@@ -68,7 +68,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when a preflight request is received then origin, methods and headers are answered`() {
+    fun `given enableCors is enabled when a preflight request is received then origin, methods and headers are answered`() {
         val connection = sendPreflight(origin = "TEST", requestHeaders = "X-Test")
 
         assertAll(
@@ -94,7 +94,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when a preflight request is received then 'Access-Control-Allow-Methods' is derived from the registered routes`() {
+    fun `given enableCors is enabled when a preflight request is received then 'Access-Control-Allow-Methods' is derived from the registered routes`() {
         // '/test/another-restricted-method' only declares GET, so the preflight must advertise exactly GET and the
         // centrally handled OPTIONS - and not the previously hard-coded "GET,PUT,POST,DELETE".
         val connection = sendPreflight(uri = "/test/another-restricted-method", origin = "TEST")
@@ -104,21 +104,21 @@ class CorsTest {
     }
 
     @Test
-    fun `given a scope overriding corsAllowAll to false when the global setting is enabled then automatic cors is disabled`() {
+    fun `given a scope overriding enableCors to false when the global setting is enabled then automatic cors is disabled`() {
         UserContext.get().setCurrentScope(configuredScope("corsDisabled", false))
-        assertFalse(TestRequest.GET("/system/ok").isCorsAllowAll)
+        assertFalse(TestRequest.GET("/system/ok").isCorsEnabled)
     }
 
     @Test
-    fun `given a scope without a corsAllowAll override when the global setting is enabled then the global setting is used`() {
+    fun `given a scope without an enableCors override when the global setting is enabled then the global setting is used`() {
         UserContext.get().setCurrentScope(configuredScope("default", null))
-        assertTrue(TestRequest.GET("/system/ok").isCorsAllowAll)
+        assertTrue(TestRequest.GET("/system/ok").isCorsEnabled)
     }
 
-    // --- Allowed origin strategies (corsAllowAll enabled) ---
+    // --- Allowed origin strategies (CORS enabled) ---
 
     @Test
-    fun `given corsAllowAll is enabled when no interceptor decides on a strategy then the requested origin is reflected as fallback`() {
+    fun `given enableCors is enabled when no interceptor decides on a strategy then the requested origin is reflected as fallback`() {
         TestCorsInterceptor.allowedOrigin = null
 
         assertEquals("https://example.com", requestAllowedOrigin("https://example.com"))
@@ -126,7 +126,7 @@ class CorsTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["https://example.com", "http://localhost:3000"])
-    fun `given corsAllowAll is enabled when the interceptor returns a Wildcard strategy then the asterisk is returned regardless of the requested origin`(
+    fun `given enableCors is enabled when the interceptor returns a Wildcard strategy then the asterisk is returned regardless of the requested origin`(
         requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
@@ -136,7 +136,7 @@ class CorsTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["https://example.com", "http://localhost:3000", "https://sub.domain.example.com:8443"])
-    fun `given corsAllowAll is enabled when the interceptor returns a MatchRequest strategy then the requested origin is reflected`(
+    fun `given enableCors is enabled when the interceptor returns a MatchRequest strategy then the requested origin is reflected`(
         requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
@@ -146,7 +146,7 @@ class CorsTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["https://a.example.com", "https://b.example.com"])
-    fun `given corsAllowAll is enabled when the interceptor returns a Specific strategy then an allowed origin is reflected`(
+    fun `given enableCors is enabled when the interceptor returns a Specific strategy then an allowed origin is reflected`(
         requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
@@ -156,7 +156,7 @@ class CorsTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["HTTPS://A.EXAMPLE.COM", "https://evil.example.com"])
-    fun `given corsAllowAll is enabled when the interceptor returns a Specific strategy then a disallowed origin yields no 'Access-Control-Allow-Origin' header`(
+    fun `given enableCors is enabled when the interceptor returns a Specific strategy then a disallowed origin yields no 'Access-Control-Allow-Origin' header`(
         requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
@@ -164,11 +164,11 @@ class CorsTest {
         assertNull(requestAllowedOrigin(requestOrigin))
     }
 
-    // --- Access-Control-Allow-Credentials (corsAllowAll enabled) ---
+    // --- Access-Control-Allow-Credentials (CORS enabled) ---
 
     @ParameterizedTest
     @ValueSource(strings = ["https://a.example.com", "https://b.example.com"])
-    fun `given corsAllowAll is enabled when the interceptor allows credentials for a Specific origin then the credentials header is set`(
+    fun `given enableCors is enabled when the interceptor allows credentials for a Specific origin then the credentials header is set`(
         requestOrigin: String
     ) {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(true, specificAllowedOrigins)
@@ -192,7 +192,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when the interceptor does not allow credentials for a Specific origin then no credentials header is set`() {
+    fun `given enableCors is enabled when the interceptor does not allow credentials for a Specific origin then no credentials header is set`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
 
         val connection = sendGet("https://a.example.com")
@@ -209,7 +209,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when the interceptor reflects the origin (MatchRequest) then no credentials header is set`() {
+    fun `given enableCors is enabled when the interceptor reflects the origin (MatchRequest) then no credentials header is set`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
 
         val connection = sendGet("https://example.com")
@@ -226,7 +226,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when the interceptor allows any origin (Wildcard) then no credentials header is set`() {
+    fun `given enableCors is enabled when the interceptor allows any origin (Wildcard) then no credentials header is set`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
 
         val connection = sendGet("https://example.com")
@@ -238,7 +238,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when a preflight allows credentials for a Specific origin then origin and credentials headers are set`() {
+    fun `given enableCors is enabled when a preflight allows credentials for a Specific origin then origin and credentials headers are set`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(true, specificAllowedOrigins)
 
         val connection = sendPreflight(origin = "https://b.example.com")
@@ -260,7 +260,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when a preflight does not allow credentials for a Specific origin then no credentials header is set`() {
+    fun `given enableCors is enabled when a preflight does not allow credentials for a Specific origin then no credentials header is set`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
 
         val connection = sendPreflight(origin = "https://b.example.com")
@@ -276,13 +276,13 @@ class CorsTest {
         )
     }
 
-    // --- Vary (corsAllowAll enabled) ---
+    // --- Vary (CORS enabled) ---
     //
     // The `Vary` header is checked for the `Origin` token rather than exact equality, so unrelated entries (e.g.
     // `Accept-Encoding` added by compression) do not affect the result.
 
     @Test
-    fun `given corsAllowAll is enabled when the origin is reflected (MatchRequest) then Vary lists Origin`() {
+    fun `given enableCors is enabled when the origin is reflected (MatchRequest) then Vary lists Origin`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
 
         val vary = sendGet("https://example.com").getHeaderField(HttpHeaderNames.VARY.toString())
@@ -293,7 +293,7 @@ class CorsTest {
     }
 
     @Test
-    fun `given corsAllowAll is enabled when a Specific origin is not allowed then Vary still lists Origin although no allow-origin header is returned`() {
+    fun `given enableCors is enabled when a Specific origin is not allowed then Vary still lists Origin although no allow-origin header is returned`() {
         TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
 
         val connection = sendGet("https://evil.example.com")
@@ -306,13 +306,13 @@ class CorsTest {
         )
     }
 
-    private fun configuredScope(scopeType: String, corsAllowAll: Boolean?): ScopeInfo =
+    private fun configuredScope(scopeType: String, enableCors: Boolean?): ScopeInfo =
         ScopeInfo(
             scopeType,
             scopeType,
             scopeType,
             null,
-            corsAllowAll?.let { value -> { ConfigFactory.parseString("http.corsAllowAll=$value") } },
+            enableCors?.let { value -> { ConfigFactory.parseString("http.enableCors=$value") } },
             null
         )
 

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -11,15 +11,23 @@ package sirius.web.http
 import com.typesafe.config.ConfigFactory
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpMethod
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 import sirius.kernel.SiriusExtension
+import sirius.web.cors.AllowedOrigin
 import sirius.web.security.ScopeInfo
 import sirius.web.security.UserContext
 import java.net.HttpURLConnection
 import java.net.URI
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -30,57 +38,134 @@ import kotlin.test.assertTrue
  */
 @ExtendWith(SiriusExtension::class)
 class CorsTest {
-    @Test
-    fun `expect 'Access-Control-Allow-Origin' for requests with 'origin'`() {
-        val connection = URI("http://localhost:9999/system/ok").toURL().openConnection() as HttpURLConnection
-        connection.addRequestProperty("Origin", "TEST")
-        connection.getInputStream().close()
-        assertEquals("TEST", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+
+    private val specificAllowedOrigins = setOf("https://a.example.com", "https://b.example.com")
+
+    @AfterEach
+    fun resetInterceptorStrategy() {
+        TestCorsInterceptor.allowedOrigin = null
     }
 
     @Test
-    fun `expect a CORS preflight request to be answered correctly`() {
-        val connection = URI("http://localhost:9999/system/ok").toURL().openConnection() as HttpURLConnection
-        connection.setRequestMethod(HttpMethod.OPTIONS.name())
-        connection.addRequestProperty("Origin", "TEST")
-        connection.addRequestProperty("Access-Control-Request-Method", "GET")
-        connection.addRequestProperty("Access-Control-Request-Headers", "X-Test")
-
-        connection.getInputStream().close()
-        assertEquals("TEST", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
-        assertTrue {
-            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString()).contains("GET")
-        }
-        assertTrue {
-            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString()).contains("X-Test")
-        }
+    fun `given corsAllowAll is enabled when a request carries an origin then it is reflected as 'Access-Control-Allow-Origin'`() {
+        assertEquals("TEST", requestAllowedOrigin("TEST", disableCorsAll = false))
     }
 
     @Test
-    fun `preflight 'Access-Control-Allow-Methods' is derived from the registered routes`() {
+    fun `given corsAllowAll is enabled when a preflight request is received then origin, methods and headers are answered`() {
+        val connection = sendPreflight(origin = "TEST", requestHeaders = "X-Test")
+
+        assertAll(
+            {
+                assertEquals(
+                    "TEST",
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+                )
+            },
+            {
+                assertContains(
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString()),
+                    "GET"
+                )
+            },
+            {
+                assertContains(
+                    connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString()),
+                    "X-Test"
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `given corsAllowAll is enabled when a preflight request is received then 'Access-Control-Allow-Methods' is derived from the registered routes`() {
         // '/test/another-restricted-method' only declares GET, so the preflight must advertise exactly GET and the
         // centrally handled OPTIONS - and not the previously hard-coded "GET,PUT,POST,DELETE".
-        val connection =
-            URI("http://localhost:9999/test/another-restricted-method").toURL().openConnection() as HttpURLConnection
-        connection.setRequestMethod(HttpMethod.OPTIONS.name())
-        connection.addRequestProperty("Origin", "TEST")
-        connection.addRequestProperty("Access-Control-Request-Method", "GET")
+        val connection = sendPreflight(uri = "/test/another-restricted-method", origin = "TEST")
 
-        connection.getInputStream().close()
         val allowedMethods = connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString())
         assertEquals("GET, OPTIONS", allowedMethods)
     }
 
     @Test
-    fun `configured scope disables automatic cors even if global setting is enabled`() {
+    fun `given a scope overriding corsAllowAll to false when the global setting is enabled then automatic cors is disabled`() {
         UserContext.get().setCurrentScope(configuredScope("corsDisabled", false))
         assertFalse(WebContext.isCorsAllowAll())
     }
 
     @Test
-    fun `global cors setting is used if scope does not define an override`() {
+    fun `given a scope without a corsAllowAll override when the global setting is enabled then the global setting is used`() {
         UserContext.get().setCurrentScope(configuredScope("default", null))
         assertTrue(WebContext.isCorsAllowAll())
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = ["https://example.com", "http://localhost:3000"])
+    fun `given corsAllowAll is disabled when the interceptor returns a Wildcard strategy then the asterisk is returned regardless of the requested origin`(
+        requestOrigin: String?
+    ) {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Wildcard()
+
+        assertEquals("*", requestAllowedOrigin(requestOrigin))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["https://example.com", "http://localhost:3000", "https://sub.domain.example.com:8443"])
+    fun `given corsAllowAll is disabled when the interceptor returns a MatchRequest strategy then the requested origin is reflected`(
+        requestOrigin: String
+    ) {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.MatchRequest()
+
+        assertEquals(requestOrigin, requestAllowedOrigin(requestOrigin))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["https://a.example.com", "https://b.example.com"])
+    fun `given corsAllowAll is disabled when the interceptor returns a Specific strategy then an allowed origin is reflected`(
+        requestOrigin: String
+    ) {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(specificAllowedOrigins)
+
+        assertEquals(requestOrigin, requestAllowedOrigin(requestOrigin))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["HTTPS://A.EXAMPLE.COM", "https://evil.example.com"])
+    fun `given corsAllowAll is disabled when the interceptor returns a Specific strategy then a disallowed origin yields no 'Access-Control-Allow-Origin' header`(
+        requestOrigin: String
+    ) {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(specificAllowedOrigins)
+
+        assertNull(requestAllowedOrigin(requestOrigin))
+    }
+
+    @Test
+    fun `given corsAllowAll is enabled when the interceptor returns a restrictive strategy then it is ignored and the requested origin is reflected`() {
+        // The interceptor would only allow a different origin, but with corsAllowAll enabled (no scope override) the
+        // dispatcher uses MatchRequest and simply reflects the requested origin.
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(setOf("https://allowed.example.com"))
+
+        assertEquals("https://any.example.com", requestAllowedOrigin("https://any.example.com", disableCorsAll = false))
+    }
+
+    @Test
+    fun `given corsAllowAll is disabled when the interceptor cannot decide on a strategy then no 'Access-Control-Allow-Origin' header is returned`() {
+        TestCorsInterceptor.allowedOrigin = null
+
+        assertNull(requestAllowedOrigin("https://example.com"))
+    }
+
+    @Test
+    fun `given corsAllowAll is disabled when a preflight request is received then the interceptor strategy is honored`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(specificAllowedOrigins)
+
+        val connection = sendPreflight(origin = "https://b.example.com", disableCorsAll = true)
+
+        assertEquals(
+            "https://b.example.com",
+            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+        )
     }
 
     private fun configuredScope(scopeType: String, corsAllowAll: Boolean?): ScopeInfo =
@@ -92,4 +177,52 @@ class CorsTest {
             corsAllowAll?.let { value -> { ConfigFactory.parseString("http.corsAllowAll=$value") } },
             null
         )
+
+    /**
+     * Sends a GET request to `/system/ok` and returns the resulting `Access-Control-Allow-Origin` response header, or
+     * `null` if none was set.
+     *
+     * If [requestOrigin] is given, it is sent as the `Origin` header. If [disableCorsAll] is set, the request is bound
+     * (via [TestCorsScopeDetector]) to a scope which disables the global CORS handling, so that the
+     * [TestCorsInterceptor] strategy is used to resolve the allowed origin.
+     */
+    private fun requestAllowedOrigin(requestOrigin: String?, disableCorsAll: Boolean = true): String? {
+        val connection = URI("http://localhost:9999/system/ok").toURL().openConnection() as HttpURLConnection
+        if (requestOrigin != null) {
+            connection.addRequestProperty(HttpHeaderNames.ORIGIN.toString(), requestOrigin)
+        }
+        if (disableCorsAll) {
+            connection.addRequestProperty(TestCorsScopeDetector.HEADER_DISABLE_CORS_ALL, "true")
+        }
+        connection.inputStream.close()
+        return connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+    }
+
+    /**
+     * Sends a CORS preflight (`OPTIONS`) request to [uri] and returns the connection, so that the response headers can
+     * be inspected.
+     *
+     * If [disableCorsAll] is set, the request is bound (via [TestCorsScopeDetector]) to a scope which disables the
+     * global CORS handling, so that the [TestCorsInterceptor] strategy is used to resolve the allowed origin.
+     */
+    private fun sendPreflight(
+        origin: String,
+        uri: String = "/system/ok",
+        requestMethod: String = HttpMethod.GET.name(),
+        requestHeaders: String? = null,
+        disableCorsAll: Boolean = false
+    ): HttpURLConnection {
+        val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
+        connection.requestMethod = HttpMethod.OPTIONS.name()
+        connection.addRequestProperty(HttpHeaderNames.ORIGIN.toString(), origin)
+        connection.addRequestProperty(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), requestMethod)
+        if (requestHeaders != null) {
+            connection.addRequestProperty(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), requestHeaders)
+        }
+        if (disableCorsAll) {
+            connection.addRequestProperty(TestCorsScopeDetector.HEADER_DISABLE_CORS_ALL, "true")
+        }
+        connection.inputStream.close()
+        return connection
+    }
 }

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -18,7 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import sirius.kernel.SiriusExtension
+import sirius.kernel.di.std.Part
 import sirius.web.cors.AllowedOrigin
+import sirius.web.cors.CorsAllowOriginResolver
+import sirius.web.cors.CorsContext
 import sirius.web.security.ScopeInfo
 import sirius.web.security.UserContext
 import java.net.HttpURLConnection
@@ -44,6 +47,53 @@ class CorsTest {
     @AfterEach
     fun resetInterceptorStrategy() {
         TestCorsInterceptor.allowedOrigin = null
+    }
+
+    // --- An origin may only be resolved once per request ---
+
+    @Test
+    fun `given an origin has already been resolved when tryResolveAndStoreOrigin is called again then the first strategy wins`() {
+        val webContext = TestRequest.GET("/system/ok")
+        webContext.addHeader(HttpHeaderNames.ORIGIN, "https://first.example.com")
+
+        corsAllowOriginResolver.tryResolveAndStoreOrigin(webContext, AllowedOrigin.MatchRequest())
+        corsAllowOriginResolver.tryResolveAndStoreOrigin(webContext, AllowedOrigin.Wildcard())
+
+        assertAll(
+            { assertEquals(AllowedOrigin.MatchRequest(), corsAllowOriginResolver.getConfiguredOrigin().orElse(null)) },
+            { assertEquals("https://first.example.com", CorsContext.get().getResolvedOrigin().orElse(null)) },
+        )
+    }
+
+    @Test
+    fun `given the first strategy resolves to no origin when tryResolveAndStoreOrigin is called again then the second strategy is still ignored`() {
+        val webContext = TestRequest.GET("/system/ok")
+        webContext.addHeader(HttpHeaderNames.ORIGIN, "https://evil.example.com")
+
+        corsAllowOriginResolver.tryResolveAndStoreOrigin(webContext, AllowedOrigin.Specific(false, specificAllowedOrigins))
+        corsAllowOriginResolver.tryResolveAndStoreOrigin(webContext, AllowedOrigin.Wildcard())
+
+        assertAll(
+            {
+                assertEquals(
+                    AllowedOrigin.Specific(false, specificAllowedOrigins),
+                    corsAllowOriginResolver.getConfiguredOrigin().orElse(null)
+                )
+            },
+            { assertNull(CorsContext.get().getResolvedOrigin().orElse(null)) },
+        )
+    }
+
+    @Test
+    fun `given an origin has already been resolved when setConfiguredOrigin or setResolvedOrigin is called directly then an exception is thrown`() {
+        val corsContext = CorsContext.get()
+        corsContext.setConfiguredOrigin(AllowedOrigin.MatchRequest())
+        corsContext.markFinalized()
+
+        assertAll(
+            { assertFailsWith<IllegalStateException> { corsContext.setConfiguredOrigin(AllowedOrigin.Wildcard()) } },
+            { assertFailsWith<IllegalStateException> { corsContext.setResolvedOrigin("https://evil.example.com") } },
+        )
     }
 
     // --- enableCors master switch ---
@@ -304,6 +354,12 @@ class CorsTest {
             { assertNotNull(vary) },
             { assertContains(vary.orEmpty(), HttpHeaderNames.ORIGIN.toString(), ignoreCase = true) },
         )
+    }
+
+    companion object {
+        @JvmStatic
+        @Part
+        private lateinit var corsAllowOriginResolver: CorsAllowOriginResolver
     }
 
     private fun configuredScope(scopeType: String, enableCors: Boolean?): ScopeInfo =

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -215,6 +215,97 @@ class CorsTest {
         assertNull(requestAllowedOrigin(requestOrigin))
     }
 
+    // --- CORS handling of the non-controller dispatchers ---
+    //
+    // Dispatchers are invoked ascending by priority: AssetsDispatcher (-10), ServiceDispatcher (-5),
+    // ControllerDispatcher (+10), HelpDispatcher (+100) and finally DefaultDispatcher (999). Since an origin may only
+    // be resolved once per request, the first dispatcher which resolves one determines the outcome for the whole
+    // request - the interceptors are only consulted if `ControllerDispatcher` gets there first.
+
+    @Test
+    fun `given enableCors is enabled when an asset is requested then the AssetsDispatcher allows any origin`() {
+        val connection = sendGetTo("/assets/test.png", "https://example.com")
+
+        assertEquals("*", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+    }
+
+    @Test
+    fun `given an interceptor restricting the origin when an asset is requested then the AssetsDispatcher still allows any origin`() {
+        // The AssetsDispatcher runs before the ControllerDispatcher, so its `Wildcard` is resolved first and wins.
+        // Assets are public static files, hence they are deliberately not subject to the interceptors.
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
+
+        val connection = sendGetTo("/assets/test.png", "https://untrusted.example.com")
+
+        assertEquals("*", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+    }
+
+    @Test
+    fun `given enableCors is enabled when the help system is requested then the requested origin is reflected`() {
+        // Note that the HelpDispatcher (+100) declares a `Wildcard`, but it is invoked after the ControllerDispatcher
+        // (+10), which already resolves an origin for every request carrying an `Origin` header. As only the first
+        // resolution counts, the `Wildcard` never takes effect for an actual CORS request and the requested origin is
+        // reflected instead. It only applies to requests without an `Origin` header - see the test below.
+        val connection = sendGetTo("/help", "https://example.com")
+
+        assertEquals(
+            "https://example.com",
+            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+        )
+    }
+
+    @Test
+    fun `given enableCors is enabled when the help system is requested without an origin then the HelpDispatcher allows any origin`() {
+        // Without an `Origin` header the ControllerDispatcher skips the resolution entirely, so the HelpDispatcher is
+        // the first to resolve one and its `Wildcard` wins.
+        val connection = sendGetTo("/help", null)
+
+        assertEquals("*", connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+    }
+
+    @Test
+    fun `given enableCors is enabled when an unknown path is requested then the requested origin is reflected`() {
+        val connection = sendGetTo("/no-such-path", "https://example.com")
+
+        assertEquals(
+            "https://example.com",
+            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+        )
+    }
+
+    @Test
+    fun `given an interceptor restricting the origin when an unknown path is requested then the DefaultDispatcher does not reflect a disallowed origin`() {
+        // The ControllerDispatcher resolves the interceptor's strategy before falling through to the DefaultDispatcher,
+        // so the latter must not be able to replace it with its own `MatchRequest`.
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
+
+        val connection = sendGetTo("/no-such-path", "https://untrusted.example.com")
+
+        assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+    }
+
+    @Test
+    fun `given enableCors is enabled when a service is requested then the requested origin is reflected`() {
+        val connection = sendGetTo("/service/json/no-such-service", "https://example.com")
+
+        assertEquals(
+            "https://example.com",
+            connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+        )
+    }
+
+    @Test
+    fun `given an interceptor restricting the origin when an unknown service is requested then a disallowed origin is not reflected`() {
+        // The ServiceDispatcher only resolves an origin once it actually handles the request. For an unknown service
+        // it continues without resolving, so the ControllerDispatcher still gets to apply the interceptor's strategy
+        // instead of the hardcoded `MatchRequest`.
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Specific(false, specificAllowedOrigins)
+
+        val connection = sendGetTo("/service/json/no-such-service", "https://untrusted.example.com")
+
+        assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+    }
+
     // --- Access-Control-Allow-Credentials (CORS enabled) ---
 
     @ParameterizedTest
@@ -442,6 +533,22 @@ class CorsTest {
      */
     private fun requestAllowedOrigin(requestOrigin: String?, disableCorsAll: Boolean = false): String? =
         sendGet(requestOrigin, disableCorsAll).getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())
+
+    /**
+     * Sends a GET request to [uri], sending [requestOrigin] as `Origin` header if given, and returns the connection so
+     * that the response headers can be inspected.
+     *
+     * In contrast to [sendGet] this also tolerates error responses (e.g. the 404 produced for an unknown path), which
+     * expose their body via `errorStream` instead of `inputStream`.
+     */
+    private fun sendGetTo(uri: String, requestOrigin: String?): HttpURLConnection {
+        val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
+        if (requestOrigin != null) {
+            connection.addRequestProperty(HttpHeaderNames.ORIGIN.toString(), requestOrigin)
+        }
+        runCatching { connection.inputStream.close() }.onFailure { connection.errorStream?.close() }
+        return connection
+    }
 
     /**
      * Sends a GET request to `/system/ok` and returns the connection so that the response headers can be inspected.

--- a/src/test/resources/component-test-web.conf
+++ b/src/test/resources/component-test-web.conf
@@ -13,7 +13,7 @@ http {
     sessionSecret = "TEST"
 
     # Enable automatic CORS handling for the integration tests in CorsTest.
-    corsAllowAll = true
+    enableCors = true
 }
 
 security {

--- a/src/test/resources/component-test-web.conf
+++ b/src/test/resources/component-test-web.conf
@@ -1,6 +1,7 @@
 sirius.frameworks {
-    # Other libraries using this test-jar do not need our test implementation...
+    # Other libraries using this test-jar do not need our test implementations...
     web.test-firewall: false
+    web.test-cors: false
 }
 
 # Test-Setup

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -1,5 +1,6 @@
 sirius.frameworks {
     web.test-firewall: true
+    web.test-cors: true
 }
 
 sirius.customizations = ["customized"]


### PR DESCRIPTION
### Description

This PR refactors CORS `Access-Control-Allow-Origin` handling out of Response into a dedicated, extensible mechanism, and lets Interceptor implementations decide which origins are allowed on a per-route basis instead of always mirroring the request's Origin header.

Previously, CORS origin handling was hardcoded in `Response` and only ever mirrored the request's `Origin` header when `http.firewall.corsAllowAll` was enabled - there was no way for a controller/route to have a different, narrower CORS policy. This introduces a pluggable strategy so interceptors can restrict allowed origins per route (e.g. an allow-list) without touching core response/dispatch code.

In controller-based routes dispatched via `ControllerDispatcher`, the CORS origin behavior can now be centrally configured via `Interceptor.determineAllowedCorsOrigin(WebContext, Collection<Route>)` and the `AllowedOrigin` abstraction. In all other dispatchers, the header can either be set manually or, recommended, via `CorsAllowOriginResolver`, which respects the CORS cofnguration and is used by `ControllerDisaptcher` as well.

> [!CAUTION]
> __Breaking config change affecting CORS handling:__
> The config key`http.corsAllowAll` has been renamed to `http.enableCors` to better reflect the updated behavior.
> If you previously enabled CORS handling via the flag, your yonfig will need to be adjusted or CORS handling will be disabled by default.

> [!WARNING]
> __Also breaking:__
> `WebContext.isCorsAllowAll()` is no longer `static` and has been renamed to `webContext.isCorsEnabled()`.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1241](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1241)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
