### PR TITLE
Makes the confirm dialog work together with a POST dropdown item

### DIFF
--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -41,9 +41,8 @@ sirius.ready(function () {
     document.querySelectorAll('.confirm-link-js').forEach(_node => {
         _node.addEventListener('click', event => {
             try {
-                const href = _node.getAttribute('href');
                 if (_node.hasAttribute('href')) {
-                    _confirmForm.setAttribute('action', href);
+                    _confirmForm.setAttribute('action', _node.getAttribute('href'));
                     _targetForm = _confirmForm;
 
                     if (_node.dataset.sciSubmitFormId) {

--- a/src/main/resources/default/assets/tycho/scripts/form.js.pasta
+++ b/src/main/resources/default/assets/tycho/scripts/form.js.pasta
@@ -28,8 +28,10 @@ sirius.ready(function () {
     const _modalElement = document.getElementById('link-confirm-modal-js');
     const _confirmForm = _modalElement.querySelector(".confirm-form-js");
     const _submitBtn = _modalElement.querySelector("button[type='submit']");
+
+    let _targetForm = _confirmForm;
     _submitBtn.addEventListener('click', () => {
-        sirius.requestSubmitForm(_confirmForm);
+        sirius.requestSubmitForm(_targetForm);
     });
 
     const modal = new bootstrap.Modal(_modalElement, {
@@ -39,20 +41,29 @@ sirius.ready(function () {
     document.querySelectorAll('.confirm-link-js').forEach(_node => {
         _node.addEventListener('click', event => {
             try {
-                _confirmForm.setAttribute('action', _node.getAttribute('href'));
+                const href = _node.getAttribute('href');
+                if (_node.hasAttribute('href')) {
+                    _confirmForm.setAttribute('action', href);
+                    _targetForm = _confirmForm;
 
-                if (_node.dataset.sciSubmitFormId) {
-                    [..._confirmForm.children].forEach(_child => _child.name !== "CSRFToken" && _confirmForm.removeChild(_child));
-                    const _form = document.getElementById(_node.dataset.sciSubmitFormId);
-                    if (_form != null) {
-                        const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
-                        _userIdInputs.forEach(_input => {
-                            const _inputHidden = document.createElement('input');
-                            _inputHidden.type = 'hidden';
-                            _inputHidden.name = _input.name;
-                            _inputHidden.value = _input.value;
-                            _confirmForm.appendChild(_inputHidden);
-                        });
+                    if (_node.dataset.sciSubmitFormId) {
+                        [..._confirmForm.children].forEach(_child => _child.name !== "CSRFToken" && _confirmForm.removeChild(_child));
+                        const _form = document.getElementById(_node.dataset.sciSubmitFormId);
+                        if (_form != null) {
+                            const _userIdInputs = _form.querySelectorAll('input[name]:not([name="CSRFToken"])');
+                            _userIdInputs.forEach(_input => {
+                                const _inputHidden = document.createElement('input');
+                                _inputHidden.type = 'hidden';
+                                _inputHidden.name = _input.name;
+                                _inputHidden.value = _input.value;
+                                _confirmForm.appendChild(_inputHidden);
+                            });
+                        }
+                    }
+                } else {
+                    _targetForm = _node.closest('form');
+                    if (_targetForm == null) {
+                        throw new Error('confirm-link-js requires either an href or an enclosing form: ' + _node.outerHTML);
                     }
                 }
 

--- a/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownDeleteItem.html.pasta
@@ -13,9 +13,7 @@
 <i:local name="dropdownClass" value="@apply('danger %s %s', class, withConfirm ? 'confirm-link-js' : '')"/>
 
 <!--@
-Only declare as POST request if no confirmation is required as both simultaneously would clash. In the case of
-requiring confirmation via an extra dialog, it will automatically be a POST request including a CSRF token after the
-user confirms the action. TODO SIRI-1223: Fix this.
+Always sent as POST, as the framework only validates CSRF tokens for POST requests.
 -->
 <t:dropdownItem class="@dropdownClass"
                 permission="@permission"
@@ -23,5 +21,5 @@ user confirms the action. TODO SIRI-1223: Fix this.
                 icon="fa-solid fa-trash fa-fw"
                 labelKey="@labelKey"
                 adminOnly="@adminOnly"
-                sendPostRequest="@!withConfirm"
+                sendPostRequest="true"
                 url="@(page != null) ? page.linkToCurrentPage(url) : url"/>

--- a/src/main/resources/default/taglib/t/dropdownItem.html.pasta
+++ b/src/main/resources/default/taglib/t/dropdownItem.html.pasta
@@ -14,8 +14,9 @@
 <i:pragma name="description" value="Renders menu entry within a tycho template"/>
 
 <!--@
-Note: Do not declare both the 'confirm-link-js' class and 'sendPostRequest=true' at the same time as they clash with
-each other. TODO SIRI-1223: Fix this.
+Note: With sendPostRequest=true, the item renders a <form> containing a <button>. The 'class' attribute is applied
+to the button, while 'data' attributes are applied to the surrounding form. Do not place such an item inside another
+form, as nested forms are dropped by the HTML parser.
 -->
 
 <i:local name="dataSerialized"


### PR DESCRIPTION
### Description

t:dropdownItem funktionierte nicht, wenn confirm-link-js und sendPostRequest=true zusammen gesetzt waren: nach dem Bestätigen ging der POST auf /null statt auf die Zielseite. Das Confirm JS merkt sich jetzt, welches Formular es absenden soll, und nutzt bei einem Button ohne href dessen eigenes POST Formular.

Zu beachten (Verhalten):

Betrifft alle Nutzer von confirm-link-js (u.a. dropdownDeleteItem, deleteButton). Der reine Link Fall bleibt unverändert, der POST Button Fall funktioniert jetzt.
dropdownDeleteItem sendet jetzt einen echten POST inklusive CSRF Token, auch mit Bestätigungsdialog.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1223](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1223) 

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
