### PR TITLE
Add an image URL to autocomplete completions

### DIFF
--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -120,7 +120,7 @@ public class AutocompleteHelper {
                 output.property("fieldLabel", fieldLabel);
                 output.property("completionLabel", Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
                 output.property("completionDescription", completionDescription);
-                output.property("imageUrl", imageUrl);
+                output.propertyIfFilled("imageUrl", imageUrl);
 
                 // LEGACY SUPPORT....
                 output.property("id", value);

--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -44,6 +44,7 @@ public class AutocompleteHelper {
         private String fieldLabel;
         private String completionLabel;
         private String completionDescription;
+        private String imageUrl;
         private boolean disabled = false;
 
         /**
@@ -90,6 +91,19 @@ public class AutocompleteHelper {
         }
 
         /**
+         * Specifies an image to be shown alongside the suggestion.
+         * <p>
+         * Note that it is up to the autocomplete in JavaScript whether and how the image is rendered.
+         *
+         * @param imageUrl the URL of the image to show
+         * @return the completion itself for fluent method calls
+         */
+        public Completion withImageUrl(String imageUrl) {
+            this.imageUrl = imageUrl;
+            return this;
+        }
+
+        /**
          * Marks the suggestion as disabled.
          *
          * @return the completion itself for fluent method calls
@@ -106,6 +120,7 @@ public class AutocompleteHelper {
                 output.property("fieldLabel", fieldLabel);
                 output.property("completionLabel", Strings.isFilled(completionLabel) ? completionLabel : fieldLabel);
                 output.property("completionDescription", completionDescription);
+                output.property("imageUrl", imageUrl);
 
                 // LEGACY SUPPORT....
                 output.property("id", value);


### PR DESCRIPTION
### Description

- Add `imageUrl` to `AutocompleteHelper.Completion`, together with `withImageUrl` and the property in `writeTo`, so an autocomplete can offer a preview image alongside the label and the description.
- Whether and how the image is rendered is left to the autocomplete in JavaScript.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11937](https://scireum.myjetbrains.com/youtrack/issue/OX-11937)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/13094

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
