### PR TITLE
fix a bug in the SASS-parser where space got lost and killed selectors

### DIFF
--- a/src/main/java/sirius/web/sass/Parser.java
+++ b/src/main/java/sirius/web/sass/Parser.java
@@ -537,8 +537,14 @@ public class Parser {
             } else if (tokenizer.current().isIdentifier()
                        || tokenizer.current().isSpecialIdentifier("#", "@")
                        || tokenizer.current().isNumber()) {
-                StringBuilder builder = new StringBuilder(tokenizer.consume().getSource());
-                parseFilterInSelector(builder);
+                Token identifier = tokenizer.consume();
+                StringBuilder builder = new StringBuilder(identifier.getSource());
+                // "a[href]" (glued) is a compound selector, but "a [href]" (whitespace) is a descendant.
+                // Only append the filter if it directly follows the identifier - otherwise it is picked up
+                // as a separate selector part by the "[" branch below.
+                if (areAdjacent(identifier, tokenizer.current())) {
+                    parseFilterInSelector(builder);
+                }
                 parseOperatorInSelector(builder);
                 selector.add(builder.toString());
             } else if (tokenizer.current().isSymbol("[")) {

--- a/src/test/resources/sass/selectors.css
+++ b/src/test/resources/sass/selectors.css
@@ -22,7 +22,11 @@ input[type="radio"]:checked + span {
     font-family: 'OpenSansSemibold';
 }
 
-.nav-list[class^="icon-"], .nav-list[class*=" icon-"] {
+.nav-list-self[class^="icon-"], .nav-list-self[class*=" icon-"] {
+    margin-right: 5px;
+}
+
+.nav-list [class^="icon-"], .nav-list [class*=" icon-"] {
     margin-right: 5px;
 }
 
@@ -91,5 +95,9 @@ div::-webkit-scrollbar {
 }
 
 .wrap [hidden] {
+    display: none;
+}
+
+.tabs[hidden], .tabs [hidden] {
     display: none;
 }

--- a/src/test/resources/sass/selectors.scss
+++ b/src/test/resources/sass/selectors.scss
@@ -113,6 +113,6 @@ div {
   }
 }
 
-.tabs[hidden], .tabs [hidden]{
+.tabs[hidden], .tabs [hidden] {
   display: none;
 }

--- a/src/test/resources/sass/selectors.scss
+++ b/src/test/resources/sass/selectors.scss
@@ -23,6 +23,11 @@ input[type="radio"]:checked + span {
   font-family: 'OpenSansSemibold';
 }
 
+.nav-list-self[class^="icon-"],
+.nav-list-self[class*=" icon-"] {
+  margin-right: 5px;
+}
+
 .nav-list [class^="icon-"],
 .nav-list [class*=" icon-"] {
   margin-right: 5px;
@@ -106,4 +111,8 @@ div {
   & [hidden] {
     display: none;
   }
+}
+
+.tabs[hidden], .tabs [hidden]{
+  display: none;
 }


### PR DESCRIPTION
### Description

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->
like the same as in the comment after, a space before attribute selector must be carried, cause the child is ment.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1256](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1256)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->https://github.com/scireum/sirius-web/pull/1689

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
