### PR TITLE
Stops logging a stack trace for every abandoned connection

### DIFF
--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -520,8 +520,8 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
         bootstrap.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
         // At mose have 128 connections waiting to be "connected" - drop everything else...
         bootstrap.option(ChannelOption.SO_BACKLOG, 128);
-        // Send a KEEPALIVE packet every 2h and expect and ACK on the TCP layer
-        bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
+        // Note that SO_KEEPALIVE is not set here as a child option, but in WebServerInitializer, which is able to
+        // handle a connection the client has already reset - see the comment there
         bootstrap.group(eventLoop);
         bootstrap.channel(NioServerSocketChannel.class);
         bootstrap.childHandler(globalContext.wire(initializer));

--- a/src/main/java/sirius/web/http/WebServerInitializer.java
+++ b/src/main/java/sirius/web/http/WebServerInitializer.java
@@ -39,10 +39,10 @@ class WebServerInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     @Override
-    public void initChannel(SocketChannel ch) throws Exception {
-        enableKeepAlive(ch);
+    public void initChannel(SocketChannel channel) throws Exception {
+        enableKeepAlive(channel);
 
-        ChannelPipeline pipeline = ch.pipeline();
+        ChannelPipeline pipeline = channel.pipeline();
 
         pipeline.addFirst("lowlevel", LowLevelHandler.INSTANCE);
         pipeline.addLast(new HttpServerCodec());
@@ -72,14 +72,14 @@ class WebServerInitializer extends ChannelInitializer<SocketChannel> {
      * option here means the failure can be recognised for what it is, while a healthy connection is set up exactly as
      * before.
      *
-     * @param ch the accepted channel
+     * @param channel the accepted channel
      */
-    private void enableKeepAlive(SocketChannel ch) {
+    private void enableKeepAlive(SocketChannel channel) {
         try {
-            ch.config().setKeepAlive(true);
+            channel.config().setKeepAlive(true);
         } catch (ChannelException exception) {
             Exceptions.ignore(exception);
-            WebServer.LOG.FINE("Cannot enable TCP keep-alive for %s, the connection is already gone", ch);
+            WebServer.LOG.FINE("Cannot enable TCP keep-alive for %s, the connection is already gone", channel);
         }
     }
 

--- a/src/main/java/sirius/web/http/WebServerInitializer.java
+++ b/src/main/java/sirius/web/http/WebServerInitializer.java
@@ -8,6 +8,7 @@
 
 package sirius.web.http;
 
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
@@ -15,6 +16,7 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.timeout.IdleStateHandler;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.di.std.Part;
+import sirius.kernel.health.Exceptions;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -38,6 +40,8 @@ class WebServerInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
+        enableKeepAlive(ch);
+
         ChannelPipeline pipeline = ch.pipeline();
 
         pipeline.addFirst("lowlevel", LowLevelHandler.INSTANCE);
@@ -52,6 +56,31 @@ class WebServerInitializer extends ChannelInitializer<SocketChannel> {
             pipeline.addLast("websockethandler", new WebsocketHandler(websocketDispatcher));
         }
         pipeline.addLast("handler", new WebServerHandler(isSSL()));
+    }
+
+    /**
+     * Asks the operating system to send a KEEPALIVE packet every 2h and to expect an ACK on the TCP layer.
+     * <p>
+     * This is done here rather than as a child option of the bootstrap, because a child option is applied to every
+     * accepted socket, including one the client has already reset in the meantime. Setting an option on such a socket
+     * fails with <tt>EINVAL</tt> on some platforms (macOS among them), and netty reports that with two warnings and a
+     * full stack trace before closing the channel.
+     * <p>
+     * That is not a rare condition: a client resolving a dual-stack host opens a connection over IPv4 and IPv6 at once
+     * and abandons the loser as soon as the other one is established (RFC 8305), which resets it. Every such connect
+     * would log a stack trace about a connection that no longer exists and never carried a request. Applying the
+     * option here means the failure can be recognised for what it is, while a healthy connection is set up exactly as
+     * before.
+     *
+     * @param ch the accepted channel
+     */
+    private void enableKeepAlive(SocketChannel ch) {
+        try {
+            ch.config().setKeepAlive(true);
+        } catch (ChannelException exception) {
+            Exceptions.ignore(exception);
+            WebServer.LOG.FINE("Cannot enable TCP keep-alive for %s, the connection is already gone", ch);
+        }
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebServerInitializer.java
+++ b/src/main/java/sirius/web/http/WebServerInitializer.java
@@ -59,7 +59,13 @@ class WebServerInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     /**
-     * Asks the operating system to send a KEEPALIVE packet every 2h and to expect an ACK on the TCP layer.
+     * Enables TCP keep-alive, so that a connection whose peer has silently gone away is eventually recognised as dead.
+     * <p>
+     * When the probing starts, how often it repeats and how many unanswered probes end the connection are the
+     * operating system's to decide — <tt>net.ipv4.tcp_keepalive_time</tt> and its neighbours on Linux, the
+     * <tt>net.inet.tcp.keepidle</tt> family on macOS — and this flag cannot influence any of it. The defaults are
+     * measured in hours, so this is a backstop against half-open connections rather than a liveness check;
+     * <tt>http.idleTimeout</tt> is what notices an idle client soon enough to act on it.
      * <p>
      * This is done here rather than as a child option of the bootstrap, because a child option is applied to every
      * accepted socket, including one the client has already reset in the meantime. Setting an option on such a socket


### PR DESCRIPTION
### Description

`SO_KEEPALIVE` was applied as a child option of the bootstrap. Netty applies child options to **every** accepted
socket before registering it — including one the client has already reset in the meantime. Setting an option on
such a socket fails with `EINVAL` on macOS, and netty answers with two warnings and a full stack trace before
closing the channel:

```
WARNING Failed to set channel option 'SO_KEEPALIVE' with value 'true' for channel
        '[id: 0x05600ce4, L:/[0:0:0:0:0:0:7f00:1]:9000 - R:/0.0.0.0:0]' ...
        Caused by: java.net.SocketException: Invalid argument
WARNING Failed to register an accepted channel: [id: 0x05600ce4, ... ! R:/0.0.0.0:0]
```

The addresses give it away: `0.0.0.0:0` is not a peer, and that local address is the IPv4-compatible form of
127.0.0.1. Once the socket is reset, `getsockname`/`getpeername` return junk. There is no connection there.

**This is not a corner case.** A client resolving a dual-stack host opens the connection over IPv4 and IPv6 at
once and abandons the loser as soon as the other is established (RFC 8305), which resets it. On a developer
machine, where `localhost` has both, that is a stack trace per connect about a connection which never carried a
request and was never in trouble.

Applying the option in `WebServerInitializer` instead puts it where the failure can be told apart from a real
one: a healthy connection is set up exactly as before, a dead one is noted at `FINE` and left to be closed. The
plain and the TLS pipeline share it, as `SSLWebServerInitializer` derives from this one.

**Verified with a standalone reproduction** — a netty server configured the way `WebServer` configures it, plus
two clients:

| client | before | after |
|---|---|---|
| normal close (FIN) | accepted, `keepAlive=true` | accepted, `keepAlive=true` |
| close with `SO_LINGER 0` (RST) | both warnings + stack traces | silent |

**Not covered by a test.** The failure happens in netty's accept path, below where `TestRequest` operates, and
neither the socket option nor the log line is observable from a client. Reproducing it needs a real server
socket and a client that resets rather than closes; I am happy to add that as a nightly test if you would
prefer one.

### Additional Notes

- No ticket — noticed while running a local server against a client that opens dual-stack connections.

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
