### PR TITLE
Keep the uri of the underlying request out of a TestRequest rewrite

### DIFF
--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -381,6 +381,15 @@ public class TestController extends BasicController {
         webContext.respondWith().redirectToGet("/test/redirect-target");
     }
 
+    @Routed("/test/rewrite-during-dispatch")
+    public void rewriteDuringDispatch(WebContext webContext) {
+        // Simulates what a dispatcher doing SEO url rewriting does: the requested uri is changed while the request
+        // is being handled, which must not change the uri the request was originally made for.
+        webContext.withCustomURI("/test/rewritten-target?rewritten=true");
+
+        webContext.respondWith().direct(HttpResponseStatus.OK, "OK");
+    }
+
     @Routed("/test/redirect-target")
     public void redirectTarget(WebContext webContext) {
         webContext.respondWith().direct(HttpResponseStatus.OK, "target");

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -69,6 +69,7 @@ public class TestRequest extends WebContext implements HttpRequest {
     private final List<Cookie> testCookies = new ArrayList<>();
     private final Map<String, String> testSession;
     private String testUri;
+    private String customUri;
     private InputStream resource;
     private HttpMethod testMethod;
     private boolean preDispatch;
@@ -437,26 +438,29 @@ public class TestRequest extends WebContext implements HttpRequest {
     }
 
     /**
-     * Keeps the uri used for dispatching in sync when a custom uri is installed before {@link #execute()}:
-     * {@link #build()} appends the collected parameters to it and re-parses the final uri, so a custom uri must
-     * become the base of that final uri instead of being silently reset to the constructor uri.
+     * Records a custom uri so that {@link #build()} can append the collected parameters to it instead of to the
+     * uri the request was created with.
+     * <p>
+     * Note that the uri of the underlying request is deliberately left untouched, just like for a real request: a
+     * rewrite performed while the request is being dispatched must not change what the client actually asked for.
      */
     @Override
     public WebContext withCustomURI(String uri) {
-        this.testUri = uri;
+        this.customUri = uri;
         return super.withCustomURI(uri);
     }
 
     protected void build() {
-        // append GET parameters to URI
+        // append GET parameters to the uri, using a custom uri installed before execute() as the base
+        String baseUri = customUri != null ? customUri : testUri;
         String queryString = generateQueryString(parameters);
         this.testUri =
-                this.testUri + (Strings.isFilled(queryString) ? (testUri.contains("?") ? "&" : "?") + queryString : "");
+                baseUri + (Strings.isFilled(queryString) ? (baseUri.contains("?") ? "&" : "?") + queryString : "");
 
         // Re-parse the query string against the final uri: if a parameter was accessed before execute() (e.g. by
         // a part which is consulted during the lazy session initialization and happens to check for a parameter),
         // the parameterless uri would otherwise remain pinned in the cached query string.
-        withCustomURI(testUri);
+        super.withCustomURI(testUri);
 
         // send resource in body
         if (resource != null && (testMethod.equals(HttpMethod.PATCH)

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -318,6 +318,21 @@ class WebContextTest {
     }
 
     @Test
+    fun `a rewrite while dispatching does not change the uri of the request itself`() {
+
+        // Guards what dispatchers doing SEO url rewriting rely on: withCustomURI changes the requested uri, but the
+        // uri of the underlying request keeps telling what the client actually asked for.
+        val request = TestRequest.GET("/test/rewrite-during-dispatch?original=true")
+
+        val result = request.execute()
+
+        assertEquals(200, result.status.code())
+        assertEquals("/test/rewrite-during-dispatch?original=true", request.uri())
+        assertEquals("/test/rewritten-target", request.requestedURI)
+        assertEquals("true", request.getParameter("rewritten"))
+    }
+
+    @Test
     fun `a legacy unencrypted session cookie is read and upgraded to the encrypted format`() {
 
         // Build a legacy (unencrypted) session cookie in the "<sha512 hash>:<querystring>" format, signed with the


### PR DESCRIPTION
### Description
- fixes bug recently introduced by https://github.com/scireum/sirius-web/pull/1705/changes/8bc25647ac2e37b8df8203799dd98203435daeb5
- letting a custom uri survive build() was implemented by overwriting the uri of the request itself, which also took effect for calls made while the request is already being dispatched
- a dispatcher rewriting the requested uri - for SEO urls, for example - therefore changed what the request appeared to have asked for, although withCustomURI explicitly only replaces the requested uri and not the one of the underlying request
- the custom uri is now recorded separately and only serves as the base for the parameters appended by build()
- adds a route which rewrites while dispatching plus a test asserting that request.uri() keeps the original uri while the requested uri and its parameters change

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15422](https://scireum.myjetbrains.com/youtrack/issue/SE-15422)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
