### PR TITLE
Add an `AllowedOrigin.Denied` for refusing CORS explicitly

### DIFF
--- a/src/main/java/sirius/web/controller/Interceptor.java
+++ b/src/main/java/sirius/web/controller/Interceptor.java
@@ -114,6 +114,12 @@ public interface Interceptor extends Priorized {
      * </p>
      *
      * <p>
+     * <b>Abstaining is therefore not the same as refusing.</b> As the fallback reflects the origin of the request,
+     * an empty optional leaves a route readable cross-origin. An interceptor which wants a route to stay unreachable
+     * for foreign origins must say so by returning an {@link AllowedOrigin.Denied}.
+     * </p>
+     *
+     * <p>
      * Please note that {@code enableCors} acts as a master switch: this method is only consulted when
      * {@link WebContext#isCorsEnabled()} returns {@code true} for the request's scope. If CORS handling is disabled,
      * no origin is resolved at all and this method is not invoked.

--- a/src/main/java/sirius/web/controller/Interceptor.java
+++ b/src/main/java/sirius/web/controller/Interceptor.java
@@ -115,7 +115,7 @@ public interface Interceptor extends Priorized {
      *
      * <p>
      * <b>Abstaining is therefore not the same as refusing.</b> As the fallback reflects the origin of the request,
-     * an empty optional leaves a route readable cross-origin. An interceptor which wants a route to stay unreachable
+     * an empty optional leaves a route readable cross-origin. An interceptor which wants a route to stay unreadable
      * for foreign origins must say so by returning an {@link AllowedOrigin.Denied}.
      * </p>
      *

--- a/src/main/java/sirius/web/cors/AllowedOrigin.java
+++ b/src/main/java/sirius/web/cors/AllowedOrigin.java
@@ -33,8 +33,13 @@ public sealed interface AllowedOrigin
      * This is <b>not</b> the same as an interceptor abstaining: an interceptor which returns an empty optional from
      * {@link Interceptor#determineAllowedCorsOrigin(WebContext, Collection)} states that it does not decide, and
      * {@link sirius.web.controller.ControllerDispatcher} then falls back to a {@link MatchRequest} - which reflects
-     * the origin of the request. An interceptor that wants a route to remain unreachable cross-origin therefore has
-     * to say so by returning this record.
+     * the origin of the request. An interceptor that wants the response of a route to stay unreadable cross-origin
+     * therefore has to say so by returning this record.
+     * </p>
+     * <p>
+     * Note that this withholds the <i>response</i> from the calling script rather than keeping the request away from
+     * the route: a simple request is still sent and still executed, and only a failing preflight stops one from
+     * arriving at all. Refusing an origin is therefore no substitute for CSRF protection.
      * </p>
      */
     record Denied() implements AllowedOrigin {

--- a/src/main/java/sirius/web/cors/AllowedOrigin.java
+++ b/src/main/java/sirius/web/cors/AllowedOrigin.java
@@ -24,7 +24,21 @@ import java.util.stream.Collectors;
  * </p>
  */
 public sealed interface AllowedOrigin
-        permits AllowedOrigin.MatchRequest, AllowedOrigin.Specific, AllowedOrigin.Wildcard {
+        permits AllowedOrigin.Denied, AllowedOrigin.MatchRequest, AllowedOrigin.Specific, AllowedOrigin.Wildcard {
+
+    /**
+     * No origin is allowed at all, so no {@code Access-Control-Allow-Origin} header is set and the response stays
+     * unreadable for every foreign origin.
+     * <p>
+     * This is <b>not</b> the same as an interceptor abstaining: an interceptor which returns an empty optional from
+     * {@link Interceptor#determineAllowedCorsOrigin(WebContext, Collection)} states that it does not decide, and
+     * {@link sirius.web.controller.ControllerDispatcher} then falls back to a {@link MatchRequest} - which reflects
+     * the origin of the request. An interceptor that wants a route to remain unreachable cross-origin therefore has
+     * to say so by returning this record.
+     * </p>
+     */
+    record Denied() implements AllowedOrigin {
+    }
 
     /**
      * The {@code Access-Control-Allow-Origin} header should be set to the origin of the request.

--- a/src/main/java/sirius/web/cors/AllowedOrigin.java
+++ b/src/main/java/sirius/web/cors/AllowedOrigin.java
@@ -37,6 +37,13 @@ public sealed interface AllowedOrigin
      * therefore has to say so by returning this record.
      * </p>
      * <p>
+     * Refusing every origin does not restrict the application's own frontend: a request issued by the origin which
+     * served the page is same-origin, and the same-origin policy permits it without any
+     * {@code Access-Control-Allow-Origin} header. Only <i>foreign</i> origins are affected. Where an application is
+     * served from several hosts and one of them legitimately calls another, that is a genuine cross-origin case and
+     * belongs into a {@link Specific} allow-list rather than here.
+     * </p>
+     * <p>
      * Note that this withholds the <i>response</i> from the calling script rather than keeping the request away from
      * the route: a simple request is still sent and still executed, and only a failing preflight stops one from
      * arriving at all. Refusing an origin is therefore no substitute for CSRF protection.

--- a/src/main/java/sirius/web/cors/CorsAllowOriginResolver.java
+++ b/src/main/java/sirius/web/cors/CorsAllowOriginResolver.java
@@ -156,6 +156,9 @@ public class CorsAllowOriginResolver {
         @Nullable String requestOrigin = webContext.getHeader(HttpHeaderNames.ORIGIN);
 
         return switch (origin) {
+            // Resolving to no origin is what makes the refusal effective: no header is set, so the response stays
+            // unreadable cross-origin. The strategy is still recorded, hence the `Vary` header remains correct.
+            case AllowedOrigin.Denied _ -> Optional.empty();
             // Using `Optional.ofNullable()` implicitly handles cases where no `Origin` header is available (e.g.
             // due to the browser not sending it for same-origin requests). Returning an empty optional results in no
             // header being set, which is the expected behavior in such a case.

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -215,6 +215,47 @@ class CorsTest {
         assertNull(requestAllowedOrigin(requestOrigin))
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["https://example.com", "http://localhost:3000"])
+    fun `given enableCors is enabled when the interceptor returns a Denied strategy then no 'Access-Control-Allow-Origin' header is set`(
+        requestOrigin: String
+    ) {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Denied()
+
+        assertNull(requestAllowedOrigin(requestOrigin))
+    }
+
+    /**
+     * The refusal has to reach the preflight as well, as a preflight answered with an origin would let the browser
+     * proceed with the actual request.
+     */
+    @Test
+    fun `given enableCors is enabled when the interceptor returns a Denied strategy then a preflight is answered without an origin`() {
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Denied()
+
+        val connection = sendPreflight(origin = "https://example.com")
+
+        assertNull(connection.getHeaderField(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()))
+    }
+
+    /**
+     * Abstaining and refusing must not be confused: an interceptor which cannot decide leaves the route readable for
+     * the requesting origin, while a refusal keeps it unreadable.
+     */
+    @Test
+    fun `given enableCors is enabled then a Denied strategy differs from an interceptor which does not decide`() {
+        TestCorsInterceptor.allowedOrigin = null
+        val whenAbstaining = requestAllowedOrigin("https://example.com")
+
+        TestCorsInterceptor.allowedOrigin = AllowedOrigin.Denied()
+        val whenDenied = requestAllowedOrigin("https://example.com")
+
+        assertAll(
+            { assertEquals("https://example.com", whenAbstaining) },
+            { assertNull(whenDenied) },
+        )
+    }
+
     // --- CORS handling of the non-controller dispatchers ---
     //
     // Dispatchers are invoked ascending by priority: AssetsDispatcher (-10), ServiceDispatcher (-5),


### PR DESCRIPTION
### Description

Adds `AllowedOrigin.Denied`, so that an `Interceptor` can state that a route must stay unreachable cross-origin.

Since #1698 an interceptor can answer `determineAllowedCorsOrigin` in two ways: name a strategy, or return an empty optional to abstain. There is no way to say *"no origin at all"* — and abstaining is not that, because `ControllerDispatcher` falls back to an `AllowedOrigin.MatchRequest`, which reflects the origin of the request.

That is easy to get wrong, because the two look alike at the call site while the consequences are opposite. It bit us in scireum/memoio#2989: MEMOIO enables `http.enableCors` globally and grants a wildcard to its external API below `/api/`. Returning an empty optional for everything else — the obvious reading of "no CORS here" — silently made the whole backend UI, `/login/*` and `/csrf-token` reflect arbitrary origins. The only way to express the refusal today is an `AllowedOrigin.Specific` with an empty allow-list, which happens to resolve to no origin but states the intent nowhere and reads like an oversight to the next person.

`Denied` gives that case a name. It resolves to no origin, so no `Access-Control-Allow-Origin` header is emitted; the strategy is still recorded, so the `Vary` handling is unchanged, and `Access-Control-Allow-Credentials` is untouched (only `Specific` can ever request it). Also spells out in the javadoc of `determineAllowedCorsOrigin` that abstaining and refusing differ.

**Notes for review:**

- *Naming.* `Denied` over `None`, because the confusion this fixes is precisely between "no decision" and "no origin", and `None` reads like the former. Happy to rename if you prefer the symmetry with the other records.
- *Compatibility.* `AllowedOrigin` is `sealed`, so a downstream `switch` over it that was exhaustive stops compiling. Nothing in sirius-web is affected (the only switch is in `CorsAllowOriginResolver`), but it may influence how you want to version this.

### Additional Notes

- This PR is related to PR: #1698

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
