### PR TITLE
Serves the configured favicon for requests to /favicon.ico

### DIFF
--- a/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
@@ -85,14 +85,17 @@ public class DefaultDispatcher implements WebDispatcher {
                                   Disallow:
                                   """);
             }
-        } else if ("/favicon.ico".equals(webContext.getRequestedURI()) && Strings.isFilled(favicon)) {
+        } else if ("/favicon.ico".equals(webContext.getRequestedURI())
+                   && Strings.isFilled(favicon)
+                   && favicon.startsWith("/assets/")) {
             // Browsers and many other clients request /favicon.ico on their own, even if no HTML document points
             // there. Without a handler each of these requests ends up as an HTTP/404, which floods the logs and
             // makes tools like fail2ban treat harmless clients as attackers.
             //
-            // We only rewrite the URI here and restart the pipeline instead of serving the file ourselves. This way
-            // the AssetsDispatcher applies its usual caching and zero-copy delivery, and the configured path has to
-            // pass its /assets check - therefore no other file than an asset can ever be served this way.
+            // We only rewrite the URI here and restart the pipeline instead of serving the file ourselves, so that
+            // the AssetsDispatcher applies its usual caching and zero-copy delivery. We deliberately only do so for
+            // a path below /assets: a value pointing back to /favicon.ico would restart the pipeline until it is
+            // aborted, and any other value would silently remap the request to a completely unrelated route.
             //
             // As this dispatcher runs last, an application can still handle /favicon.ico itself (e.g. to serve a
             // tenant specific icon) without being shadowed by the framework.

--- a/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 /**
  * Sends a 404 (not found) for all unhandled URIs.
  * <p>
- * Also handles some special static URIs if enabled, like /robots.txt.
+ * Also handles some special static URIs if enabled, like /robots.txt or /favicon.ico.
  * <p>
  * If no other dispatcher jumps in, this will take care of handing the request by sending an HTTP/404.
  */
@@ -47,6 +47,9 @@ public class DefaultDispatcher implements WebDispatcher {
 
     @ConfigValue("http.robots.txt.disallow")
     private boolean robotsDisallowAll;
+
+    @ConfigValue("http.favicon")
+    private String favicon;
 
     @Override
     public int getPriority() {
@@ -82,6 +85,19 @@ public class DefaultDispatcher implements WebDispatcher {
                                   Disallow:
                                   """);
             }
+        } else if ("/favicon.ico".equals(webContext.getRequestedURI()) && Strings.isFilled(favicon)) {
+            // Browsers and many other clients request /favicon.ico on their own, even if no HTML document points
+            // there. Without a handler each of these requests ends up as an HTTP/404, which floods the logs and
+            // makes tools like fail2ban treat harmless clients as attackers.
+            //
+            // We only rewrite the URI here and restart the pipeline instead of serving the file ourselves. This way
+            // the AssetsDispatcher applies its usual caching and zero-copy delivery, and the configured path has to
+            // pass its /assets check - therefore no other file than an asset can ever be served this way.
+            //
+            // As this dispatcher runs last, an application can still handle /favicon.ico itself (e.g. to serve a
+            // tenant specific icon) without being shadowed by the framework.
+            webContext.withCustomURI(favicon);
+            return DispatchDecision.RESTART;
         } else if ("/".equals(webContext.getRequestedURI())) {
             // If there is no controller and no other dispatcher which is willing to handle a "/" request, we
             // re-start the pipeline with "/admin". This will at least be picked up by the DashboardController

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -210,6 +210,13 @@ http {
     # Accept search engines? (By default we don't allow any indexing, therefore disallow is true).
     robots.txt.disallow = true
 
+    # The asset to serve when a client requests /favicon.ico. Browsers request this path on their own, therefore
+    # serving it prevents 404s which would otherwise pollute the logs and mislead tools like fail2ban.
+    # This has to be a path below /assets (it is resolved like any other asset and may therefore be overwritten
+    # per customization or scope). Use an empty string to not serve a favicon at all. If the asset cannot be
+    # resolved, the request results in a 404 just like before.
+    favicon = "/assets/images/favicon.ico"
+
     # Contains the name of the directory used to cache generated content like CSS files computed from SCSS files.
     # Will be created if it does not exist.
     generated-directory = "web-cache"


### PR DESCRIPTION
### Description
Browsers request /favicon.ico on their own, even without a link in the HTML. So far this ended in a 404, which pollutes the logs and irritates fail2ban. The DefaultDispatcher now rewrites the request to the asset configured via http.favicon and restarts the pipeline, so the AssetsDispatcher serves it as usual. 
<img width="4100" height="1816" alt="image" src="https://github.com/user-attachments/assets/12c033b3-3baf-41b7-96ba-734aa42d6f80" />

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15244](https://scireum.myjetbrains.com/youtrack/issue/SE-15244)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
