### PR TITLE
Add a floating, non-modal chat widget component

### DIFF
--- a/src/main/resources/assets/design-system/icons.scss
+++ b/src/main/resources/assets/design-system/icons.scss
@@ -141,6 +141,11 @@
   background-color: currentColor;
 }
 
+.sci-icon-down {
+  mask-image: url(svgResource('/assets/images/icons/navigation/down.svg'));
+  background-color: currentColor;
+}
+
 .sci-icon-copy {
   mask-image: url(svgResource('/assets/images/icons/fontawesome/copy.svg'));
   background-color: currentColor;

--- a/src/main/resources/default/assets/common/components.js.pasta
+++ b/src/main/resources/default/assets/common/components.js.pasta
@@ -1,3 +1,12 @@
+/**@
+ * Every component listed here ends up in one script, so a syntax error in any of them takes all the others down with
+ * it. Browsers as old as IE11 are still being served, and those reject modern syntax (classes, arrow functions,
+ * template literals, private fields, spread) while parsing - long before anyone could have used the component. Keep
+ * the files below on ES5 syntax, even the ones which are never rendered in such a browser.
+ *
+ * A component which wants modern syntax stays out of this list and is included by the products which use it, the way
+ * scripts/toast.js and scripts/chat-widget.js.pasta are.
+ */
 ___invoke("/assets/common/common.js.pasta");
 ___invoke("/assets/common/scripts/overlay.js.pasta");
 ___invoke("/assets/common/scripts/sidebar-overlay.js.pasta");

--- a/src/main/resources/default/assets/common/scripts/chat-widget.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/chat-widget.js.pasta
@@ -42,6 +42,21 @@ window.sirius.chatWidget = (function () {
     }
 
     /**@
+     * Describes the options which shape a chat widget. They are all optional - the defaults below are used for the
+     * ones the caller leaves out.
+     *
+     * @typedef {object} ChatWidgetOptions
+     * @property {string} [title=''] the title shown in the header, also used as the label of the bubble
+     * @property {string|HTMLElement} [content=''] the content rendered into the panel - a string is inserted as HTML
+     *                                             and its embedded scripts are executed, an element is appended as is
+     * @property {string|HTMLElement} [bubbleContent=''] the content of the bubble, commonly an icon
+     * @property {boolean} [closable=true] whether the header renders a close button
+     * @property {boolean} [minimized=false] whether the widget starts out as a bubble instead of an open panel
+     * @property {string} [minimizeLabel='Minimize'] the label of the minimize button, shown as its tooltip
+     * @property {string} [closeLabel='Close'] the label of the close button, shown as its tooltip
+     */
+
+    /**@
      * Represents a single floating chat widget.
      *
      * A widget is either open (the panel is visible) or minimized (only a round bubble remains). Unlike a dialog or an
@@ -55,6 +70,12 @@ window.sirius.chatWidget = (function () {
      * Instances are created via `sirius.chatWidget.create` and are never constructed directly.
      */
     class ChatWidget {
+
+        /**@
+         * Holds the value used for each option which the caller did not supply.
+         *
+         * @type {ChatWidgetOptions}
+         */
         static defaults = {
             title: '',
             content: '',
@@ -148,6 +169,9 @@ window.sirius.chatWidget = (function () {
         /**@
          * Registers a listener for one of the `sci-chat-widget-*` events of this widget.
          *
+         * The listener receives a `CustomEvent` whose target is the element of the widget and which carries the widget
+         * itself as `event.detail.widget`.
+         *
          * @param {...*} args the arguments to pass on to `addEventListener` of the underlying element
          */
         addEventListener(...args) {
@@ -208,14 +232,7 @@ window.sirius.chatWidget = (function () {
          *
          * The widget reports its state changes as events, see `ChatWidget.addEventListener`.
          *
-         * @param {object} options the options of the widget
-         * @param {string} [options.title=''] the title shown in the header and used as the label of the bubble
-         * @param {string|HTMLElement} [options.content=''] the content rendered into the panel
-         * @param {string|HTMLElement} [options.bubbleContent=''] the content of the bubble, commonly an icon
-         * @param {boolean} [options.closable=true] whether the header renders a close button
-         * @param {boolean} [options.minimized=false] whether the widget starts out minimized
-         * @param {string} [options.minimizeLabel='Minimize'] the label of the minimize button
-         * @param {string} [options.closeLabel='Close'] the label of the close button
+         * @param {ChatWidgetOptions} [options] the options of the widget
          * @returns {ChatWidget} the created widget
          */
         create(options) {

--- a/src/main/resources/default/assets/common/scripts/chat-widget.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/chat-widget.js.pasta
@@ -1,0 +1,236 @@
+/**@
+ * Unlike the components in components.js.pasta, this one is written in modern JS and is therefore included by the
+ * products which use it (like toast.js is), not by the shared bundle - a single modern token in that bundle would
+ * break its parsing, and with it every component in it, in browsers as old as IE11.
+ */
+window.sirius.chatWidget = (function () {
+
+    const template = '@escapeJS(inlineResource("/assets/common/templates/chat-widget.html.mustache"))';
+
+    /**@
+     * Holds the transparent start value of the opening animation.
+     */
+    const CLASS_ENTERING = 'sci-chat-widget-entering';
+
+    /**@
+     * Marks a widget which is fading out before it is removed from the DOM.
+     */
+    const CLASS_CLOSING = 'sci-chat-widget-closing';
+
+    /**@
+     * Marks a widget which is reduced to its bubble.
+     */
+    const CLASS_MINIMIZED = 'sci-chat-widget-minimized';
+
+    /**@
+     * Runs the given callback once the transition of the given element finished.
+     *
+     * The callback runs right away if the element does not animate at all - which is the case when the user asked for
+     * reduced motion. We read the duration off the element instead of repeating it here, so that the stylesheet stays
+     * the single place defining it.
+     *
+     * @param {HTMLElement} _element the element being transitioned
+     * @param {function} callback invoked once the transition finished
+     */
+    function runAfterTransition(_element, callback) {
+        const seconds = parseFloat(window.getComputedStyle(_element).transitionDuration) || 0;
+        if (seconds <= 0) {
+            callback();
+            return;
+        }
+        setTimeout(callback, seconds * 1000);
+    }
+
+    /**@
+     * Represents a single floating chat widget.
+     *
+     * A widget is either open (the panel is visible) or minimized (only a round bubble remains). Unlike a dialog or an
+     * overlay it is not modal: the page below stays scrollable and clickable, and several widgets may live side by side.
+     * Which part of the chrome is on screen follows from the state class alone - the stylesheet fades the two into each
+     * other, so the widget animates without being driven from here.
+     *
+     * A widget reports `sci-chat-widget-minimized`, `sci-chat-widget-restored` and `sci-chat-widget-destroyed` via
+     * `addEventListener`. These events do not bubble, as a listener always belongs to one specific widget.
+     *
+     * Instances are created via `sirius.chatWidget.create` and are never constructed directly.
+     */
+    class ChatWidget {
+        static defaults = {
+            title: '',
+            content: '',
+            bubbleContent: '',
+            closable: true,
+            minimized: false,
+            minimizeLabel: 'Minimize',
+            closeLabel: 'Close'
+        };
+
+        constructor(manager, options) {
+            this.manager = manager;
+            this.options = sirius.deepExtend({}, ChatWidget.defaults, options);
+            this.#render();
+        }
+
+        #render() {
+            const isStringContent = typeof this.options.content === 'string';
+            const isStringBubbleContent = typeof this.options.bubbleContent === 'string';
+
+            const _container = document.createElement('div');
+            _container.innerHTML = Mustache.render(template, {
+                title: this.options.title,
+                content: isStringContent ? this.options.content : undefined,
+                bubbleContent: isStringBubbleContent ? this.options.bubbleContent : undefined,
+                closable: this.options.closable,
+                minimizeLabel: this.options.minimizeLabel,
+                closeLabel: this.options.closeLabel
+            });
+            this._widget = _container.firstChild;
+
+            if (!isStringContent) {
+                this._widget.querySelector('.sci-chat-widget-content-js').appendChild(this.options.content);
+            }
+            if (!isStringBubbleContent) {
+                this._widget.querySelector('.sci-chat-widget-bubble-js').appendChild(this.options.bubbleContent);
+            }
+
+            const _minimizeButton = this._widget.querySelector('.sci-chat-widget-button-minimize-js');
+            sirius.addClickOrEnterListener(_minimizeButton, () => this.minimize());
+
+            if (this.options.closable) {
+                const _closeButton = this._widget.querySelector('.sci-chat-widget-button-close-js');
+                sirius.addClickOrEnterListener(_closeButton, () => this.destroy());
+            }
+
+            const _bubble = this._widget.querySelector('.sci-chat-widget-bubble-js');
+            sirius.addClickOrEnterListener(_bubble, () => this.restore());
+
+            // Escape is bound on the widget itself, not on the window: the widget is non-modal, so it must not
+            // swallow the Escape key of the page it floats above.
+            this._widget.addEventListener('keyup', event => {
+                if (event.key === 'Escape' && !this.isMinimized()) {
+                    this.minimize();
+                }
+            });
+
+            this._widget.classList.toggle(CLASS_MINIMIZED, !!this.options.minimized);
+            // A widget always animates into view, no matter which state it starts in.
+            this._widget.classList.add(CLASS_ENTERING);
+            this.manager._container.appendChild(this._widget);
+
+            if (isStringContent) {
+                sirius.executeEmbeddedScripts(this._widget);
+            }
+
+            // Forces a reflow, so the browser registers the transparent start value before it is removed again - a
+            // transition only runs if the browser got to see the start value at least once.
+            void this._widget.offsetWidth;
+            this._widget.classList.remove(CLASS_ENTERING);
+        }
+
+        /**@
+         * Determines whether this widget is minimized, i.e. reduced to its bubble.
+         *
+         * @returns {boolean} true if the widget is minimized, false otherwise
+         */
+        isMinimized() {
+            return !!this._widget && this._widget.classList.contains(CLASS_MINIMIZED);
+        }
+
+        /**@
+         * Returns the element the content was rendered into.
+         *
+         * @returns {HTMLElement|null} the content element or null if the widget was destroyed
+         */
+        getContentElement() {
+            return this._widget ? this._widget.querySelector('.sci-chat-widget-content-js') : null;
+        }
+
+        /**@
+         * Registers a listener for one of the `sci-chat-widget-*` events of this widget.
+         *
+         * @param {...*} args the arguments to pass on to `addEventListener` of the underlying element
+         */
+        addEventListener(...args) {
+            this._widget.addEventListener(...args);
+        }
+
+        /**@
+         * Reduces the widget to its bubble.
+         *
+         * The content stays in the DOM (it is only hidden), so an embedded iframe keeps its state and is not reloaded
+         * when the widget is restored.
+         */
+        minimize() {
+            if (!this._widget || this.isMinimized()) {
+                return;
+            }
+            this._widget.classList.add(CLASS_MINIMIZED);
+            sirius.dispatchEvent('sci-chat-widget-minimized', this._widget, {widget: this});
+        }
+
+        /**@
+         * Shows the panel of a minimized widget again.
+         */
+        restore() {
+            if (!this._widget || !this.isMinimized()) {
+                return;
+            }
+            this._widget.classList.remove(CLASS_MINIMIZED);
+            sirius.dispatchEvent('sci-chat-widget-restored', this._widget, {widget: this});
+        }
+
+        /**@
+         * Removes the widget (panel and bubble) from the DOM.
+         */
+        destroy() {
+            if (!this._widget) {
+                return;
+            }
+            const _widget = this._widget;
+            this._widget = null;
+
+            // Only the node lingers until it faded out. The event fires right away, as a consumer may create the next
+            // widget immediately, and that one must not be touched by the one leaving the screen.
+            sirius.dispatchEvent('sci-chat-widget-destroyed', _widget, {widget: this});
+
+            _widget.classList.add(CLASS_CLOSING);
+            runAfterTransition(_widget, () => _widget.parentElement.removeChild(_widget));
+        }
+    }
+
+    /**@
+     * Creates the floating chat widgets and hosts them in a shared container.
+     */
+    class ChatWidgetManager {
+
+        /**@
+         * Creates a new chat widget and attaches it to the page.
+         *
+         * The widget reports its state changes as events, see `ChatWidget.addEventListener`.
+         *
+         * @param {object} options the options of the widget
+         * @param {string} [options.title=''] the title shown in the header and used as the label of the bubble
+         * @param {string|HTMLElement} [options.content=''] the content rendered into the panel
+         * @param {string|HTMLElement} [options.bubbleContent=''] the content of the bubble, commonly an icon
+         * @param {boolean} [options.closable=true] whether the header renders a close button
+         * @param {boolean} [options.minimized=false] whether the widget starts out minimized
+         * @param {string} [options.minimizeLabel='Minimize'] the label of the minimize button
+         * @param {string} [options.closeLabel='Close'] the label of the close button
+         * @returns {ChatWidget} the created widget
+         */
+        create(options) {
+            if (!this._container) {
+                this.#createContainer();
+            }
+            return new ChatWidget(this, options || {});
+        }
+
+        #createContainer() {
+            this._container = document.createElement('div');
+            this._container.id = 'sci-chat-widgets-container';
+            document.body.appendChild(this._container);
+        }
+    }
+
+    return new ChatWidgetManager();
+})();

--- a/src/main/resources/default/assets/common/scripts/chat-widget.js.pasta
+++ b/src/main/resources/default/assets/common/scripts/chat-widget.js.pasta
@@ -217,6 +217,12 @@ window.sirius.chatWidget = (function () {
             // widget immediately, and that one must not be touched by the one leaving the screen.
             sirius.dispatchEvent('sci-chat-widget-destroyed', _widget, {widget: this});
 
+            // Pins the widget where it currently stands before it is taken out of the layout, so that it fades out in
+            // place while its siblings close the gap at once. Leaving the offsets to the stylesheet would not do: an
+            // absolutely positioned child of a flex container is placed as if it were the only item in it, which is
+            // the corner of the container - no matter which of several widgets side by side is closing.
+            _widget.style.left = _widget.offsetLeft + 'px';
+            _widget.style.top = _widget.offsetTop + 'px';
             _widget.classList.add(CLASS_CLOSING);
             runAfterTransition(_widget, () => _widget.parentElement.removeChild(_widget));
         }

--- a/src/main/resources/default/assets/common/styles/chat-widget.scss
+++ b/src/main/resources/default/assets/common/styles/chat-widget.scss
@@ -33,11 +33,10 @@
   }
 
   /* A widget on its way out leaves the layout at once, so that a widget opening right behind it - as it happens when
-     the assistant switches to another context - is not pushed aside for the duration of the fade-out. */
+     the assistant switches to another context - is not pushed aside for the duration of the fade-out. The script pins
+     it to the spot it occupied, see destroy() in chat-widget.js.pasta. */
   .sci-chat-widget-closing {
     position: absolute;
-    right: var(--sci-chat-widget-base-unit);
-    bottom: var(--sci-chat-widget-base-unit);
     pointer-events: none;
   }
 

--- a/src/main/resources/default/assets/common/styles/chat-widget.scss
+++ b/src/main/resources/default/assets/common/styles/chat-widget.scss
@@ -1,0 +1,117 @@
+#sci-chat-widgets-container {
+  --sci-chat-widget-base-unit: var(--sci-base-unit, 16px);
+  /* Duration of the opening and closing animations. The script reads the effective duration off the element, so
+     changing it here needs no counterpart in chat-widget.js.pasta. */
+  --sci-chat-widget-transition: 200ms;
+  /* Above the overlay and the dialog, below the toasts - a toast must remain readable above an open widget. */
+  z-index: 11500;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: flex-end;
+  gap: var(--sci-chat-widget-base-unit);
+  padding: var(--sci-chat-widget-base-unit);
+  /* The container spans only its widgets, but it must never swallow clicks meant for the page below it. */
+  pointer-events: none;
+
+  .sci-chat-widget {
+    pointer-events: auto;
+    transition: opacity var(--sci-chat-widget-transition) ease;
+  }
+
+  /* Start value of the opening animation and end value of the closing one. The script adds the entering class, forces
+     the browser to see it, and removes it again - which is what makes the transition run.
+
+     A widget appears and leaves by fading only. It must not be transformed as a whole: a transformed element becomes
+     the containing block of its fixed descendants, which would tear the full-screen panel of a phone out of the
+     viewport for the duration of the animation. The scaling happens one level down, on the panel and the bubble. */
+  .sci-chat-widget-entering,
+  .sci-chat-widget-closing {
+    opacity: 0;
+  }
+
+  /* A widget on its way out leaves the layout at once, so that a widget opening right behind it - as it happens when
+     the assistant switches to another context - is not pushed aside for the duration of the fade-out. */
+  .sci-chat-widget-closing {
+    position: absolute;
+    right: var(--sci-chat-widget-base-unit);
+    bottom: var(--sci-chat-widget-base-unit);
+    pointer-events: none;
+  }
+
+  .sci-chat-widget-panel {
+    width: 400px;
+    max-width: calc(100vw - 2 * var(--sci-chat-widget-base-unit));
+    height: calc(100vh - 2 * var(--sci-chat-widget-base-unit));
+    max-height: 720px;
+    /* The panel grows out of, and shrinks back into, the corner the bubble sits in. */
+    transform-origin: bottom right;
+    transition: opacity var(--sci-chat-widget-transition) ease, transform var(--sci-chat-widget-transition) ease,
+    visibility var(--sci-chat-widget-transition);
+  }
+
+  .sci-chat-widget-bubble {
+    width: calc(3.5 * var(--sci-chat-widget-base-unit));
+    height: calc(3.5 * var(--sci-chat-widget-base-unit));
+    border-radius: 50%;
+    transition: opacity var(--sci-chat-widget-transition) ease, transform var(--sci-chat-widget-transition) ease,
+    visibility var(--sci-chat-widget-transition);
+  }
+
+  /* Only one part of the chrome is on screen, which part follows from the minimized state alone. The other one fades
+     out, drops out of the flow so that it stops pushing its sibling around, and leaves the accessibility tree - but
+     never the DOM, so an embedded iframe keeps its state. Visibility transitions in discrete steps, so it only flips
+     to hidden once the fade-out finished, and back to visible right when the fade-in starts. */
+  .sci-chat-widget-minimized .sci-chat-widget-panel,
+  .sci-chat-widget:not(.sci-chat-widget-minimized) .sci-chat-widget-bubble {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .sci-chat-widget-minimized .sci-chat-widget-panel {
+    transform: translateY(calc(0.5 * var(--sci-chat-widget-base-unit))) scale(0.98);
+  }
+
+  .sci-chat-widget:not(.sci-chat-widget-minimized) .sci-chat-widget-bubble {
+    transform: scale(0.8);
+  }
+}
+
+/* Users who ask for reduced motion get the plain state switch. The script reads the duration off the element, so it
+   drops the waiting as well and applies the end state at once. */
+@media (prefers-reduced-motion: reduce) {
+  #sci-chat-widgets-container .sci-chat-widget,
+  #sci-chat-widgets-container .sci-chat-widget-panel,
+  #sci-chat-widgets-container .sci-chat-widget-bubble {
+    transition: none;
+  }
+}
+
+/* On small viewports an open panel takes the whole viewport, just like a dialog does. The bubble stays small. The
+   second selector keeps a minimized panel full-screen as well, so that it fades out where it stands instead of
+   snapping into the corner on its way. */
+@media (max-width: 576px) {
+  #sci-chat-widgets-container .sci-chat-widget-panel,
+  #sci-chat-widgets-container .sci-chat-widget-minimized .sci-chat-widget-panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    max-width: none;
+    height: 100vh;
+    height: 100dvh;
+    max-height: none;
+    border-radius: 0;
+  }
+
+  /* A full-screen panel only slides - scaling it would reveal the page along its edges. */
+  #sci-chat-widgets-container .sci-chat-widget-minimized .sci-chat-widget-panel {
+    transform: translateY(var(--sci-chat-widget-base-unit));
+  }
+}

--- a/src/main/resources/default/assets/common/templates/chat-widget.html.mustache
+++ b/src/main/resources/default/assets/common/templates/chat-widget.html.mustache
@@ -1,0 +1,29 @@
+<div class="sci-chat-widget sci-enable-font sci-text sci-d-flex sci-flex-column sci-align-items-end sci-position-relative">
+    <div class="sci-chat-widget-panel sci-font sci-shadow-elevated sci-bg-white sci-d-flex sci-flex-column sci-overflow-hidden sci-border-radius-25"
+         role="dialog"
+         aria-label="{{title}}">
+        <div class="sci-chat-widget-header sci-d-flex sci-align-items-center sci-justify-content-space-between sci-flex-shrink-0 sci-p-1 sci-pl-2 sci-border-grey sci-border-bottom-solid-0.5">
+            <div class="sci-chat-widget-title sci-text-ellipsis sci-text-grey-dark">{{title}}</div>
+            <div class="sci-chat-widget-header-buttons sci-d-flex sci-align-items-center">
+                <a role="button"
+                   tabindex="0"
+                   title="{{minimizeLabel}}"
+                   aria-label="{{minimizeLabel}}"
+                   class="sci-cursor-pointer sci-icon-small sci-icon-down sci-chat-widget-button-minimize-js"></a>
+                {{#closable}}
+                    <a role="button"
+                       tabindex="0"
+                       title="{{closeLabel}}"
+                       aria-label="{{closeLabel}}"
+                       class="sci-cursor-pointer sci-icon-small sci-icon-close sci-ml-2 sci-chat-widget-button-close-js"></a>
+                {{/closable}}
+            </div>
+        </div>
+        <div class="sci-chat-widget-content sci-chat-widget-content-js sci-d-flex sci-flex-column sci-flex-grow-1 sci-min-height-0">{{{content}}}</div>
+    </div>
+    <div class="sci-chat-widget-bubble sci-shadow-elevated sci-bg-white sci-cursor-pointer sci-chat-widget-bubble-js sci-d-flex sci-align-items-center sci-justify-content-center"
+         role="button"
+         tabindex="0"
+         title="{{title}}"
+         aria-label="{{title}}">{{{bubbleContent}}}</div>
+</div>


### PR DESCRIPTION
### Description

The widget renders a panel in the bottom corner of the screen which can be reduced to a round bubble and restored again. Unlike a dialog or an overlay it is not modal: the page below stays scrollable and clickable, and several widgets may live side by side. The content is supplied by the caller and stays in the DOM while the widget is minimized, so an embedded iframe keeps its state instead of being reloaded on every restore. On small viewports the open panel takes the whole viewport, just like a dialog does.

<img width="2228" height="1109" alt="grafik" src="https://github.com/user-attachments/assets/8ad9956c-ed2d-453f-bd54-3982cdc1780c" />

<img width="783" height="242" alt="grafik" src="https://github.com/user-attachments/assets/c7dbbb2b-e94e-4486-ba38-4002ebee7f54" />

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12689](https://scireum.myjetbrains.com/youtrack/issue/OX-12689)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
