### PR TITLE
Adds XLS and XLSX parity tests and fixes missing sheets in XLS imports

### DIFF
--- a/src/main/java/sirius/web/data/XLSProcessor.java
+++ b/src/main/java/sirius/web/data/XLSProcessor.java
@@ -67,28 +67,51 @@ public class XLSProcessor extends LineBasedProcessor {
     }
 
     /**
-     * Processes the XLS (MS Excel) file using the given {@link SheetBasedRowProcessor sheetProcessors}.
+     * Processes the workbook using the given {@link SheetBasedRowProcessor sheetProcessors}.
+     * <p>
+     * Note that {@link XLSXProcessor} inherits this, so the workbook is an XLS or an XLSX file.
+     * <p>
+     * A sheet which is not present in the workbook is reported to the {@link TaskContext} as an info message
+     * and skipped, and the sheet processors behind it are still run. Note that this is all a caller learns
+     * about an absent sheet: the import is not marked as erroneous, as a sheet processor cannot state whether
+     * its sheet is mandatory.
+     * <p>
+     * A row which fails and whose error handler declines to handle it still aborts the whole run, and the
+     * {@code importAllSheets} flag given to the constructor has no effect here, as the sheets to process are
+     * named by the given processors.
      *
      * @param sheetProcessors one or more sheet processors to use
-     * @throws Exception                             in case an error occurred while processing.
-     * @throws IOException                           if the stream providing the given workbook cannot be read.
-     * @throws sirius.kernel.health.HandledException if workbook does not contain a sheet with the given name.
+     * @throws Exception   in case an error occurred while processing.
+     * @throws IOException if the stream providing the given workbook cannot be read.
      */
     public void runForSheets(SheetBasedRowProcessor... sheetProcessors) throws Exception {
         try (Workbook workbook = openWorkbook()) {
             for (SheetBasedRowProcessor processor : sheetProcessors) {
                 try {
                     Sheet sheet = workbook.getSheet(processor.sheetName());
+                    if (sheet == null) {
+                        // HSSFWorkbook reports an unknown sheet by returning null, whereas the streaming
+                        // reader used for XLSX raises a MissingSheetException
+                        reportMissingSheet(processor.sheetName());
+                        continue;
+                    }
                     importSheet(processor.rowProcessor(), processor.errorHandler(), sheet);
                 } catch (MissingSheetException missingSheetException) {
-                    TaskContext.get()
-                               .log(NLS.fmtr("XLSProcessor.info.missingSheet")
-                                       .set("sheet", processor.sheetName())
-                                       .format());
+                    reportMissingSheet(processor.sheetName());
                     Exceptions.ignore(missingSheetException);
                 }
             }
         }
+    }
+
+    /**
+     * Reports a sheet requested via {@link #runForSheets(SheetBasedRowProcessor...)} which the workbook does
+     * not contain.
+     *
+     * @param sheetName the name of the absent sheet
+     */
+    private void reportMissingSheet(String sheetName) {
+        TaskContext.get().log(NLS.fmtr("XLSProcessor.info.missingSheet").set("sheet", sheetName).format());
     }
 
     protected Workbook openWorkbook() throws IOException {

--- a/src/test/kotlin/sirius/web/data/XLSProcessorTest.kt
+++ b/src/test/kotlin/sirius/web/data/XLSProcessorTest.kt
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import sirius.kernel.SiriusExtension
+import sirius.kernel.async.BasicTaskContextAdapter
+import sirius.kernel.async.TaskContext
 import sirius.kernel.commons.Values
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -30,6 +32,7 @@ import java.util.TimeZone
 import java.util.function.Predicate
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
  * Verifies that [XLSProcessor] and [XLSXProcessor] read the same file contents in the same way.
@@ -195,6 +198,27 @@ class XLSProcessorTest {
         assertEquals(listOf(1 to listOf("beta-1"), 1 to listOf("alpha-1"), 2 to listOf("alpha-2")), rows.toList())
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `runForSheets reports a missing sheet and keeps processing`(format: String) {
+
+        val rows = mutableListOf<Pair<Int, List<Any?>>>()
+
+        val messages = captureTaskLog {
+            sheetProcessorFor(format).runForSheets(
+                collectingSheetProcessor("Missing", rows),
+                collectingSheetProcessor("Alpha", rows)
+            )
+        }
+
+        assertEquals(listOf(1 to listOf("alpha-1"), 2 to listOf("alpha-2")), rows.toList())
+        assertEquals(1, messages.size)
+        assertTrue(
+            messages.single().contains("Missing"),
+            "The absent sheet should be named in the log, but the log read: ${messages.single()}"
+        )
+    }
+
     /**
      * Writes the rows which cover the cell types and row shapes an import has to cope with.
      *
@@ -339,6 +363,19 @@ class XLSProcessorTest {
             sheetName
         )
 
+    private fun captureTaskLog(block: () -> Unit): List<String> {
+        val context = TaskContext.get()
+        val previous = context.adapter
+        val capturing = CapturingTaskContextAdapter(context)
+        context.adapter = capturing
+        try {
+            block()
+        } finally {
+            context.adapter = previous
+        }
+        return capturing.messages.toList()
+    }
+
     private fun <T> withTimeZone(zone: String, block: () -> T): T {
         val previous = TimeZone.getDefault()
         TimeZone.setDefault(TimeZone.getTimeZone(zone))
@@ -349,4 +386,15 @@ class XLSProcessorTest {
         }
     }
 
+    /**
+     * Records what a processor reports to its [TaskContext], so that a test can assert on it.
+     */
+    private class CapturingTaskContextAdapter(context: TaskContext) : BasicTaskContextAdapter(context) {
+
+        val messages = mutableListOf<String>()
+
+        override fun log(message: String) {
+            messages.add(message)
+        }
+    }
 }

--- a/src/test/kotlin/sirius/web/data/XLSProcessorTest.kt
+++ b/src/test/kotlin/sirius/web/data/XLSProcessorTest.kt
@@ -1,0 +1,352 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.data
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook
+import org.apache.poi.ss.usermodel.Cell
+import org.apache.poi.ss.usermodel.CellStyle
+import org.apache.poi.ss.usermodel.CellType
+import org.apache.poi.ss.usermodel.Row
+import org.apache.poi.ss.usermodel.Sheet
+import org.apache.poi.ss.usermodel.Workbook
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Values
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+import java.util.TimeZone
+import java.util.function.Predicate
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Verifies that [XLSProcessor] and [XLSXProcessor] read the same file contents in the same way.
+ *
+ * Both processors share their cell extraction, but obtain their workbook from entirely different
+ * libraries - POI's `HSSFWorkbook` for XLS and the streaming reader for XLSX - so every expectation
+ * here is asserted against both formats to keep the two backends from drifting apart.
+ *
+ * The workbooks are written by POI at the start of each test rather than read from a committed binary,
+ * so that the contents being asserted can be reviewed right next to the assertions. Files as they are
+ * written by an actual spreadsheet application are covered by `LineBasedProcessorTest`, whose
+ * `test.xlsx` was saved by Excel.
+ */
+@ExtendWith(SiriusExtension::class)
+class XLSProcessorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `reads strings and numbers`(format: String) {
+
+        val rows = readCellTypes(format)
+
+        assertEquals(listOf("padded", "plain", "umlauts äöüß"), rows[0])
+        assertEquals(listOf(42L, 3.5, -7L, 0L), rows[1])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `reads dates using the default time zone`(format: String) {
+
+        // the zone is pinned because the extraction converts via java.util.Date and back: on a JVM
+        // running in UTC the two conversions cancel out and the assertion would hold even if the
+        // extraction stopped honouring the default zone
+        val rows = withTimeZone("Europe/Berlin") { readCellTypes(format) }
+
+        assertEquals(
+            listOf(LocalDateTime.of(2026, 1, 2, 0, 0, 0), LocalDateTime.of(2026, 1, 2, 3, 4, 5)),
+            rows[2]
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `reads boolean cells`(format: String) {
+
+        assertEquals(listOf(true, false), readCellTypes(format)[3])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `reads formulas via their cached results`(format: String) {
+
+        // the error formula (1 divided by 0) is read as null and only survives because the formulas
+        // behind it keep it from being trimmed away as a trailing empty cell
+        assertEquals(listOf(null, 7L, "ab", true), readCellTypes(format)[4])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `keeps gaps within a row but drops trailing empty cells`(format: String) {
+
+        assertEquals(listOf("start", null, "after gap"), readCellTypes(format)[5])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `anchors every row at the first column`(format: String) {
+
+        // the row starts in column C, which must arrive as two leading nulls rather than shifting left
+        assertEquals(listOf(null, null, "leading gap"), readCellTypes(format)[9])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `reports a row holding nothing but whitespace as empty`(format: String) {
+
+        assertEquals(emptyList(), readCellTypes(format)[6])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `reports a row without a single cell as empty`(format: String) {
+
+        assertEquals(emptyList(), readCellTypes(format)[7])
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `numbers the processed rows instead of the spreadsheet rows`(format: String) {
+
+        val rows = readNumberedRows(format, ::fillCellTypes)
+
+        // the workbook has no cell in the spreadsheet rows 9 and 10, which must not shift the numbering
+        assertEquals((1..10).toList(), rows.map { it.first })
+        assertEquals(listOf("after skipped rows"), rows[8].second)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `keeps importing when the error handler swallows a failure`(format: String) {
+
+        val handled = mutableListOf<Exception>()
+        val lineNumbers = mutableListOf<Int>()
+
+        process(format, ::fillCellTypes, false, { exception -> handled.add(exception); true }) { lineNumber, _ ->
+            if (lineNumber == 2) {
+                throw IllegalStateException("Row 2 cannot be imported")
+            }
+            lineNumbers.add(lineNumber)
+        }
+
+        assertEquals(1, handled.size)
+        assertEquals(listOf(1, 3, 4, 5, 6, 7, 8, 9, 10), lineNumbers)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `propagates a failure which the error handler rejects`(format: String) {
+
+        assertFailsWith<IllegalStateException> {
+            process(format, ::fillCellTypes, false, { false }) { _, _ ->
+                throw IllegalStateException("Row cannot be imported")
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `imports only the first sheet by default`(format: String) {
+
+        assertEquals(listOf(listOf("alpha-1"), listOf("alpha-2")), readSheets(format))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `imports all sheets if requested`(format: String) {
+
+        assertEquals(
+            listOf(listOf("alpha-1"), listOf("alpha-2"), listOf("beta-1")),
+            readSheets(format, importAllSheets = true)
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `restarts the line numbers for every sheet`(format: String) {
+
+        assertEquals(listOf(1, 2, 1), readNumberedRows(format, ::fillSheets, true).map { it.first })
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["xls", "xlsx"])
+    fun `runForSheets processes the sheets in the requested order`(format: String) {
+
+        val rows = mutableListOf<Pair<Int, List<Any?>>>()
+
+        sheetProcessorFor(format).runForSheets(
+            collectingSheetProcessor("Beta", rows),
+            collectingSheetProcessor("Alpha", rows)
+        )
+
+        // every sheet processor starts counting at one again
+        assertEquals(listOf(1 to listOf("beta-1"), 1 to listOf("alpha-1"), 2 to listOf("alpha-2")), rows.toList())
+    }
+
+    /**
+     * Writes the rows which cover the cell types and row shapes an import has to cope with.
+     *
+     * The row numbers are load bearing: the tests address the rows by the line number they arrive with,
+     * and the gap in front of the last two rows is what pins that line numbers count processed rows
+     * rather than spreadsheet rows.
+     */
+    private fun fillCellTypes(workbook: Workbook) {
+        val sheet = workbook.createSheet("Data")
+
+        val strings = sheet.createRow(0)
+        strings.createCell(0).setCellValue("  padded  ")
+        strings.createCell(1).setCellValue("plain")
+        strings.createCell(2).setCellValue("umlauts äöüß")
+
+        val numbers = sheet.createRow(1)
+        numbers.createCell(0).setCellValue(42.0)
+        numbers.createCell(1).setCellValue(3.5)
+        numbers.createCell(2).setCellValue(-7.0)
+        numbers.createCell(3).setCellValue(0.0)
+
+        val dates = sheet.createRow(2)
+        // a January date dodges every DST transition on earth, so that the conversion via
+        // java.util.Date cannot shift it in any time zone
+        dateCell(dates, 0, LocalDateTime.of(2026, 1, 2, 0, 0, 0), style(workbook, "yyyy-mm-dd"))
+        dateCell(dates, 1, LocalDateTime.of(2026, 1, 2, 3, 4, 5), style(workbook, "yyyy-mm-dd hh:mm:ss"))
+
+        val booleans = sheet.createRow(3)
+        booleans.createCell(0).setCellValue(true)
+        booleans.createCell(1).setCellValue(false)
+
+        // the error formula sits first on purpose: as the last cell of the row it would be trimmed away
+        val formulas = sheet.createRow(4)
+        formulas.createCell(0).cellFormula = "1/0"
+        formulas.createCell(1).cellFormula = "B2*2"
+        formulas.createCell(2).cellFormula = "CONCATENATE(\"a\",\"b\")"
+        formulas.createCell(3).cellFormula = "1=1"
+
+        val gaps = sheet.createRow(5)
+        gaps.createCell(0).setCellValue("start")
+        // the cell in column B is missing entirely, the two cells behind "after gap" are empty
+        gaps.createCell(2).setCellValue("after gap")
+        gaps.createCell(3).setBlank()
+        gaps.createCell(4).setCellValue("")
+
+        sheet.createRow(6).createCell(0).setCellValue("   ")
+
+        sheet.createRow(7)
+
+        // leaves the spreadsheet rows 9 and 10 without a single cell
+        sheet.createRow(10).createCell(0).setCellValue("after skipped rows")
+
+        sheet.createRow(11).createCell(2).setCellValue("leading gap")
+    }
+
+    /**
+     * Writes the two named sheets used to cover sheet selection.
+     */
+    private fun fillSheets(workbook: Workbook) {
+        val alpha = workbook.createSheet("Alpha")
+        alpha.createRow(0).createCell(0).setCellValue("alpha-1")
+        alpha.createRow(1).createCell(0).setCellValue("alpha-2")
+        val beta = workbook.createSheet("Beta")
+        beta.createRow(0).createCell(0).setCellValue("beta-1")
+    }
+
+    private fun readCellTypes(format: String): List<List<Any?>> =
+        readNumberedRows(format, ::fillCellTypes).map { it.second }
+
+    private fun readSheets(format: String, importAllSheets: Boolean = false): List<List<Any?>> =
+        readNumberedRows(format, ::fillSheets, importAllSheets).map { it.second }
+
+    private fun readNumberedRows(
+        format: String,
+        fill: (Workbook) -> Unit,
+        importAllSheets: Boolean = false
+    ): List<Pair<Int, List<Any?>>> {
+        val rows = mutableListOf<Pair<Int, List<Any?>>>()
+        process(format, fill, importAllSheets, { false }) { lineNumber, row -> rows.add(lineNumber to row.asList()) }
+        return rows
+    }
+
+    private fun process(
+        format: String,
+        fill: (Workbook) -> Unit,
+        importAllSheets: Boolean,
+        errorHandler: (Exception) -> Boolean,
+        rowProcessor: (Int, Values) -> Unit
+    ) {
+        LineBasedProcessor.create("fixture.$format", workbookStream(format, fill), importAllSheets)
+            .run({ lineNumber, row -> rowProcessor(lineNumber, row) }, errorHandler)
+    }
+
+    private fun sheetProcessorFor(format: String): XLSProcessor {
+        val workbook = workbookStream(format, ::fillSheets)
+        return if (format == "xlsx") XLSXProcessor(workbook, false) else XLSProcessor(workbook, false)
+    }
+
+    /**
+     * Writes a workbook of the given format and hands it over as a stream, the way an upload would arrive.
+     */
+    private fun workbookStream(format: String, fill: (Workbook) -> Unit): ByteArrayInputStream {
+        val bytes = ByteArrayOutputStream()
+        val workbook: Workbook = if (format == "xlsx") XSSFWorkbook() else HSSFWorkbook()
+        workbook.use {
+            fill(it)
+            evaluateFormulas(it)
+            it.write(bytes)
+        }
+        return ByteArrayInputStream(bytes.toByteArray())
+    }
+
+    /**
+     * Computes the cached results of every formula, as the streaming reader has no evaluator of its own
+     * and reports a formula cell by its cached result alone.
+     */
+    private fun evaluateFormulas(workbook: Workbook) {
+        val evaluator = workbook.creationHelper.createFormulaEvaluator()
+        workbook.forEach { sheet: Sheet ->
+            sheet.forEach { row: Row ->
+                row.filter { it.cellType == CellType.FORMULA }.forEach { evaluator.evaluateFormulaCell(it) }
+            }
+        }
+    }
+
+    private fun dateCell(row: Row, column: Int, value: LocalDateTime, style: CellStyle) {
+        val cell: Cell = row.createCell(column)
+        cell.setCellValue(Date.from(value.atZone(ZoneId.systemDefault()).toInstant()))
+        cell.cellStyle = style
+    }
+
+    private fun style(workbook: Workbook, format: String): CellStyle {
+        val style = workbook.createCellStyle()
+        style.dataFormat = workbook.creationHelper.createDataFormat().getFormat(format)
+        return style
+    }
+
+    private fun collectingSheetProcessor(sheetName: String, target: MutableList<Pair<Int, List<Any?>>>) =
+        SheetBasedRowProcessor(
+            { lineNumber: Int, row: Values -> target.add(lineNumber to row.asList()) },
+            Predicate { false },
+            sheetName
+        )
+
+    private fun <T> withTimeZone(zone: String, block: () -> T): T {
+        val previous = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone(zone))
+        try {
+            return block()
+        } finally {
+            TimeZone.setDefault(previous)
+        }
+    }
+
+}

--- a/src/test/kotlin/sirius/web/data/XLSProcessorTest.kt
+++ b/src/test/kotlin/sirius/web/data/XLSProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data


### PR DESCRIPTION
### Description

Follow-up to #1728. Bumping `excel-streaming-reader` to 5.3.0 exposed how thin the coverage of our Excel import path was: a single 3x3 fixture with strings, integers and formulas.

**Parity tests.** `XLSProcessorTest` asserts every expectation against both formats, because `XLSProcessor` and `XLSXProcessor` share their cell extraction but obtain the `Workbook` from entirely different libraries - POI's `HSSFWorkbook` for XLS, the streaming reader for XLSX. A parity suite is what keeps the two backends from drifting apart, across future library bumps as well as across changes to the extraction itself.

Newly pinned: date and date-time cells, boolean cells, error cells (`1/0` reads as `null`), the integer/double normalization, whitespace trimming, interior gaps versus trailing empty cells, a whitespace-only row, a row without a single cell, column anchoring, the `errorHandler` contract in both directions, `importAllSheets`, and `runForSheets` including its missing-sheet report - which had no test whatsoever.

Two behaviours worth knowing, both now pinned:

- Line numbers count **processed** rows, not spreadsheet rows: the fixture's row in Excel row 11 arrives as line 9, because rows 9 and 10 hold no cells. Importer messages can therefore name a different row than the user sees in Excel.
- Every row is anchored at column A rather than at its own first cell, so a row starting in column C arrives with two leading `null`s instead of shifting left.

**Bug fix.** `runForSheets` only handled the way the streaming reader reports an unknown sheet (`MissingSheetException`, caught in order to log and continue). `HSSFWorkbook` returns `null` instead, so the same import of an **XLS** file died with a `NullPointerException` and took the sheets behind it down with it. Reachable in production: scireum-core's FabDis import hands the same sheet processors to either processor, depending only on the extension of the uploaded file.

### Known gap, deliberately not fixed here

An absent sheet is reported to the `TaskContext` as an *info* message and nothing marks the import erroneous. For a **mandatory** sheet that is worse than it sounds: in FabDis, `importTransactionHelper.start(...)` runs inside the `00_CARTOUCHE` row processor, and `close()` gates the assortment delete/mark pass on `importTransactionHelper.isActive()`. So a renamed Cartouche sheet now yields a *successful* import that silently skipped both the cartouche and the entire sync-source pass. That hazard already existed on the XLSX path; this PR extends it to XLS, where the NPE used to make the problem visible by accident.

Telling a mandatory sheet from an optional one needs something `SheetBasedRowProcessor` does not have: a way to declare itself required. Adding it touches this record's API and needs a decision in scireum-core, so it belongs in its own change rather than riding along here. The limitation is now stated in the `runForSheets` Javadoc. **Happy to raise a ticket for it.**

Also worth a ticket, unrelated to this change: because we trust `getCachedFormulaResultType()`, a `.xls` file whose cached formula results were dropped by the writing application imports text- and boolean-valued formula cells as `0`/`1`.

### Where the fixtures come from

POI writes the workbooks when a test runs, as `ExcelExportTest` already does - no binaries and no tooling, so the contents being asserted sit next to the assertions and adding a cell is an edit rather than a regeneration.

An earlier draft committed the workbooks as binaries, passed the XLSX ones through LibreOffice for a more realistic serialization and carried a generator to reproduce that pipeline. Measuring it deflated the idea: the only structural difference to POI's own output is `xl/theme/theme1.xml`, which no reader touches - POI's XSSF already writes shared strings, styles and doc properties. Meanwhile the conversion turned boolean literals into `TRUE()`/`FALSE()` formulas, normalized the empty-string cell to a blank and dropped the cell-less row, so it cost three workarounds and found no reader defect.

Coverage of files as a real application writes them stays where it already was: `LineBasedProcessorTest` reads `test.xlsx`, which was saved by Excel.

### Verification

- Full suite locally: 451 tests, 0 failures. `XLSProcessorTest` contributes 32.
- Date assertions verified timezone-independent under UTC, Europe/Berlin, Pacific/Auckland, America/Santiago and Asia/Kolkata; the date test pins the zone itself, since on a UTC JVM the conversion via `java.util.Date` cancels out and the assertion would otherwise hold even if the extraction stopped honouring the default zone.
- Reviewed adversarially from three angles, and the resulting findings are worked in. Mutation-verified in a throwaway worktree that the tests actually catch: hardcoding the date zone to UTC, anchoring rows at their own first cell, ignoring the `errorHandler`, dropping either of the two missing-sheet reports, and skipping the trailing-empty-cell trim. The first five all survived the initial draft of the suite.

### Additional Notes

- This PR fixes or works on following ticket(s): none - follow-up to #1728
- This PR is related to PR: #1728

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc) - **SonarLint was not run**, as it cannot be executed headlessly; please run *Analyze VCS Changed Files* in the IDE
- [x] Patch Tasks: not necessary
