### PR TITLE
Repairs the Wondergem image upload (MIO-6562)

### DIFF
--- a/src/main/resources/default/taglib/w/fileUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/fileUpload.html.pasta
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     $(document).ready(function() {
         $('.@name').each(function (index) {
-            fileUpload('@uploadUrl',
+            fileUpload('<i:raw>@escapeJS(uploadUrl)</i:raw>',
                 this,
                 {CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'},
                 <i:raw>@allowedExtensions</i:raw>,

--- a/src/main/resources/default/taglib/w/fileUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/fileUpload.html.pasta
@@ -11,7 +11,7 @@
         $('.@name').each(function (index) {
             fileUpload('<i:raw>@escapeJS(uploadUrl)</i:raw>',
                 this,
-                {CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'},
+                {CSRFToken: '@part(CSRFHelper.class).getCSRFToken()'},
                 <i:raw>@allowedExtensions</i:raw>,
                 @maxParallelConnections);
         });

--- a/src/main/resources/default/taglib/w/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/imageUpload.html.pasta
@@ -17,7 +17,7 @@
                 '@imageUrl',
                 <i:raw>@allowedExtensions</i:raw>,
                 @singleFile,
-                {CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'});
+                {CSRFToken: '@part(CSRFHelper.class).getCSRFToken()'});
         });
     });
 </script>

--- a/src/main/resources/default/taglib/w/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/imageUpload.html.pasta
@@ -15,9 +15,9 @@
                 this,
                 '@previewUrl',
                 '@imageUrl',
-                 <i:raw>@allowedExtensions</i:raw>,
-                @singleFile
-        );
+                <i:raw>@allowedExtensions</i:raw>,
+                @singleFile,
+                {CSRFToken: '@part(sirius.web.http.CSRFHelper.class).getCSRFToken()'});
         });
     });
 </script>

--- a/src/main/resources/default/taglib/w/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/imageUpload.html.pasta
@@ -11,7 +11,7 @@
 <script type="text/javascript">
     $(document).ready(function() {
         $('.@name').each(function (index) {
-            imageUpload('@uploadUrl',
+            imageUpload('<i:raw>@escapeJS(uploadUrl)</i:raw>',
                 this,
                 '@previewUrl',
                 '@imageUrl',

--- a/src/main/resources/default/taglib/w/imageUpload.html.pasta
+++ b/src/main/resources/default/taglib/w/imageUpload.html.pasta
@@ -2,7 +2,7 @@
 <i:arg type="String" name="uploadUrl" />
 <i:arg type="String" name="imageUrl" default="" />
 <i:arg type="String" name="previewUrl" default="@imageUrl" />
-<i:arg type="String" name="allowedExtensions" default="'[]'" />
+<i:arg type="String" name="allowedExtensions" default="[]" />
 <i:arg type="boolean" name="singleFile" default="false" />
 
 <i:pragma name="description" value="Renders an image upload within a Wondergem template" />

--- a/src/main/resources/default/templates/wondergem/page-script.html.pasta
+++ b/src/main/resources/default/templates/wondergem/page-script.html.pasta
@@ -148,11 +148,12 @@
         return params;
     }
 
-    function imageUpload(url, target, defaultPreview, defaultImage, allowedExtensions, singleFile) {
+    function imageUpload(url, target, defaultPreview, defaultImage, allowedExtensions, singleFile, params) {
         var container = target;
         new qq.FileUploader({
             element: target,
             action: url,
+            params: params || {},
             multiple: !singleFile,
             debug: false,
             onComplete: function (cmp_id, fileName, responseJSON) {

--- a/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.pasta.tagliatelle
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.di.std.Part
+import sirius.pasta.noodle.compiler.SourceCodeInfo
+import sirius.pasta.tagliatelle.compiler.TemplateCompilationContext
+import sirius.pasta.tagliatelle.compiler.TemplateCompiler
+import sirius.web.http.CSRFHelper
+import kotlin.test.assertTrue
+
+/**
+ * Ensures that the Wondergem upload taglibs hand the CSRF token to the uploader.
+ *
+ * As every upload is posted, it is subject to CSRF validation and would be rejected with a 403 without the token.
+ */
+@ExtendWith(SiriusExtension::class)
+class WondergemUploadTest {
+
+    @Test
+    fun `w imageUpload passes the CSRF token to the uploader`() {
+        val token = csrfHelper.csrfToken
+
+        assertTrue { render("<w:imageUpload uploadUrl=\"/test/upload\"/>").contains("CSRFToken: '$token'") }
+    }
+
+    @Test
+    fun `w fileUpload passes the CSRF token to the uploader`() {
+        val token = csrfHelper.csrfToken
+
+        assertTrue { render("<w:fileUpload uploadUrl=\"/test/upload\"/>").contains("CSRFToken: '$token'") }
+    }
+
+    private fun render(source: String): String {
+        val context = TemplateCompilationContext(
+                Template("test.html.pasta", null),
+                SourceCodeInfo.forInlineCode(source),
+                null
+        )
+        val errors = TemplateCompiler(context).compile()
+
+        assertTrue { errors.isEmpty() }
+
+        return context.template.renderToString()
+    }
+
+    companion object {
+        @JvmStatic
+        @Part
+        private lateinit var csrfHelper: CSRFHelper
+    }
+}

--- a/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
@@ -16,6 +16,7 @@ import sirius.pasta.noodle.compiler.SourceCodeInfo
 import sirius.pasta.tagliatelle.compiler.TemplateCompilationContext
 import sirius.pasta.tagliatelle.compiler.TemplateCompiler
 import sirius.web.http.CSRFHelper
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -38,6 +39,12 @@ class WondergemUploadTest {
         val token = csrfHelper.csrfToken
 
         assertTrue { render("<w:fileUpload uploadUrl=\"/test/upload\"/>").contains("CSRFToken: '$token'") }
+    }
+
+    @Test
+    fun `w imageUpload accepts any extension by default`() {
+        // A quoted [] would reach the uploader as a two element extension list which rejects every file
+        assertFalse { render("<w:imageUpload uploadUrl=\"/test/upload\"/>").contains("'[]'") }
     }
 
     private fun render(source: String): String {

--- a/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
@@ -16,6 +16,7 @@ import sirius.pasta.noodle.compiler.SourceCodeInfo
 import sirius.pasta.tagliatelle.compiler.TemplateCompilationContext
 import sirius.pasta.tagliatelle.compiler.TemplateCompiler
 import sirius.web.http.CSRFHelper
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -47,6 +48,27 @@ class WondergemUploadTest {
         assertFalse { render("<w:imageUpload uploadUrl=\"/test/upload\"/>").contains("'[]'") }
     }
 
+    @Test
+    fun `w imageUpload keeps every query parameter of the upload URL`() {
+        val rendered = render("<w:imageUpload uploadUrl=\"/test/upload?a=1&b=2\"/>")
+
+        assertEquals("/test/upload?a=1&b=2", uploadUrlPassedTo("imageUpload", rendered))
+    }
+
+    @Test
+    fun `w fileUpload keeps every query parameter of the upload URL`() {
+        val rendered = render("<w:fileUpload uploadUrl=\"/test/upload?a=1&b=2\"/>")
+
+        assertEquals("/test/upload?a=1&b=2", uploadUrlPassedTo("fileUpload", rendered))
+    }
+
+    @Test
+    fun `w fileUpload keeps an apostrophe within the upload URL`() {
+        val rendered = render("<w:fileUpload uploadUrl=\"/test/upload?name=O'Brien&a=1\"/>")
+
+        assertEquals("/test/upload?name=O'Brien&a=1", uploadUrlPassedTo("fileUpload", rendered))
+    }
+
     private fun render(source: String): String {
         val context = TemplateCompilationContext(
                 Template("test.html.pasta", null),
@@ -58,6 +80,19 @@ class WondergemUploadTest {
         assertTrue { errors.isEmpty() }
 
         return context.template.renderToString()
+    }
+
+    /**
+     * Reads back the URL the given uploader was invoked with.
+     * <p>
+     * The JavaScript string escapes are undone so that the result can be compared to the URL which was handed to
+     * the taglib. This deliberately does not assert how the value is escaped, only that it survives unharmed.
+     */
+    private fun uploadUrlPassedTo(uploader: String, rendered: String): String {
+        return rendered.substringAfter("$uploader('")
+                       .substringBefore("',")
+                       .replace("\\/", "/")
+                       .replace("\\'", "'")
     }
 
     companion object {


### PR DESCRIPTION
### Description

Repairs the Wondergem `<w:imageUpload>` tag, which has been unable to upload anything at all. Three defects, one commit each:

**1. No CSRF token was sent.** `imageUpload()` passed no parameters to the underlying `qq.FileUploader`, so its POST reached the server without a token. Since CSRF validation became the default for every POST (SIRI-1216), every `<w:imageUpload>` was answered with a `403`. The helper now takes an optional `params` object — exactly as `fileUpload()` already did — and the taglib supplies the token through it. This is the defect behind the reported customer issue.

**2. The default extension filter rejected every file.** `allowedExtensions` defaulted to the four character string `'[]'`, so the uploader received the JavaScript *string* `"[]"` rather than an empty array. Its extension check then matched each file against the two characters `[` and `]`, refused all of them, and threw `allowed.join is not a function` while assembling the error message. Dropping the inner quotes yields an empty array literal, matching what `<w:fileUpload>` has always used. Only callers that omit the argument were affected — every current consumer passes it explicitly.

**3. The upload URL was escaped for the wrong context.** Both upload taglibs emit the URL into a JavaScript string literal, but the value was escaped by the XML escaper an HTML template renders with. Every character that escaper touches is destroyed on the way to the server — `?name=O'Brien` arrives as a lone `name=O`, because the `&` opening the entity restarts query string parsing. An `&` of our own currently survives, but only by accident: netty's `QueryStringDecoder` splits on `;` as well, so `&amp;a=b` degrades into a junk empty `amp` parameter next to an intact `a=b`. That is non-standard and being phased out, so it is nothing to rely upon. Escaping for the surrounding JavaScript context keeps the URL intact either way, and additionally guards against a stray quote or a `</script>` breaking out of the literal.

`previewUrl` and `imageUrl` are deliberately left untouched in (3): those end up inside an HTML attribute assembled by the uploader, where the entity is what the browser expects and decodes for itself.

No breaking changes. `imageUpload()` gained a trailing optional argument, so existing six-argument callers keep working unchanged. No consumer in our repositories writes `&amp;` into an `uploadUrl`, and apart from one memoio template every `w:` consumer has zero or one query parameter, where (3) is a no-op.

### Verification

`WondergemUploadTest` pins all three behaviours for both upload taglibs; every assertion was confirmed to fail when its own fix is reverted. The URL assertions read the emitted value back and undo the JavaScript escapes, so they pin the URL that actually reaches the uploader rather than a particular escaping scheme. Full suite green.

The emitted JavaScript was also evaluated in a JS engine to confirm the literal behaves as intended: `'\/test\/upload?a=1&b=2'` evaluates to `/test/upload?a=1&b=2`, an embedded apostrophe round-trips, and `</script>` never appears unescaped in the source.

Beyond that, the change was verified end to end against a locally running memoio, using an artifact built from tag `107.0.5` plus these three commits, so the delta under test was exactly this PR:

| Upload | Without the token | With the token the fixed taglib emits |
| --- | --- | --- |
| `/account/avatar` (user picture) | `403` | `200`, avatar stored |
| `/company/:1/avatar` (company picture) | `403` | `200`, avatar stored |
| `/company/mail-config/header-image` | `403` | `200`, image stored |

The `403` reproduces the reported customer symptom. `<w:fileUpload>` pages were re-checked for regressions and still emit their token and their full URL unchanged.

### Additional Notes

- This PR fixes or works on following ticket(s): [MIO-6562](https://scireum.myjetbrains.com/youtrack/issue/MIO-6562)
- Follow-up for consumers: memoio needs the resulting release to pick the fix up; its three `<w:imageUpload>` call sites need no change of their own.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
