### PR TITLE
Extends WebContext session handling to enable hook-ins of server-side sessions

### DIFF
--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -654,10 +654,16 @@ public class ControllerDispatcher implements WebDispatcher {
     @SuppressWarnings("java:S1067")
     @Explain("The check is complex, but that is the nature of having multiple skip options and call cases.")
     private void validateCsrfTokenUnlessSkipped(WebContext webContext, Route route) {
+        // A request whose session is managed by a ServerSessionStorage cannot be victim of CSRF: the session
+        // cookie is entirely ignored for such requests, so there is no ambient cookie authority to abuse - the
+        // identity can only come from explicitly presented credentials (e.g. a bearer token). Note that this
+        // condition is deliberately evaluated after the cheap method/exemption checks, as it forces the (lazy)
+        // session initialization - safe methods like GET must not pay for it.
         if (!skipCsrfTokens
             && !route.isSkipCsrfValidation()
             && isCsrfValidatedMethod(webContext)
             && !isExemptFromCsrfValidation(route)
+            && !webContext.isServerSessionActive()
             && !csrfHelper.hasValidCsrfToken(webContext)) {
             throw Exceptions.createHandled()
                             .hint(Controller.HTTP_STATUS, HttpResponseStatus.FORBIDDEN.code())

--- a/src/main/java/sirius/web/http/ServerSessionStorage.java
+++ b/src/main/java/sirius/web/http/ServerSessionStorage.java
@@ -8,6 +8,8 @@
 
 package sirius.web.http;
 
+import sirius.kernel.di.std.AutoRegister;
+
 import java.util.Map;
 
 /**
@@ -25,6 +27,7 @@ import java.util.Map;
  * (which can carry a session id) instead of a session cookie. Implementations are registered via
  * {@link sirius.kernel.di.std.Register} against this interface.
  */
+@AutoRegister
 public interface ServerSessionStorage {
 
     /**

--- a/src/main/java/sirius/web/http/ServerSessionStorage.java
+++ b/src/main/java/sirius/web/http/ServerSessionStorage.java
@@ -1,0 +1,64 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import java.util.Map;
+
+/**
+ * Permits an application to store the client session of selected requests on the server instead of transporting
+ * it via the session cookie.
+ * <p>
+ * If an implementation is registered and claims responsibility for a request (via
+ * {@link #isResponsibleFor(WebContext)}), the {@link WebContext} will neither read nor write the session cookie
+ * (nor the session pinning cookie) for that request. Instead, the session values are loaded once (lazily, on the
+ * first session access) and persisted back at response time if they were modified. If no implementation is
+ * registered, or it does not claim responsibility, the built-in cookie based client session remains fully in
+ * charge.
+ * <p>
+ * This is commonly used to provide a server side session for requests which are authenticated via a bearer token
+ * (which can carry a session id) instead of a session cookie. Implementations are registered via
+ * {@link sirius.kernel.di.std.Register} against this interface.
+ */
+public interface ServerSessionStorage {
+
+    /**
+     * Determines if this storage manages the session of the given request.
+     * <p>
+     * This is invoked at most once per request, lazily, when the session is first accessed. Implementations should
+     * be cheap for non-matching requests (e.g. check for the presence of a header first) and may cache expensive
+     * intermediate results (e.g. a validated token) as request attributes.
+     *
+     * @param webContext the request to check
+     * @return <tt>true</tt> if the session of this request is managed by this storage, <tt>false</tt> otherwise
+     */
+    boolean isResponsibleFor(WebContext webContext);
+
+    /**
+     * Loads the stored session values for the given request.
+     * <p>
+     * Returning an empty map starts a fresh session. If an exception is thrown, the framework falls back to an
+     * empty session and suppresses persistence for this request, so that a transient error cannot overwrite the
+     * stored session with an empty one.
+     *
+     * @param webContext the request to load the session for
+     * @return the previously stored session values or an empty map if there is no stored session yet
+     */
+    Map<String, String> loadSession(WebContext webContext);
+
+    /**
+     * Persists the given session values for the given request.
+     * <p>
+     * This is only invoked at response time, if the session was modified and the response is not cacheable. An
+     * empty map signals a cleared session (e.g. a logout) and should delete the stored session.
+     *
+     * @param webContext the request to persist the session for
+     * @param session    the session values to persist
+     */
+    void persistSession(WebContext webContext, Map<String, String> session);
+}

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -202,7 +202,9 @@ public class WebContext implements SubContext {
 
     /**
      * Contains decoded data of the client session - this is sent back and forth using a cookie. This data
-     * will not be stored on the server.
+     * will not be stored on the server - unless a {@link ServerSessionStorage} claims responsibility for the
+     * request, in which case the data is loaded from and persisted to that storage and no session cookie is used
+     * at all.
      */
     private Map<String, String> session;
 
@@ -226,6 +228,18 @@ public class WebContext implements SubContext {
      * encrypted format, even if it was not otherwise modified during this request.
      */
     private volatile boolean sessionUpgradeRequired;
+
+    /**
+     * Determines if the session of this request is managed by the registered {@link ServerSessionStorage} rather
+     * than by the session cookie.
+     */
+    private volatile boolean serverSessionActive;
+
+    /**
+     * Set if the {@link ServerSessionStorage} failed to load the session. In this case the request proceeds with an
+     * empty session, but persisting is suppressed so that a transient error cannot overwrite the stored session.
+     */
+    private volatile boolean serverSessionLoadFailed;
 
     /**
      * Specifies the micro-timing key used for this request. If null, no micro-timing will be recorded.
@@ -429,6 +443,10 @@ public class WebContext implements SubContext {
     @Part
     @Nullable
     private static SessionSecretComputer sessionSecretComputer;
+
+    @Part
+    @Nullable
+    private static ServerSessionStorage serverSessionStorage;
 
     @Part
     private static CSRFHelper csrfHelper;
@@ -858,9 +876,15 @@ public class WebContext implements SubContext {
     }
 
     /*
-     * Loads and parses the client session (cookie)
+     * Loads the session - either from the registered server session storage (if it claims responsibility for
+     * this request) or by parsing the client session cookie.
      */
     private void initSession() {
+        if (serverSessionStorage != null && isServerSessionResponsible()) {
+            initServerSession();
+            return;
+        }
+
         String encodedSession = getCookieValue(sessionCookieName);
         if (Strings.isFilled(encodedSession)) {
             session = decodeSession(encodedSession);
@@ -873,6 +897,52 @@ public class WebContext implements SubContext {
         } else {
             session = new HashMap<>();
         }
+    }
+
+    /*
+     * Determines if the registered server session storage claims this request. A throwing storage is treated as
+     * not responsible, so that e.g. a transient database error during its token checks degrades the request to
+     * the (for token clients effectively empty) cookie session instead of failing it.
+     */
+    private boolean isServerSessionResponsible() {
+        try {
+            return serverSessionStorage.isResponsibleFor(this);
+        } catch (Exception exception) {
+            Exceptions.handle(WebServer.LOG, exception);
+            return false;
+        }
+    }
+
+    /*
+     * Loads the session from the registered server session storage. Note that neither the session cookie nor the
+     * session pinning are involved for such requests - both remain cookie-only concerns.
+     */
+    private void initServerSession() {
+        serverSessionActive = true;
+        try {
+            session = new HashMap<>(serverSessionStorage.loadSession(this));
+        } catch (Exception exception) {
+            Exceptions.handle(WebServer.LOG, exception);
+            session = new HashMap<>();
+            serverSessionLoadFailed = true;
+        }
+    }
+
+    /**
+     * Determines if the session of this request is managed by a {@link ServerSessionStorage} rather than by the
+     * session cookie.
+     * <p>
+     * Note that this initializes the session if it hasn't been accessed yet, so that the decision is made
+     * deterministically (e.g. before a CSRF check consults this method).
+     *
+     * @return <tt>true</tt> if the session of this request is stored on the server, <tt>false</tt> if the
+     * session cookie is in charge
+     */
+    public boolean isServerSessionActive() {
+        if (session == null) {
+            initSession();
+        }
+        return serverSessionActive;
     }
 
     /**
@@ -1060,6 +1130,9 @@ public class WebContext implements SubContext {
      * Sets an explicit session cookie TTL (time to live).
      * <p>
      * If a non-null value is given, this will overwrite {@link #defaultSessionCookieTTL} for this request/response.
+     * <p>
+     * Note that this has no effect if the session of this request is managed by a {@link ServerSessionStorage},
+     * as no session cookie is emitted at all in this case - the storage implementation owns the session lifetime.
      *
      * @param customSessionCookieTTL the new TTL for the client session cookie.
      */
@@ -1127,7 +1200,10 @@ public class WebContext implements SubContext {
      */
     public void clearSession() {
         if (session == null) {
-            session = new HashMap<>();
+            // Properly initialize the session (which may claim a server session) before clearing it - otherwise
+            // a server side session would neither be claimed nor deleted if clearing is the first session access
+            // of the request.
+            initSession();
         }
 
         session.clear();
@@ -1523,6 +1599,11 @@ public class WebContext implements SubContext {
      * @return a list of all cookies to be sent to the client.
      */
     protected Collection<Cookie> getOutCookies(boolean cacheableRequest) {
+        if (serverSessionActive) {
+            persistServerSessionIfRequired(cacheableRequest);
+            return cookiesOut == null ? null : cookiesOut.values();
+        }
+
         if (cacheableRequest) {
             // Notify a developer that changes to the client session are discarded due to a request being marked
             // as cacheable. This is treated as info, as it might be totally fine to have this behaviour if
@@ -1537,6 +1618,33 @@ public class WebContext implements SubContext {
         }
 
         return cookiesOut == null ? null : cookiesOut.values();
+    }
+
+    /*
+     * Persists a modified server side session at response time. Mirrors the contract of the session cookie:
+     * changes on cacheable responses are discarded, and a failed load suppresses persisting entirely so that a
+     * transient error cannot overwrite the stored session. Persist errors are logged but never break the
+     * response commit.
+     */
+    private void persistServerSessionIfRequired(boolean cacheableRequest) {
+        if (!sessionModified || serverSessionLoadFailed) {
+            return;
+        }
+
+        if (cacheableRequest) {
+            if (Sirius.isDev()) {
+                WebServer.LOG.INFO("Not going to update the server session (%s) for a cacheable request: %n%s",
+                                   session,
+                                   this);
+            }
+            return;
+        }
+
+        try {
+            serverSessionStorage.persistSession(this, session);
+        } catch (Exception exception) {
+            Exceptions.handle(WebServer.LOG, exception);
+        }
     }
 
     private void buildClientSessionCookie() {

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -42,16 +42,6 @@ public class UserInfo extends Composable {
     public static final String PERMISSION_LOGGED_IN = "flag-logged-in";
 
     /**
-     * This permission represents a user whose identity was established via an API token presented in the request
-     * (e.g. an OAuth bearer token) rather than via an ambient session cookie.
-     * <p>
-     * This has to be granted by the resolving {@link UserManager} on the user info built for the current request -
-     * it must never be stored in cached role sets, as the very same user may be resolved via a session cookie in
-     * another request.
-     */
-    public static final String PERMISSION_TOKEN_AUTHENTICATED = "flag-token-authenticated";
-
-    /**
      * Fallback user if no user is currently available. This user has no permissions.
      */
     public static final UserInfo NOBODY = Builder.createUser("ANONYMOUS").withUsername("(no user)").build();

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -42,6 +42,16 @@ public class UserInfo extends Composable {
     public static final String PERMISSION_LOGGED_IN = "flag-logged-in";
 
     /**
+     * This permission represents a user whose identity was established via an API token presented in the request
+     * (e.g. an OAuth bearer token) rather than via an ambient session cookie.
+     * <p>
+     * This has to be granted by the resolving {@link UserManager} on the user info built for the current request -
+     * it must never be stored in cached role sets, as the very same user may be resolved via a session cookie in
+     * another request.
+     */
+    public static final String PERMISSION_TOKEN_AUTHENTICATED = "flag-token-authenticated";
+
+    /**
      * Fallback user if no user is currently available. This user has no permissions.
      */
     public static final UserInfo NOBODY = Builder.createUser("ANONYMOUS").withUsername("(no user)").build();

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -362,6 +362,20 @@ public class TestController extends BasicController {
                           + webContext.getSessionValue("test2").asString("<none>"));
     }
 
+    @Routed("/test/session-test-clear")
+    public void sessionTestClear(WebContext webContext) {
+        webContext.clearSession();
+
+        webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
+
+    @Routed("/test/session-test-cacheable")
+    public void sessionTestCacheable(WebContext webContext) {
+        webContext.setSessionValue("test1", "test");
+
+        webContext.respondWith().cached().direct(HttpResponseStatus.OK, "OK");
+    }
+
     @Routed("/test/redirect-to-get")
     public void redirect(WebContext webContext) {
         webContext.respondWith().redirectToGet("/test/redirect-target");

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -436,11 +436,27 @@ public class TestRequest extends WebContext implements HttpRequest {
         }
     }
 
+    /**
+     * Keeps the uri used for dispatching in sync when a custom uri is installed before {@link #execute()}:
+     * {@link #build()} appends the collected parameters to it and re-parses the final uri, so a custom uri must
+     * become the base of that final uri instead of being silently reset to the constructor uri.
+     */
+    @Override
+    public WebContext withCustomURI(String uri) {
+        this.testUri = uri;
+        return super.withCustomURI(uri);
+    }
+
     protected void build() {
         // append GET parameters to URI
         String queryString = generateQueryString(parameters);
         this.testUri =
                 this.testUri + (Strings.isFilled(queryString) ? (testUri.contains("?") ? "&" : "?") + queryString : "");
+
+        // Re-parse the query string against the final uri: if a parameter was accessed before execute() (e.g. by
+        // a part which is consulted during the lazy session initialization and happens to check for a parameter),
+        // the parameterless uri would otherwise remain pinned in the cached query string.
+        withCustomURI(testUri);
 
         // send resource in body
         if (resource != null && (testMethod.equals(HttpMethod.PATCH)

--- a/src/test/java/sirius/web/http/TestServerSessionStorage.java
+++ b/src/test/java/sirius/web/http/TestServerSessionStorage.java
@@ -1,0 +1,112 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.std.Register;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provides a server session storage for tests which is only responsible for requests carrying the
+ * {@link #SESSION_HEADER} - all other requests (i.e. the whole existing test suite) remain on the built-in
+ * cookie based client session.
+ * <p>
+ * Like {@link TestFirewall} this is gated behind a framework flag which is disabled in the packaged test-jar
+ * (see <tt>component-test-web.conf</tt>) and only enabled by the local <tt>test.conf</tt> - other libraries using
+ * this test-jar must not have this storage registered, as it would compete with their own implementation for the
+ * single {@link ServerSessionStorage} part slot.
+ */
+@Register(framework = "web.test-server-session-storage")
+public class TestServerSessionStorage implements ServerSessionStorage {
+
+    /**
+     * Requests carrying this header are handled by this storage. The header value is used as session id.
+     */
+    public static final String SESSION_HEADER = "X-Test-Server-Session";
+
+    /**
+     * Using this session id makes {@link #loadSession(WebContext)} fail to test the fail-open behavior.
+     */
+    public static final String FAILING_SESSION_ID = "fail-load";
+
+    private static final Map<String, Map<String, String>> sessions = new ConcurrentHashMap<>();
+    private static final AtomicInteger persistCalls = new AtomicInteger();
+    private static final AtomicInteger responsibilityChecks = new AtomicInteger();
+
+    @Override
+    public boolean isResponsibleFor(WebContext webContext) {
+        responsibilityChecks.incrementAndGet();
+        return Strings.isFilled(webContext.getHeader(SESSION_HEADER));
+    }
+
+    @Override
+    public Map<String, String> loadSession(WebContext webContext) {
+        String sessionId = webContext.getHeader(SESSION_HEADER);
+        if (FAILING_SESSION_ID.equals(sessionId)) {
+            throw new IllegalStateException("Simulated session load failure");
+        }
+
+        return sessions.getOrDefault(sessionId, Collections.emptyMap());
+    }
+
+    @Override
+    public void persistSession(WebContext webContext, Map<String, String> session) {
+        persistCalls.incrementAndGet();
+        String sessionId = webContext.getHeader(SESSION_HEADER);
+        if (session.isEmpty()) {
+            sessions.remove(sessionId);
+        } else {
+            sessions.put(sessionId, new HashMap<>(session));
+        }
+    }
+
+    /**
+     * Returns the stored session values for the given session id.
+     *
+     * @param sessionId the session id to look up
+     * @return the stored values or an empty map if no session is stored
+     */
+    public static Map<String, String> getStoredSession(String sessionId) {
+        return sessions.getOrDefault(sessionId, Collections.emptyMap());
+    }
+
+    /**
+     * Determines if a session is stored for the given session id.
+     *
+     * @param sessionId the session id to look up
+     * @return <tt>true</tt> if a session is stored, <tt>false</tt> otherwise
+     */
+    public static boolean hasStoredSession(String sessionId) {
+        return sessions.containsKey(sessionId);
+    }
+
+    /**
+     * Counts the invocations of {@link #persistSession(WebContext, Map)} so far.
+     *
+     * @return the number of persist calls
+     */
+    public static int getPersistCalls() {
+        return persistCalls.get();
+    }
+
+    /**
+     * Counts the invocations of {@link #isResponsibleFor(WebContext)} so far, i.e. how often the session was
+     * initialized.
+     *
+     * @return the number of responsibility checks
+     */
+    public static int getResponsibilityChecks() {
+        return responsibilityChecks.get();
+    }
+}

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -269,6 +269,34 @@ class WebContextTest {
     }
 
     @Test
+    fun `a safe GET does not initialize the session just for the CSRF check`() {
+
+        // The CSRF skip condition must be evaluated after the cheap method check: GETs are never CSRF-validated,
+        // so they must not pay for the (potentially expensive) session initialization.
+        val checksBefore = TestServerSessionStorage.getResponsibilityChecks()
+
+        val connection = openConnection("/test/redirect-target")
+        connection.requestMethod = "GET"
+        connection.connect()
+
+        assertEquals(200, connection.responseCode)
+        assertEquals(checksBefore, TestServerSessionStorage.getResponsibilityChecks())
+    }
+
+    @Test
+    fun `a POST without CSRF token is accepted when the server session is active`() {
+
+        // Without the server session header this request yields 403 (see CSRFTokenTest): the CSRF check protects
+        // ambient cookie authority. With an active server session the cookie is ignored entirely, so there is
+        // nothing to protect and the check is skipped.
+        val connection = openConnection("/test/fake-delete-data", "csrf-skip")
+        connection.requestMethod = "POST"
+        connection.connect()
+
+        assertEquals(200, connection.responseCode)
+    }
+
+    @Test
     fun `a custom uri installed before execute survives the build step`() {
 
         // build() re-parses the final uri; a uri installed via withCustomURI must remain its base instead of
@@ -284,7 +312,6 @@ class WebContextTest {
         assertEquals("b", request.getParameter("b"))
         assertEquals(200, result.status.code())
     }
-
 
     @Test
     fun `a legacy unencrypted session cookie is read and upgraded to the encrypted format`() {

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -169,7 +169,7 @@ class WebContextTest {
     fun `a server session round-trips between requests without emitting any cookie`() {
 
         // The first request writes into the server session...
-        val writeConnection = openConnection("/test/session-test", "roundtrip").apply {
+        val writeConnection = openConnectionWithServerSession("/test/session-test", "roundtrip").apply {
             requestMethod = "GET"
             connect()
         }
@@ -182,7 +182,7 @@ class WebContextTest {
         assertEquals("test", TestServerSessionStorage.getStoredSession("roundtrip")["test1"])
 
         // The second request reads the value back from the storage (value set to null is not stored).
-        val readConnection = openConnection("/test/session-test-read", "roundtrip").apply {
+        val readConnection = openConnectionWithServerSession("/test/session-test-read", "roundtrip").apply {
             requestMethod = "GET"
             connect()
         }
@@ -197,7 +197,7 @@ class WebContextTest {
     fun `a session cookie is ignored when the server session is active`() {
 
         // Obtain a valid session cookie carrying test1=test the classic way...
-        val cookieConnection = openConnection("/test/session-test").apply {
+        val cookieConnection = openConnectionWithServerSession("/test/session-test").apply {
             requestMethod = "GET"
             connect()
         }
@@ -207,7 +207,7 @@ class WebContextTest {
             .substringBefore(";")
 
         // ...and send it along with a server session id: the cookie values must be invisible.
-        val readConnection = openConnection("/test/session-test-read", "cookie-ignored").apply {
+        val readConnection = openConnectionWithServerSession("/test/session-test-read", "cookie-ignored").apply {
             requestMethod = "GET"
             setRequestProperty(HttpHeaderNames.COOKIE.toString(), sessionCookie)
             connect()
@@ -222,7 +222,7 @@ class WebContextTest {
 
         val persistCallsBefore = TestServerSessionStorage.getPersistCalls()
 
-        val connection = openConnection("/test/session-test-cacheable", "cacheable").apply {
+        val connection = openConnectionWithServerSession("/test/session-test-cacheable", "cacheable").apply {
             requestMethod = "GET"
             connect()
         }
@@ -238,7 +238,7 @@ class WebContextTest {
         val persistCallsBefore = TestServerSessionStorage.getPersistCalls()
 
         // The load fails, but the request is still answered normally (fail-open) with an empty session...
-        val connection = openConnection("/test/session-test", TestServerSessionStorage.FAILING_SESSION_ID).apply {
+        val connection = openConnectionWithServerSession("/test/session-test", TestServerSessionStorage.FAILING_SESSION_ID).apply {
             requestMethod = "GET"
             connect()
         }
@@ -253,7 +253,7 @@ class WebContextTest {
     fun `clearing a server session deletes the stored session`() {
 
         // Seed a stored session...
-        val writeConnection = openConnection("/test/session-test", "to-clear").apply {
+        val writeConnection = openConnectionWithServerSession("/test/session-test", "to-clear").apply {
             requestMethod = "GET"
             connect()
         }
@@ -261,7 +261,7 @@ class WebContextTest {
         assertTrue { TestServerSessionStorage.hasStoredSession("to-clear") }
 
         // ...and clear it: the storage receives an empty map and removes the session.
-        val clearConnection = openConnection("/test/session-test-clear", "to-clear").apply {
+        val clearConnection = openConnectionWithServerSession("/test/session-test-clear", "to-clear").apply {
             requestMethod = "GET"
             connect()
         }
@@ -277,7 +277,7 @@ class WebContextTest {
         // so they must not pay for the (potentially expensive) session initialization.
         val checksBefore = TestServerSessionStorage.getResponsibilityChecks()
 
-        val connection = openConnection("/test/redirect-target").apply {
+        val connection = openConnectionWithServerSession("/test/redirect-target").apply {
             requestMethod = "GET"
             connect()
         }
@@ -292,7 +292,7 @@ class WebContextTest {
         // Without the server session header this request yields 403 (see CSRFTokenTest): the CSRF check protects
         // ambient cookie authority. With an active server session the cookie is ignored entirely, so there is
         // nothing to protect and the check is skipped.
-        val connection = openConnection("/test/fake-delete-data", "csrf-skip").apply {
+        val connection = openConnectionWithServerSession("/test/fake-delete-data", "csrf-skip").apply {
             requestMethod = "POST"
             connect()
         }
@@ -345,9 +345,9 @@ class WebContextTest {
 
     }
 
-    private fun openConnection(path: String, sessionId: String? = null): HttpURLConnection {
+    private fun openConnectionWithServerSession(path: String, serverSessionId: String? = null): HttpURLConnection {
         val connection = URI("http://localhost:9999$path").toURL().openConnection() as HttpURLConnection
-        sessionId?.let { connection.setRequestProperty(TestServerSessionStorage.SESSION_HEADER, it) }
+        serverSessionId?.let { connection.setRequestProperty(TestServerSessionStorage.SESSION_HEADER, it) }
         return connection
     }
 }

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -165,19 +165,14 @@ class WebContextTest {
 
     }
 
-    private fun openConnection(path: String, sessionId: String? = null): HttpURLConnection {
-        val connection = URI("http://localhost:9999$path").toURL().openConnection() as HttpURLConnection
-        sessionId?.let { connection.setRequestProperty(TestServerSessionStorage.SESSION_HEADER, it) }
-        return connection
-    }
-
     @Test
     fun `a server session round-trips between requests without emitting any cookie`() {
 
         // The first request writes into the server session...
-        val writeConnection = openConnection("/test/session-test", "roundtrip")
-        writeConnection.requestMethod = "GET"
-        writeConnection.connect()
+        val writeConnection = openConnection("/test/session-test", "roundtrip").apply {
+            requestMethod = "GET"
+            connect()
+        }
 
         assertEquals(200, writeConnection.responseCode)
         // ...but neither a session cookie nor a session pin cookie is emitted.
@@ -187,9 +182,10 @@ class WebContextTest {
         assertEquals("test", TestServerSessionStorage.getStoredSession("roundtrip")["test1"])
 
         // The second request reads the value back from the storage (value set to null is not stored).
-        val readConnection = openConnection("/test/session-test-read", "roundtrip")
-        readConnection.requestMethod = "GET"
-        readConnection.connect()
+        val readConnection = openConnection("/test/session-test-read", "roundtrip").apply {
+            requestMethod = "GET"
+            connect()
+        }
 
         assertEquals(200, readConnection.responseCode)
         val body = readConnection.inputStream.bufferedReader().readText()
@@ -201,19 +197,21 @@ class WebContextTest {
     fun `a session cookie is ignored when the server session is active`() {
 
         // Obtain a valid session cookie carrying test1=test the classic way...
-        val cookieConnection = openConnection("/test/session-test")
-        cookieConnection.requestMethod = "GET"
-        cookieConnection.connect()
+        val cookieConnection = openConnection("/test/session-test").apply {
+            requestMethod = "GET"
+            connect()
+        }
         assertEquals(200, cookieConnection.responseCode)
         val sessionCookie = cookieConnection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!!
             .first { it.startsWith("SIRIUS_SESSION=") }
             .substringBefore(";")
 
         // ...and send it along with a server session id: the cookie values must be invisible.
-        val readConnection = openConnection("/test/session-test-read", "cookie-ignored")
-        readConnection.requestMethod = "GET"
-        readConnection.setRequestProperty(HttpHeaderNames.COOKIE.toString(), sessionCookie)
-        readConnection.connect()
+        val readConnection = openConnection("/test/session-test-read", "cookie-ignored").apply {
+            requestMethod = "GET"
+            setRequestProperty(HttpHeaderNames.COOKIE.toString(), sessionCookie)
+            connect()
+        }
 
         assertEquals(200, readConnection.responseCode)
         assertTrue { readConnection.inputStream.bufferedReader().readText().contains("test1=<none>") }
@@ -224,9 +222,10 @@ class WebContextTest {
 
         val persistCallsBefore = TestServerSessionStorage.getPersistCalls()
 
-        val connection = openConnection("/test/session-test-cacheable", "cacheable")
-        connection.requestMethod = "GET"
-        connection.connect()
+        val connection = openConnection("/test/session-test-cacheable", "cacheable").apply {
+            requestMethod = "GET"
+            connect()
+        }
 
         assertEquals(200, connection.responseCode)
         assertEquals(persistCallsBefore, TestServerSessionStorage.getPersistCalls())
@@ -239,9 +238,10 @@ class WebContextTest {
         val persistCallsBefore = TestServerSessionStorage.getPersistCalls()
 
         // The load fails, but the request is still answered normally (fail-open) with an empty session...
-        val connection = openConnection("/test/session-test", TestServerSessionStorage.FAILING_SESSION_ID)
-        connection.requestMethod = "GET"
-        connection.connect()
+        val connection = openConnection("/test/session-test", TestServerSessionStorage.FAILING_SESSION_ID).apply {
+            requestMethod = "GET"
+            connect()
+        }
 
         assertEquals(200, connection.responseCode)
         // ...and the written value is NOT persisted, so a transient error cannot wipe the stored session.
@@ -253,16 +253,18 @@ class WebContextTest {
     fun `clearing a server session deletes the stored session`() {
 
         // Seed a stored session...
-        val writeConnection = openConnection("/test/session-test", "to-clear")
-        writeConnection.requestMethod = "GET"
-        writeConnection.connect()
+        val writeConnection = openConnection("/test/session-test", "to-clear").apply {
+            requestMethod = "GET"
+            connect()
+        }
         assertEquals(200, writeConnection.responseCode)
         assertTrue { TestServerSessionStorage.hasStoredSession("to-clear") }
 
         // ...and clear it: the storage receives an empty map and removes the session.
-        val clearConnection = openConnection("/test/session-test-clear", "to-clear")
-        clearConnection.requestMethod = "GET"
-        clearConnection.connect()
+        val clearConnection = openConnection("/test/session-test-clear", "to-clear").apply {
+            requestMethod = "GET"
+            connect()
+        }
 
         assertEquals(200, clearConnection.responseCode)
         assertFalse { TestServerSessionStorage.hasStoredSession("to-clear") }
@@ -275,9 +277,10 @@ class WebContextTest {
         // so they must not pay for the (potentially expensive) session initialization.
         val checksBefore = TestServerSessionStorage.getResponsibilityChecks()
 
-        val connection = openConnection("/test/redirect-target")
-        connection.requestMethod = "GET"
-        connection.connect()
+        val connection = openConnection("/test/redirect-target").apply {
+            requestMethod = "GET"
+            connect()
+        }
 
         assertEquals(200, connection.responseCode)
         assertEquals(checksBefore, TestServerSessionStorage.getResponsibilityChecks())
@@ -289,9 +292,10 @@ class WebContextTest {
         // Without the server session header this request yields 403 (see CSRFTokenTest): the CSRF check protects
         // ambient cookie authority. With an active server session the cookie is ignored entirely, so there is
         // nothing to protect and the check is skipped.
-        val connection = openConnection("/test/fake-delete-data", "csrf-skip")
-        connection.requestMethod = "POST"
-        connection.connect()
+        val connection = openConnection("/test/fake-delete-data", "csrf-skip").apply {
+            requestMethod = "POST"
+            connect()
+        }
 
         assertEquals(200, connection.responseCode)
     }
@@ -339,5 +343,11 @@ class WebContextTest {
         assertTrue { rewrittenCookie.contains("SIRIUS_SESSION=E1:") }
         assertFalse { rewrittenCookie.contains("test1=test") }
 
+    }
+
+    private fun openConnection(path: String, sessionId: String? = null): HttpURLConnection {
+        val connection = URI("http://localhost:9999$path").toURL().openConnection() as HttpURLConnection
+        sessionId?.let { connection.setRequestProperty(TestServerSessionStorage.SESSION_HEADER, it) }
+        return connection
     }
 }

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -166,6 +166,24 @@ class WebContextTest {
     }
 
     @Test
+    fun `a custom uri installed before execute survives the build step`() {
+
+        // build() re-parses the final uri; a uri installed via withCustomURI must remain its base instead of
+        // being reset to the constructor uri.
+        val request = TestRequest.GET("/test/wrong-route")
+        request.withParameters(mapOf("b" to "b"))
+        request.withCustomURI("/test/redirect-target?a=a")
+
+        val result = request.execute()
+
+        assertEquals("/test/redirect-target", request.requestedURI)
+        assertEquals("a", request.getParameter("a"))
+        assertEquals("b", request.getParameter("b"))
+        assertEquals(200, result.status.code())
+    }
+
+
+    @Test
     fun `a legacy unencrypted session cookie is read and upgraded to the encrypted format`() {
 
         // Build a legacy (unencrypted) session cookie in the "<sha512 hash>:<querystring>" format, signed with the

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -165,6 +165,109 @@ class WebContextTest {
 
     }
 
+    private fun openConnection(path: String, sessionId: String? = null): HttpURLConnection {
+        val connection = URI("http://localhost:9999$path").toURL().openConnection() as HttpURLConnection
+        sessionId?.let { connection.setRequestProperty(TestServerSessionStorage.SESSION_HEADER, it) }
+        return connection
+    }
+
+    @Test
+    fun `a server session round-trips between requests without emitting any cookie`() {
+
+        // The first request writes into the server session...
+        val writeConnection = openConnection("/test/session-test", "roundtrip")
+        writeConnection.requestMethod = "GET"
+        writeConnection.connect()
+
+        assertEquals(200, writeConnection.responseCode)
+        // ...but neither a session cookie nor a session pin cookie is emitted.
+        val setCookies = writeConnection.headerFields[HttpHeaderNames.SET_COOKIE.toString()] ?: emptyList()
+        assertTrue { setCookies.none { it.startsWith("SIRIUS_SESSION") } }
+        assertTrue { setCookies.none { it.contains("PIN", ignoreCase = true) } }
+        assertEquals("test", TestServerSessionStorage.getStoredSession("roundtrip")["test1"])
+
+        // The second request reads the value back from the storage (value set to null is not stored).
+        val readConnection = openConnection("/test/session-test-read", "roundtrip")
+        readConnection.requestMethod = "GET"
+        readConnection.connect()
+
+        assertEquals(200, readConnection.responseCode)
+        val body = readConnection.inputStream.bufferedReader().readText()
+        assertTrue { body.contains("test1=test") }
+        assertFalse { body.contains("test2=test") }
+    }
+
+    @Test
+    fun `a session cookie is ignored when the server session is active`() {
+
+        // Obtain a valid session cookie carrying test1=test the classic way...
+        val cookieConnection = openConnection("/test/session-test")
+        cookieConnection.requestMethod = "GET"
+        cookieConnection.connect()
+        assertEquals(200, cookieConnection.responseCode)
+        val sessionCookie = cookieConnection.headerFields[HttpHeaderNames.SET_COOKIE.toString()]!!
+            .first { it.startsWith("SIRIUS_SESSION=") }
+            .substringBefore(";")
+
+        // ...and send it along with a server session id: the cookie values must be invisible.
+        val readConnection = openConnection("/test/session-test-read", "cookie-ignored")
+        readConnection.requestMethod = "GET"
+        readConnection.setRequestProperty(HttpHeaderNames.COOKIE.toString(), sessionCookie)
+        readConnection.connect()
+
+        assertEquals(200, readConnection.responseCode)
+        assertTrue { readConnection.inputStream.bufferedReader().readText().contains("test1=<none>") }
+    }
+
+    @Test
+    fun `server session changes on a cacheable response are discarded`() {
+
+        val persistCallsBefore = TestServerSessionStorage.getPersistCalls()
+
+        val connection = openConnection("/test/session-test-cacheable", "cacheable")
+        connection.requestMethod = "GET"
+        connection.connect()
+
+        assertEquals(200, connection.responseCode)
+        assertEquals(persistCallsBefore, TestServerSessionStorage.getPersistCalls())
+        assertFalse { TestServerSessionStorage.hasStoredSession("cacheable") }
+    }
+
+    @Test
+    fun `a failing server session load yields an empty session and suppresses persisting`() {
+
+        val persistCallsBefore = TestServerSessionStorage.getPersistCalls()
+
+        // The load fails, but the request is still answered normally (fail-open) with an empty session...
+        val connection = openConnection("/test/session-test", TestServerSessionStorage.FAILING_SESSION_ID)
+        connection.requestMethod = "GET"
+        connection.connect()
+
+        assertEquals(200, connection.responseCode)
+        // ...and the written value is NOT persisted, so a transient error cannot wipe the stored session.
+        assertEquals(persistCallsBefore, TestServerSessionStorage.getPersistCalls())
+        assertFalse { TestServerSessionStorage.hasStoredSession(TestServerSessionStorage.FAILING_SESSION_ID) }
+    }
+
+    @Test
+    fun `clearing a server session deletes the stored session`() {
+
+        // Seed a stored session...
+        val writeConnection = openConnection("/test/session-test", "to-clear")
+        writeConnection.requestMethod = "GET"
+        writeConnection.connect()
+        assertEquals(200, writeConnection.responseCode)
+        assertTrue { TestServerSessionStorage.hasStoredSession("to-clear") }
+
+        // ...and clear it: the storage receives an empty map and removes the session.
+        val clearConnection = openConnection("/test/session-test-clear", "to-clear")
+        clearConnection.requestMethod = "GET"
+        clearConnection.connect()
+
+        assertEquals(200, clearConnection.responseCode)
+        assertFalse { TestServerSessionStorage.hasStoredSession("to-clear") }
+    }
+
     @Test
     fun `a custom uri installed before execute survives the build step`() {
 

--- a/src/test/resources/component-test-web.conf
+++ b/src/test/resources/component-test-web.conf
@@ -1,6 +1,7 @@
 sirius.frameworks {
     # Other libraries using this test-jar do not need our test implementation...
     web.test-firewall: false
+    web.test-server-session-storage: false
 }
 
 # Test-Setup

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -1,5 +1,6 @@
 sirius.frameworks {
     web.test-firewall: true
+    web.test-server-session-storage: true
 }
 
 sirius.customizations = ["customized"]


### PR DESCRIPTION
### Description
Adds an optional, application-supplied hook which permits storing the client session of selected
requests **on the server** instead of transporting it via the session cookie. Token authenticated
clients (mobile apps on a JSON API) have no cookie jar and currently lose all session state. The
framework only defines the seam - the actual store lives in the application, so browser and token
requests run side by side, each with its own session, without touching the ~60 call sites of
`setSessionValue`.

**`ServerSessionStorage`** (new, `sirius.web.http`) is consulted as an optional `@Part` (same shape
as `SessionSecretComputer`):

```java
boolean isResponsibleFor(WebContext webContext);            // once per request, lazily
Map<String, String> loadSession(WebContext webContext);      // empty map = fresh session
void persistSession(WebContext webContext, Map<String, String> session);  // empty map = delete
```

If a storage claims a request, `WebContext` neither reads nor writes the session cookie (nor the pin
cookie); all session accessors work unchanged on the loaded map. The cookie contract is mirrored:
only modified sessions are persisted at response time, cacheable responses discard changes, and the
response commit is never broken. Claiming and loading degrade instead of failing - a failed load
additionally suppresses persisting, so a transient error cannot overwrite the stored session.

Three smaller changes come with it:

* **`UserInfo.PERMISSION_TOKEN_AUTHENTICATED`** (following the existing `flag-logged-in` pattern) so
  a user manager can mark token-authenticated users.
* **CSRF skip for server session requests**: CSRF protects ambient cookie authority, which these
  requests do not have. Evaluated after the cheap method checks, so GETs do not force session init.
* **`TestRequest` uri handling** (test-jar): reading a parameter before `execute()` pinned the
  parameterless uri, hiding the parameters `build()` appends. Independent pre-existing bug which the
  new hook merely surfaced.

**No behavioural change without an implementation** - the state of every existing product. The test
storage is gated behind a framework flag disabled in the published test-jar.

### Additional Notes
- This PR fixes or works on following ticket(s): [SE-15422](https://scireum.myjetbrains.com/youtrack/issue/SE-15422)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
