### PR TITLE
Prevents tunnel back-pressure from stranding pooled connections

### DIFF
--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -99,6 +99,7 @@ public class TunnelHandler implements AsyncHandler<String> {
              + "required cross-thread visibility.")
     private volatile Channel upstreamChannel;
 
+
     private volatile boolean failed;
 
     TunnelHandler(Response response,
@@ -129,7 +130,7 @@ public class TunnelHandler implements AsyncHandler<String> {
     @Override
     public void onTcpConnectSuccess(InetSocketAddress remoteAddress, Channel connection) {
         this.timeToConnect = watch.elapsedMillis();
-        this.upstreamChannel = connection;
+        adoptUpstream(connection);
     }
 
     @Override
@@ -137,7 +138,21 @@ public class TunnelHandler implements AsyncHandler<String> {
         // Pooled connections never trigger onTcpConnectSuccess, but we still need a reference
         // to the upstream channel to apply back-pressure (toggling autoRead) once the response
         // headers have been received.
-        this.upstreamChannel = connection;
+        adoptUpstream(connection);
+
+        // A pause applied by a previous user of this connection can outlive that request:
+        // mirrorWritabilityToUpstream only verifies that the channel is open, and a connection
+        // sitting in the pool is open. Such a connection can never deliver a response, because
+        // installBackpressureBridge - which is what would re-apply the current writability - is
+        // only reached from onHeadersReceived, and no headers can arrive while reading is off.
+        // Reading is therefore restored here, at the one point where a pooled connection is handed
+        // to a new request.
+        if (!connection.config().isAutoRead()) {
+            WebServer.LOG.WARN("Tunnel: re-enabled reading on a pooled upstream connection which was"
+                               + " left paused by a previous request. Target: %s",
+                               webContext.getRequestedURI());
+            mirrorWritabilityToUpstream(true);
+        }
     }
 
     @Override
@@ -402,28 +417,99 @@ public class TunnelHandler implements AsyncHandler<String> {
                 mirrorWritabilityToUpstream(true);
             }
         });
+
+        // Authoritative restore: the removal above happens on the client's event loop and therefore
+        // possibly after the connection was pooled. Hand it back readable right now instead.
+        releaseUpstream();
+    }
+
+    /**
+     * Takes ownership of the given upstream connection.
+     * <p>
+     * A single handler can see more than one connection: AsyncHttpClient retries failed attempts, and each
+     * attempt reports its own channel. Whatever we did to the previous one has to be undone before we forget
+     * about it, otherwise a pause applied for this request outlives it on a connection which is about to be
+     * handed to somebody else.
+     *
+     * @param connection the connection this request will use from now on
+     */
+    private void adoptUpstream(Channel connection) {
+        Channel previous = upstreamChannel;
+        upstreamChannel = connection;
+        if (previous != null && previous != connection) {
+            applyAutoRead(previous, true);
+        }
+    }
+
+    /**
+     * Gives up the upstream connection, restoring its ability to read.
+     * <p>
+     * From here on the connection is no longer ours - most likely it goes straight back into
+     * AsyncHttpClient's pool - so it must be left in a state in which the next request can use it.
+     */
+    private void releaseUpstream() {
+        Channel released = upstreamChannel;
+        upstreamChannel = null;
+        if (released != null) {
+            applyAutoRead(released, true);
+        }
+    }
+
+    /**
+     * Sets {@code autoRead} on the given channel, making sure the mutation happens on that channel's own
+     * event loop.
+     *
+     * @param channel the channel to modify
+     * @param autoRead whether the channel should read on its own
+     */
+    @SuppressWarnings("resource")
+    @Explain("The eventLoop gets managed by Netty.")
+    private void applyAutoRead(Channel channel, boolean autoRead) {
+        if (!channel.isOpen()) {
+            return;
+        }
+        if (channel.eventLoop().inEventLoop()) {
+            if (mayApplyAutoRead(channel, autoRead)) {
+                channel.config().setAutoRead(autoRead);
+            }
+        } else {
+            channel.eventLoop().execute(() -> {
+                if (channel.isOpen() && mayApplyAutoRead(channel, autoRead)) {
+                    channel.config().setAutoRead(autoRead);
+                }
+            });
+        }
+    }
+
+    /**
+     * Decides whether a pending {@code autoRead} change may still be applied.
+     * <p>
+     * Pausing and releasing can be issued from different event loops - a writability change arrives on the
+     * client's loop, while completion arrives on the upstream's - so a pause can still be queued when the
+     * connection is given up, and would then take effect on a connection which is already back in the pool.
+     * Ownership is therefore re-checked at the moment the change is applied, not when it is issued. Re-enabling
+     * reading is always safe and always allowed.
+     *
+     * @param channel  the channel about to be modified
+     * @param autoRead the value about to be set
+     * @return <tt>true</tt> if the change may be applied
+     */
+    private boolean mayApplyAutoRead(Channel channel, boolean autoRead) {
+        return autoRead || channel == upstreamChannel;
     }
 
     /**
      * Mirrors the given writability state onto the upstream channel's {@code autoRead} flag,
      * making sure the mutation happens on the upstream channel's own event loop.
      */
-    @SuppressWarnings("resource")
-    @Explain("The upstream eventLoop gets managed by Netty.")
     private void mirrorWritabilityToUpstream(boolean writable) {
         Channel upstream = upstreamChannel;
-        if (upstream == null || !upstream.isOpen()) {
+        if (upstream == null) {
+            // Either no attempt is in flight, or this request has already given the connection up.
+            // Pausing it in that state would strand whichever request picks it up next.
             return;
         }
-        if (upstream.eventLoop().inEventLoop()) {
-            upstream.config().setAutoRead(writable);
-        } else {
-            upstream.eventLoop().execute(() -> {
-                if (upstream.isOpen()) {
-                    upstream.config().setAutoRead(writable);
-                }
-            });
-        }
+        applyAutoRead(upstream, writable);
     }
 
     private void commitAndCompleteResponse(HttpResponseBodyPart bodyPart, ByteBuf data) {

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -100,7 +100,6 @@ public class TunnelHandler implements AsyncHandler<String> {
              + "required cross-thread visibility.")
     private volatile Channel upstreamChannel;
 
-
     private volatile boolean failed;
 
     TunnelHandler(Response response,
@@ -150,8 +149,7 @@ public class TunnelHandler implements AsyncHandler<String> {
         // to a new request.
         if (!connection.config().isAutoRead()) {
             WebServer.LOG.WARN("Tunnel: re-enabled reading on a pooled upstream connection which was"
-                               + " left paused by a previous request. Target: %s",
-                               webContext.getRequestedURI());
+                               + " left paused by a previous request. Target: %s", webContext.getRequestedURI());
             mirrorWritabilityToUpstream(true);
         }
     }
@@ -488,7 +486,7 @@ public class TunnelHandler implements AsyncHandler<String> {
      * Sets {@code autoRead} on the given channel, making sure the mutation happens on that channel's own
      * event loop.
      *
-     * @param channel the channel to modify
+     * @param channel  the channel to modify
      * @param autoRead whether the channel should read on its own
      */
     @SuppressWarnings("resource")

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -30,6 +30,7 @@ import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Processor;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Value;
 import sirius.kernel.commons.ValueHolder;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.health.Exceptions;
@@ -208,7 +209,9 @@ public class TunnelHandler implements AsyncHandler<String> {
     public State onHeadersReceived(HttpHeaders httpHeaders) throws Exception {
         CallContext.setCurrent(callContext);
 
-        installBackpressureBridge();
+        if (shouldApplyBackpressure(httpHeaders)) {
+            installBackpressureBridge();
+        }
 
         if (webContext.responseCommitted) {
             if (WebServer.LOG.isFINE()) {
@@ -421,6 +424,32 @@ public class TunnelHandler implements AsyncHandler<String> {
         // Authoritative restore: the removal above happens on the client's event loop and therefore
         // possibly after the connection was pooled. Hand it back readable right now instead.
         releaseUpstream();
+    }
+
+    /**
+     * Determines whether this response is worth applying back-pressure to.
+     * <p>
+     * Back-pressure exists to stop a slow consumer from making us buffer an arbitrarily large download in
+     * memory. For a response which fits into a buffer or two that gains nothing, while still exposing the
+     * request to the pause/resume machinery - so small responses skip it entirely. A response whose length we
+     * do not know (chunked) is treated as large, because those are precisely the ones which can grow without
+     * bound.
+     *
+     * @param httpHeaders the upstream response headers
+     * @return <tt>true</tt> if the back-pressure bridge should be installed
+     */
+    private boolean shouldApplyBackpressure(HttpHeaders httpHeaders) {
+        if (!WebServer.isTunnelBackpressureEnabled()) {
+            return false;
+        }
+
+        long minResponseSize = WebServer.getTunnelBackpressureMinResponseSize();
+        if (minResponseSize <= 0) {
+            return true;
+        }
+
+        long contentLength = Value.of(httpHeaders.get(HttpHeaderNames.CONTENT_LENGTH)).asLong(-1);
+        return contentLength < 0 || contentLength >= minResponseSize;
     }
 
     /**

--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -137,6 +137,29 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
     private static long maxTimeToFirstByte;
 
     /**
+     * Config value determining whether tunneled responses apply back-pressure to their upstream
+     * (<tt>http.tunnel.backpressure.enabled</tt>).
+     * <p>
+     * This exists as an operational escape hatch, so the mechanism can be ruled in or out during an incident
+     * without a custom build. Turning it off re-introduces unbounded outbound buffering for slow consumers on
+     * large tunneled downloads, so it is not a safe permanent setting - use
+     * <tt>http.tunnel.backpressure.minResponseSize</tt> to limit <i>where</i> it applies instead.
+     */
+    @ConfigValue("http.tunnel.backpressure.enabled")
+    private static boolean tunnelBackpressureEnabled;
+
+    /**
+     * Config value of the response size from which on tunneled responses apply back-pressure
+     * (<tt>http.tunnel.backpressure.minResponseSize</tt>).
+     * <p>
+     * Below this size the whole body fits into a buffer or two anyway, so pausing the upstream achieves
+     * nothing while still exposing the request to the pause/resume machinery. Responses of unknown length
+     * (chunked) always apply back-pressure, as they are the ones that can be arbitrarily large.
+     */
+    @ConfigValue("http.tunnel.backpressure.minResponseSize")
+    private static long tunnelBackpressureMinResponseSize;
+
+    /**
      * Contains a list of IP ranges which are permitted to access this server. Access from unauthorized IPs will be
      * blocked at the lowest level possible (probably no connection will be accepted). The format accepted by this
      * field is defined by {@link IPRange#parseRangeSet(String)}.
@@ -394,6 +417,24 @@ public class WebServer implements Startable, Stoppable, Killable, MetricProvider
      */
     protected static long getMaxTimeToFirstByte() {
         return maxTimeToFirstByte;
+    }
+
+    /**
+     * Determines whether tunneled responses should apply back-pressure to their upstream at all.
+     *
+     * @return <tt>true</tt> if back-pressure is enabled, <tt>false</tt> to disable it entirely
+     */
+    protected static boolean isTunnelBackpressureEnabled() {
+        return tunnelBackpressureEnabled;
+    }
+
+    /**
+     * Returns the response size from which on back-pressure is applied to a tunneled upstream.
+     *
+     * @return the minimal response size in bytes
+     */
+    protected static long getTunnelBackpressureMinResponseSize() {
+        return tunnelBackpressureMinResponseSize;
     }
 
     /**

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -76,6 +76,20 @@ http {
     # Use 0 to disable.
     maxTimeToFirstByte = 2500
 
+    tunnel {
+        backpressure {
+            # Whether a tunnelled response slows its upstream down when the receiving client cannot keep up.
+            # This is an escape hatch for diagnosis - disabling it re-introduces unbounded buffering for slow
+            # consumers on large downloads. Prefer minResponseSize below to limit where it applies.
+            enabled = true
+
+            # Response size from which on back-pressure is applied. Smaller responses fit into a buffer or two
+            # anyway, so pausing the upstream gains nothing for them. Responses without a Content-Length
+            # (chunked) always apply back-pressure, as those are the ones which can be arbitrarily large.
+            minResponseSize = 256K
+        }
+    }
+
     # Maximal size of structured data (XML / JSON) which is accepted by the server. As this data is completely held
     # in memory, this value should not be too large.
     maxStructuredInputSize = 10M

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -182,6 +182,11 @@ public class TestController extends BasicController {
         webContext.respondWith().tunnel("http://localhost:9999/test/streaming-payload");
     }
 
+    @Routed("/tunnel/burst-payload")
+    public void tunnelBurstPayload(WebContext webContext) {
+        webContext.respondWith().tunnel("http://localhost:9999/test/burst-payload");
+    }
+
     @Routed("/tunnel/test_transform")
     public void tunnelTestTransform(WebContext webContext) {
         webContext.respondWith().tunnel("http://localhost:9999/api/test/test_large", buffer -> {

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -114,8 +114,7 @@ public class TestController extends BasicController {
                                     JSONStructuredOutput output,
                                     String parameter1,
                                     String parameter2) {
-        output.property("param1", parameter1);
-        output.property("param2", parameter2);
+        testJSONParams(webContext, output, parameter1, parameter2);
     }
 
     @InternalService

--- a/src/test/java/sirius/web/dispatch/TestDispatcher.java
+++ b/src/test/java/sirius/web/dispatch/TestDispatcher.java
@@ -17,6 +17,9 @@ import sirius.web.http.WebDispatcher;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * A test dispatcher used to verify the behavior of the web server and its tunnel.
+ */
 @Register
 public class TestDispatcher implements WebDispatcher {
 
@@ -75,9 +78,8 @@ public class TestDispatcher implements WebDispatcher {
             // control. Without it, the dispatcher would dump the entire payload into its own Netty
             // outbound buffer on the same JVM, masking any back-pressure applied on the tunnel
             // side.
-            ChunkedOutputStream out = ctx.respondWith()
-                                         .outputStream(HttpResponseStatus.OK, "text/plain")
-                                         .enableContentionControl();
+            ChunkedOutputStream out =
+                    ctx.respondWith().outputStream(HttpResponseStatus.OK, "text/plain").enableContentionControl();
             byte[] chunk = "THISISLARGECONTENT".getBytes(StandardCharsets.UTF_8);
             for (int i = 0; i < STREAMING_PAYLOAD_CHUNKS; i++) {
                 out.write(chunk);

--- a/src/test/java/sirius/web/dispatch/TestDispatcher.java
+++ b/src/test/java/sirius/web/dispatch/TestDispatcher.java
@@ -35,6 +35,15 @@ public class TestDispatcher implements WebDispatcher {
     public static final int STREAMING_PAYLOAD_TOTAL_BYTES = STREAMING_PAYLOAD_CHUNKS * 18;
     public static final String STREAMING_PAYLOAD_PATH = "/test/streaming-payload";
 
+    /**
+     * A payload that exceeds Netty's 64 KiB high watermark, so the tunnel's back-pressure bridge
+     * has to engage, yet is small enough for the upstream to hand over in a single burst and thus
+     * finish (and pool its connection) while the consuming client is still draining.
+     */
+    public static final int BURST_PAYLOAD_CHUNKS = 32_768;
+    public static final int BURST_PAYLOAD_TOTAL_BYTES = BURST_PAYLOAD_CHUNKS * 18;
+    public static final String BURST_PAYLOAD_PATH = "/test/burst-payload";
+
     @Override
     public DispatchDecision dispatch(WebContext ctx) throws Exception {
         if ("/large-blocking-calls".equalsIgnoreCase(ctx.getRequestedURI())) {
@@ -44,6 +53,20 @@ public class TestDispatcher implements WebDispatcher {
                 out.write("THISISLARGECONTENT".getBytes(StandardCharsets.UTF_8));
             }
             out.close();
+            return DispatchDecision.DONE;
+        }
+        if (BURST_PAYLOAD_PATH.equalsIgnoreCase(ctx.getRequestedURI())) {
+            // The deliberate opposite of STREAMING_PAYLOAD_PATH: no contention control, so the
+            // whole payload is dumped into the outbound buffer at once and the tunnel's upstream
+            // response completes (and its connection is returned to the pool) while the consuming
+            // client is still draining. That is the window in which a back-pressure pause can
+            // land on an already pooled connection.
+            OutputStream burst = ctx.respondWith().outputStream(HttpResponseStatus.OK, "text/plain");
+            byte[] burstChunk = "THISISLARGECONTENT".getBytes(StandardCharsets.UTF_8);
+            for (int i = 0; i < BURST_PAYLOAD_CHUNKS; i++) {
+                burst.write(burstChunk);
+            }
+            burst.close();
             return DispatchDecision.DONE;
         }
         if (STREAMING_PAYLOAD_PATH.equalsIgnoreCase(ctx.getRequestedURI())) {

--- a/src/test/java/sirius/web/http/TunnelHandlerOwnershipTest.java
+++ b/src/test/java/sirius/web/http/TunnelHandlerOwnershipTest.java
@@ -1,6 +1,6 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
  * http://www.scireum.de - info@scireum.de

--- a/src/test/java/sirius/web/http/TunnelHandlerOwnershipTest.java
+++ b/src/test/java/sirius/web/http/TunnelHandlerOwnershipTest.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TunnelHandlerOwnershipTest.java
+++ b/src/test/java/sirius/web/http/TunnelHandlerOwnershipTest.java
@@ -1,0 +1,83 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import sirius.kernel.SiriusExtension;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers what a {@link TunnelHandler} owes an upstream connection it stops using.
+ * <p>
+ * Back-pressure is applied by disabling {@code autoRead} on the upstream channel, but that channel belongs to
+ * AsyncHttpClient's connection pool rather than to the request. A single handler can see more than one of them,
+ * because a failed attempt is retried and each attempt reports its own channel. Whatever was done to a channel has
+ * to be undone before the handler lets go of it - otherwise a pause applied for this request survives on a
+ * connection which is about to be handed to somebody else, and that connection can never deliver a response:
+ * {@code installBackpressureBridge} is only reached from {@code onHeadersReceived}, and no headers can arrive while
+ * reading is disabled.
+ * <p>
+ * These tests drive the ownership callbacks directly. The full sequence cannot be provoked through a real request:
+ * a response small enough for the upstream to finish in one burst disappears into the loopback socket buffers,
+ * which makes the consumer writable again and lifts the pause, while a response large enough to keep the consumer
+ * blocked causes the upstream to be paused before it has finished - so its connection never reaches the pool.
+ */
+@ExtendWith(SiriusExtension.class)
+class TunnelHandlerOwnershipTest {
+
+    private static final InetSocketAddress ANY_ADDRESS = new InetSocketAddress("localhost", 9999);
+
+    /**
+     * Builds a handler which is complete enough to accept the ownership callbacks. None of them touch the client
+     * side, so an otherwise empty {@link WebContext} is sufficient.
+     */
+    private TunnelHandler createHandler() {
+        WebContext webContext = new WebContext();
+        webContext.setChannelHandlerContext(new EmbeddedChannel().pipeline().firstContext());
+        return new TunnelHandler(new Response(webContext), "http://localhost:9999/test", null, null, null);
+    }
+
+    @Test
+    void pausedConnectionIsRestoredWhenAPooledConnectionReplacesIt() {
+        TunnelHandler handler = createHandler();
+        EmbeddedChannel firstAttempt = new EmbeddedChannel();
+        EmbeddedChannel secondAttempt = new EmbeddedChannel();
+
+        handler.onConnectionPooled(firstAttempt);
+        // Stands in for the back-pressure bridge pausing the upstream while this request owned it.
+        firstAttempt.config().setAutoRead(false);
+
+        handler.onConnectionPooled(secondAttempt);
+
+        assertTrue(firstAttempt.config().isAutoRead(),
+                   "The replaced connection was left unable to read. It is back in the pool in that state, so the"
+                   + " next request to receive it cannot be answered until AsyncHttpClient's read timeout fires.");
+    }
+
+    @Test
+    void pausedConnectionIsRestoredWhenAFreshConnectionReplacesIt() {
+        TunnelHandler handler = createHandler();
+        EmbeddedChannel firstAttempt = new EmbeddedChannel();
+        EmbeddedChannel secondAttempt = new EmbeddedChannel();
+
+        handler.onConnectionPooled(firstAttempt);
+        firstAttempt.config().setAutoRead(false);
+
+        // A retry which has to establish a new connection reports it through onTcpConnectSuccess instead.
+        handler.onTcpConnectSuccess(ANY_ADDRESS, secondAttempt);
+
+        assertTrue(firstAttempt.config().isAutoRead(),
+                   "The replaced connection was left unable to read after a retry established a new one.");
+    }
+}

--- a/src/test/java/sirius/web/http/TunnelPoolProbe.java
+++ b/src/test/java/sirius/web/http/TunnelPoolProbe.java
@@ -1,0 +1,306 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.web.http;
+
+import io.netty.channel.Channel;
+import io.netty.util.HashedWheelTimer;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.AsyncHttpClientConfig;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.channel.ChannelPool;
+import org.asynchttpclient.netty.channel.DefaultChannelPool;
+import sirius.kernel.commons.Explain;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * Swaps the static HTTP client used by {@link Response#tunnel(String)} for one whose connection
+ * pool can be observed by tests.
+ * <p>
+ * {@link TunnelHandler} applies back-pressure by toggling {@code autoRead} on the <b>upstream</b>
+ * channel, which is a connection owned and re-used by AsyncHttpClient's pool. Nothing in the
+ * existing test suite looks at the state of that channel once the request which paused it has
+ * finished, so this probe records every channel that enters or leaves the pool while reading is
+ * disabled. A channel handed out in that state can never complete its next response: no bytes are
+ * read, so {@code onHeadersReceived} - and with it the code that would re-enable reading - never
+ * runs.
+ * <p>
+ * The pool is pinned to a single connection per host by default so that connection re-use is
+ * deterministic rather than incidental.
+ */
+public final class TunnelPoolProbe {
+
+    private static AsyncHttpClient previousClient;
+    private static AsyncHttpClient probeClient;
+    private static HashedWheelTimer timer;
+    private static RecordingChannelPool pool;
+
+    private TunnelPoolProbe() {
+    }
+
+    /**
+     * Installs the probe.
+     *
+     * @param maxConnectionsPerHost the size of the connection pool. Use <tt>1</tt> to force every
+     *                              request onto the same upstream connection.
+     * @param readTimeout           how long AsyncHttpClient waits for data before it aborts. The
+     *                              production default is one minute, which would make a stalled
+     *                              test hang for that long, so tests pass something short.
+     */
+    public static void install(int maxConnectionsPerHost, Duration readTimeout) {
+        previousClient = Response.asyncClient;
+
+        timer = new HashedWheelTimer();
+        DefaultAsyncHttpClientConfig.Builder builder = Dsl.config()
+                                                          .setCookieStore(null)
+                                                          // mirrors Response.getAsyncClient()
+                                                          .setRequestTimeout(Duration.ofSeconds(-1))
+                                                          .setReadTimeout(readTimeout)
+                                                          .setKeepAlive(true)
+                                                          .setMaxConnectionsPerHost(maxConnectionsPerHost);
+
+        AsyncHttpClientConfig poolConfig = builder.build();
+        pool = new RecordingChannelPool(new DefaultChannelPool(poolConfig, timer));
+
+        probeClient = Dsl.asyncHttpClient(builder.setChannelPool(pool));
+        Response.asyncClient = probeClient;
+    }
+
+    /**
+     * Restores the original client. Must be called from a teardown block, as the field is static
+     * and would otherwise leak into unrelated tests.
+     */
+    public static void restore() {
+        Response.asyncClient = previousClient;
+        previousClient = null;
+
+        if (probeClient != null) {
+            try {
+                probeClient.close();
+            } catch (Exception _) {
+                // Nothing we can do about a client which refuses to close, and failing here would
+                // mask the actual assertion of the test...
+            }
+            probeClient = null;
+        }
+        if (timer != null) {
+            timer.stop();
+            timer = null;
+        }
+        pool = null;
+    }
+
+    /**
+     * Lists the upstream connections which were <b>returned to</b> the pool while reading was
+     * disabled.
+     *
+     * @return a description per occurrence, empty if there was none
+     */
+    public static List<String> pausedOnOffer() {
+        return pool == null ? Collections.emptyList() : pool.snapshot(pool.pausedOnOffer);
+    }
+
+    /**
+     * Lists the upstream connections which were <b>handed out of</b> the pool while reading was
+     * disabled. Every entry here is a request that cannot make progress.
+     *
+     * @return a description per occurrence, empty if there was none
+     */
+    public static List<String> pausedOnPoll() {
+        return pool == null ? Collections.emptyList() : pool.snapshot(pool.pausedOnPoll);
+    }
+
+    /**
+     * Simulates the leak deterministically by disabling reading on every connection as it is
+     * returned to the pool.
+     * <p>
+     * {@code Pooled upstream connections are never left with reading disabled} shows that this
+     * state does occur on its own, but only for a few hundred milliseconds and only when the
+     * timing works out. Injecting it directly makes the <i>consequence</i> testable without
+     * depending on that race: a connection in this state cannot deliver a response, because
+     * nothing in AsyncHttpClient re-enables the flag and {@code installBackpressureBridge} is only
+     * reached once headers have arrived.
+     *
+     * @param poison whether to disable reading on pooled connections
+     */
+    public static void poisonPooledConnections(boolean poison) {
+        if (pool != null) {
+            pool.poison = poison;
+        }
+    }
+
+    /**
+     * Lists the upstream connections which were observed <b>sitting idle in the pool</b> with
+     * reading disabled. This is the defect state itself: the connection belongs to nobody, yet it
+     * will not read, so whichever request picks it up next cannot make progress.
+     *
+     * @return a description per occurrence, empty if there was none
+     */
+    public static List<String> pausedWhileIdle() {
+        return pool == null ? Collections.emptyList() : pool.snapshot(pool.pausedWhileIdle);
+    }
+
+    /**
+     * Lists pooled connections still unable to read {@value #STUCK_THRESHOLD_MILLIS}ms after being
+     * pooled. A brief pause is benign - the owning request may simply not have released the
+     * connection yet - but one that persists is a connection nobody can use again.
+     *
+     * @return a description per occurrence, empty if there was none
+     */
+    public static List<String> stuckWhileIdle() {
+        if (pool == null) {
+            return Collections.emptyList();
+        }
+        return pool.snapshot(pool.pausedWhileIdle)
+                   .stream()
+                   .filter(entry -> entry.contains("after " + STUCK_THRESHOLD_MILLIS + "ms"))
+                   .toList();
+    }
+
+    /**
+     * @return the number of times a pooled connection was re-used, so a test can assert that it
+     * actually exercised connection re-use instead of silently opening fresh connections
+     */
+    public static int reusedConnections() {
+        return pool == null ? 0 : pool.reused.size();
+    }
+
+    /**
+     * When to re-inspect a pooled connection. Spread out so a late pause is caught regardless of
+     * how long the event loop takes to get to it.
+     */
+    private static final int[] IDLE_PROBE_DELAYS_MILLIS = {20, 100, 400, 2_000};
+
+    /**
+     * How long after pooling the injected pause is applied - long enough to be past the restore
+     * performed when the previous request's bridge is removed.
+     */
+    private static final int POISON_DELAY_MILLIS = 400;
+
+    /**
+     * The probe delay beyond which a pause is considered stuck rather than transient.
+     */
+    private static final int STUCK_THRESHOLD_MILLIS = 2_000;
+
+    private static final class RecordingChannelPool implements ChannelPool {
+
+        private final ChannelPool delegate;
+        private final List<String> pausedOnOffer = Collections.synchronizedList(new ArrayList<>());
+        private final List<String> pausedOnPoll = Collections.synchronizedList(new ArrayList<>());
+        private final List<String> pausedWhileIdle = Collections.synchronizedList(new ArrayList<>());
+        private final List<String> reused = Collections.synchronizedList(new ArrayList<>());
+        /**
+         * Channels currently sitting in the pool. An idle check must only report a channel that is
+         * still pooled - once it has been handed to a new request, that request may pause it
+         * perfectly legitimately, and reporting it then would be a false positive.
+         */
+        private final Set<Channel> pooled = ConcurrentHashMap.newKeySet();
+        private volatile boolean poison;
+
+        private RecordingChannelPool(ChannelPool delegate) {
+            this.delegate = delegate;
+        }
+
+        private List<String> snapshot(List<String> source) {
+            synchronized (source) {
+                return new ArrayList<>(source);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("resource")
+        @Explain("The eventLoop gets managed by Netty.")
+        public boolean offer(Channel channel, Object partitionKey) {
+            if (!channel.config().isAutoRead()) {
+                pausedOnOffer.add(describe("returned to pool", channel, partitionKey));
+            }
+            boolean accepted = delegate.offer(channel, partitionKey);
+            if (!accepted) {
+                return false;
+            }
+
+            pooled.add(channel);
+            if (poison) {
+                // Deliberately delayed: the finishing request's bridge removal restores autoRead
+                // *after* the connection was pooled, so injecting immediately would simply be
+                // overwritten by it. This lands once the connection is genuinely idle.
+                channel.eventLoop()
+                       .schedule(() -> channel.config().setAutoRead(false), POISON_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+            }
+            // A pause queued by the finishing request can only land on the upstream event loop
+            // after it was pooled, so sampling once at offer time is not enough. These checks
+            // run on the channel's own event loop, i.e. after any such pending task.
+            for (int delay : IDLE_PROBE_DELAYS_MILLIS) {
+                watchIdleChannel(channel, partitionKey, delay);
+            }
+            return true;
+        }
+
+        @SuppressWarnings("resource")
+        @Explain("The eventLoop gets managed by Netty.")
+        private void watchIdleChannel(Channel channel, Object partitionKey, int delayMillis) {
+            channel.eventLoop().schedule(() -> {
+                if (channel.isOpen() && pooled.contains(channel) && !channel.config().isAutoRead()) {
+                    pausedWhileIdle.add(describe("idle in pool after " + delayMillis + "ms", channel, partitionKey));
+                }
+            }, delayMillis, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public Channel poll(Object partitionKey) {
+            Channel channel = delegate.poll(partitionKey);
+            if (channel != null) {
+                pooled.remove(channel);
+                reused.add(channel.id().asShortText());
+                if (!channel.config().isAutoRead()) {
+                    pausedOnPoll.add(describe("handed out of pool", channel, partitionKey));
+                }
+            }
+            return channel;
+        }
+
+        private String describe(String what, Channel channel, Object partitionKey) {
+            return what + " with autoRead=false: channel=" + channel.id().asShortText() + ", partition=" + partitionKey;
+        }
+
+        @Override
+        public boolean removeAll(Channel channel) {
+            pooled.remove(channel);
+            return delegate.removeAll(channel);
+        }
+
+        @Override
+        public boolean isOpen() {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public void destroy() {
+            delegate.destroy();
+        }
+
+        @Override
+        public void flushPartitions(Predicate<Object> predicate) {
+            delegate.flushPartitions(predicate);
+        }
+
+        @Override
+        public java.util.Map<String, Long> getIdleChannelCountPerHost() {
+            return delegate.getIdleChannelCountPerHost();
+        }
+    }
+}

--- a/src/test/java/sirius/web/http/TunnelPoolProbe.java
+++ b/src/test/java/sirius/web/http/TunnelPoolProbe.java
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
+++ b/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
@@ -1,6 +1,6 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
  * http://www.scireum.de - info@scireum.de

--- a/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
+++ b/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+@file:Suppress("DANGEROUS_CHARACTERS")
+
+package sirius.web.http
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Wait
+import sirius.kernel.commons.Watch
+import java.time.Duration
+import kotlin.test.assertTrue
+
+/**
+ * Covers the upstream half of the tunnel back-pressure bridge.
+ *
+ * [TunnelHandler] pauses the upstream connection with `setAutoRead(false)` whenever the client
+ * cannot keep up and re-enables it when the bridge is removed. Both of those happen as tasks on
+ * *different* event loops, while the upstream connection itself belongs to AsyncHttpClient's
+ * connection pool and outlives the request that paused it. `mirrorWritabilityToUpstream` only
+ * checks `upstream.isOpen()` - never whether the channel still belongs to the request - and an
+ * idle pooled connection is open.
+ *
+ * A connection left paused is unrecoverable for the request that picks it up next:
+ * `installBackpressureBridge` (which re-applies the current writability) is only reached from
+ * `onHeadersReceived`, and no headers can be received while reading is disabled. The request
+ * therefore hangs until AsyncHttpClient's `readTimeout` closes the connection - one minute in
+ * production, which is what the 14s-median / 59.7s-max "Long running tunneling" warnings on
+ * `oxomi.cos.scireum.com` look like.
+ *
+ * The existing tests in `WebServerTest` cover the *client* side of the bridge (full delivery to a
+ * slow consumer, and no handler leak across keep-alive). Neither observes the upstream channel
+ * after the request ends, which is the seam these tests close.
+ */
+@ExtendWith(SiriusExtension::class)
+class TunnelUpstreamPoolTest {
+
+    @AfterEach
+    fun restoreTunnelClient() {
+        TunnelPoolProbe.restore()
+    }
+
+    /**
+     * Asserts the consequence, with the leak injected rather than raced for.
+     *
+     * The first request leaves a pooled connection behind, which the probe then puts into exactly
+     * the state the leak produces. With the pool pinned to a single connection, the second request
+     * has to re-use it. Today nothing repairs the flag, so no response can arrive until
+     * AsyncHttpClient's read timeout closes the connection - the production timeout is 60s, which
+     * is what the 14s-median / 59.7s-max `Long running tunneling` warnings look like.
+     *
+     * Enabling reading in `onConnectionPooled` fixes this and makes the test pass.
+     */
+    @Test
+    fun `A pooled connection with reading disabled is repaired before it is reused`() {
+        TunnelPoolProbe.install(1, READ_TIMEOUT)
+
+        // Establishes and pools a connection, then leaves it behind in the broken state.
+        WebServerTest.callAndRead(SMALL_TUNNEL)
+        TunnelPoolProbe.poisonPooledConnections(true)
+        WebServerTest.callAndRead(SMALL_TUNNEL)
+        Wait.millis(POISON_SETTLE_MILLIS)
+
+        val reusedBefore = TunnelPoolProbe.reusedConnections()
+        val watch = Watch.start()
+        // A stalled tunnel does not just take long, it ultimately fails once the read timeout
+        // closes the connection - so the failure has to be caught to be reported properly.
+        var tunnelFailure: Exception? = null
+        try {
+            WebServerTest.callAndRead(SMALL_TUNNEL)
+        } catch (exception: Exception) {
+            tunnelFailure = exception
+        }
+        val elapsed = watch.elapsedMillis()
+
+        assertTrue(
+            TunnelPoolProbe.reusedConnections() > reusedBefore,
+            "Precondition not reached: the timed request opened a fresh connection instead of"
+                    + " re-using the pooled one, so nothing was tested."
+        )
+        assertTrue(
+            TunnelPoolProbe.pausedOnPoll().isNotEmpty(),
+            "Precondition not reached: the pooled connection was readable when it was handed out,"
+                    + " so the injected pause never took effect."
+        )
+        assertTrue(
+            tunnelFailure == null && elapsed <= STALL_THRESHOLD_MILLIS,
+            "A tunnel which re-used a pooled connection with reading disabled took ${elapsed}ms"
+                    + " (threshold ${STALL_THRESHOLD_MILLIS}ms, read timeout"
+                    + " ${READ_TIMEOUT.toMillis()}ms)"
+                    + (tunnelFailure?.let { " and then failed with ${it.javaClass.simpleName}: ${it.message}" } ?: "")
+                    + ". Nothing re-enabled reading on that connection, so no response could"
+                    + " arrive until the timeout closed it."
+        )
+    }
+
+    companion object {
+        private const val SMALL_TUNNEL = "/tunnel/test"
+
+        /**
+         * The leak needs a pause to be queued while the connection is being pooled, so a single
+         * round can miss it. A handful of rounds keep the test quick while making a hit likely.
+         */
+        private const val ROUNDS = 5
+
+        private val READ_TIMEOUT: Duration = Duration.ofSeconds(5)
+
+        /**
+         * Well above a healthy loopback tunnel (single-digit milliseconds) and well below the read
+         * timeout, so the assertion separates "slow machine" from "not reading at all".
+         */
+        private const val STALL_THRESHOLD_MILLIS = 2_000L
+
+        /** Must outlast the probe's injection delay, so the pause is in place before we measure. */
+        private const val POISON_SETTLE_MILLIS = 800
+
+    }
+}

--- a/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
+++ b/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
@@ -16,7 +16,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import sirius.kernel.SiriusExtension
 import sirius.kernel.commons.Wait
 import sirius.kernel.commons.Watch
+import sirius.web.dispatch.TestDispatcher
+import java.net.HttpURLConnection
+import java.net.URI
 import java.time.Duration
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -46,6 +50,72 @@ class TunnelUpstreamPoolTest {
     @AfterEach
     fun restoreTunnelClient() {
         TunnelPoolProbe.restore()
+    }
+
+    /**
+     * Reads a response in small blocks with a pause between them, so the server side runs out of
+     * writable buffer, and the bridge has to pause the upstream repeatedly.
+     */
+    private fun drainSlowly(uri: String, blockSize: Int = 8 * 1024, pauseMillis: Int = 1): Int {
+        val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
+        connection.connect()
+
+        var totalBytes = 0
+        val block = ByteArray(blockSize)
+        var read: Int
+        try {
+            connection.inputStream.use { input ->
+                while (input.read(block).also { read = it } > 0) {
+                    totalBytes += read
+                    Wait.millis(pauseMillis)
+                }
+            }
+        } finally {
+            connection.disconnect()
+        }
+
+        return totalBytes
+    }
+
+    /**
+     * Asserts the invariant directly: a pooled upstream connection must always be readable.
+     *
+     * This is the assertion a fix has to satisfy, and it does not depend on any timing threshold.
+     */
+    @Test
+    fun `Pooled upstream connections are never left with reading disabled`() {
+        TunnelPoolProbe.install(1, Duration.ofSeconds(5))
+
+        repeat(ROUNDS) {
+            // The contention-controlled endpoint exercises the bridge across many pause/resume
+            // cycles, the burst endpoint completes its upstream response (and pools the
+            // connection) while this client is still draining.
+            assertEquals(TestDispatcher.STREAMING_PAYLOAD_TOTAL_BYTES, drainSlowly(STREAMING_TUNNEL))
+            assertEquals(TestDispatcher.BURST_PAYLOAD_TOTAL_BYTES, drainSlowly(BURST_TUNNEL, 4 * 1024, 4))
+            WebServerTest.callAndRead(SMALL_TUNNEL)
+        }
+
+        assertTrue(
+            TunnelPoolProbe.reusedConnections() > 0,
+            "The test never re-used a pooled connection, so it cannot have exercised the bug."
+        )
+        assertTrue(
+            TunnelPoolProbe.stuckWhileIdle().isEmpty(),
+            "Pooled upstream connections were still unable to read 2s after being pooled, so they"
+                    + " are unusable for any future request:\n"
+                    + TunnelPoolProbe.stuckWhileIdle().joinToString("\n")
+                    + "\n(transient observations: ${TunnelPoolProbe.pausedWhileIdle().size})"
+        )
+        assertTrue(
+            TunnelPoolProbe.pausedOnPoll().isEmpty(),
+            "Paused upstream connections were handed out to new requests, which can only end in a"
+                    + " read timeout:\n" + TunnelPoolProbe.pausedOnPoll().joinToString("\n")
+        )
+        assertTrue(
+            TunnelPoolProbe.pausedOnOffer().isEmpty(),
+            "Upstream connections were returned to the pool while still paused:\n"
+                    + TunnelPoolProbe.pausedOnOffer().joinToString("\n")
+        )
     }
 
     /**
@@ -102,7 +172,17 @@ class TunnelUpstreamPoolTest {
         )
     }
 
+    // Note: a test that reproduces the *whole* chain end to end - a real back-pressure pause
+    // leaking onto a pooled connection AND a second request then stalling on it - cannot be built
+    // in-process. Keeping a consumer unwritable needs a payload of several MiB, but at that size
+    // the bridge pauses the upstream before its response completes, so the connection is never
+    // pooled; a payload small enough to complete in one burst vanishes into the loopback socket
+    // buffers, which makes the consumer writable again and undoes the pause. The two tests above
+    // therefore split the chain: the first shows the state occurs, the second shows it is fatal.
+
     companion object {
+        private const val STREAMING_TUNNEL = "/tunnel/streaming-payload"
+        private const val BURST_TUNNEL = "/tunnel/burst-payload"
         private const val SMALL_TUNNEL = "/tunnel/test"
 
         /**

--- a/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
+++ b/src/test/kotlin/sirius/web/http/TunnelUpstreamPoolTest.kt
@@ -3,7 +3,7 @@
  * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 @file:Suppress("DANGEROUS_CHARACTERS")


### PR DESCRIPTION
### Description

Back-pressure for tunnelled responses (SE-15103, #1611) slows the upstream down by disabling `autoRead` on its channel. That channel belongs to AsyncHttpClient's connection pool and therefore outlives the request which paused it, while `mirrorWritabilityToUpstream` only verified that the channel was still open — not that it still belonged to the request. A pause could consequently survive on a connection that was already back in the pool, and such a connection can never answer: the code which would re-apply the current writability is only reached from `onHeadersReceived`, and no headers can arrive while reading is disabled. The request hangs until AsyncHttpClient's read timeout closes the connection, which is one minute by default.

Ownership of an upstream connection is now explicit, so a channel that gets replaced by a retry or given up at the end of a request is always left readable. The ownership check happens at the moment the change is applied rather than when it is issued, because pausing arrives on the client's event loop while releasing arrives on the upstream's — an already queued pause could otherwise still take effect afterwards. `onConnectionPooled` additionally restores reading on a connection that arrives paused and logs a warning; that is a deliberate second line of defence, and the warning makes any remaining gap visible.

The final commit is a framework enhancement rather than part of the fix. `http.tunnel.backpressure.minResponseSize` keeps small responses out of the mechanism altogether — they fit into a buffer or two, so pausing the upstream gains nothing for them — while responses without a `Content-Length` continue to get back-pressure, as those are the ones which can grow without bound. `http.tunnel.backpressure.enabled` exists so the mechanism can be ruled in or out on an installation without a custom build.

Two things worth knowing for review:

- The first commit is intentionally red. It adds the tests before the fix, so anyone bisecting through this range will see three failures there.
- The pause-versus-release ordering across the two event loops is not covered by a test. That interleaving cannot be provoked from a test, and the commit body states so rather than implying full coverage.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1271](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1271)
- This PR is related to PR: https://github.com/scireum/sirius-web/pull/1611

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.

🤖 Generated with Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
