### PR TITLE
Moves the copyright headers to Stuttgart and https

### DIFF
--- a/src/main/java/sirius/pasta/Pasta.java
+++ b/src/main/java/sirius/pasta/Pasta.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta;

--- a/src/main/java/sirius/pasta/noodle/Callable.java
+++ b/src/main/java/sirius/pasta/noodle/Callable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/ClassAliasProvider.java
+++ b/src/main/java/sirius/pasta/noodle/ClassAliasProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/ConstantCall.java
+++ b/src/main/java/sirius/pasta/noodle/ConstantCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/Environment.java
+++ b/src/main/java/sirius/pasta/noodle/Environment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/InterpreterCall.java
+++ b/src/main/java/sirius/pasta/noodle/InterpreterCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/Invocation.java
+++ b/src/main/java/sirius/pasta/noodle/Invocation.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/LambdaEnvironment.java
+++ b/src/main/java/sirius/pasta/noodle/LambdaEnvironment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/LambdaHandler.java
+++ b/src/main/java/sirius/pasta/noodle/LambdaHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/MethodPointer.java
+++ b/src/main/java/sirius/pasta/noodle/MethodPointer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/NLSCall.java
+++ b/src/main/java/sirius/pasta/noodle/NLSCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/OpCode.java
+++ b/src/main/java/sirius/pasta/noodle/OpCode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/ReturnVariableCall.java
+++ b/src/main/java/sirius/pasta/noodle/ReturnVariableCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/ScriptingException.java
+++ b/src/main/java/sirius/pasta/noodle/ScriptingException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
+++ b/src/main/java/sirius/pasta/noodle/SharedConstantPool.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/SimpleEnvironment.java
+++ b/src/main/java/sirius/pasta/noodle/SimpleEnvironment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
+++ b/src/main/java/sirius/pasta/noodle/SiriusClassAliasProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle;

--- a/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Assembler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/CompilationContext.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/CompilationContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/CompileError.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/CompileError.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/CompileException.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/CompileException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/InputProcessor.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/InputProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/LegacyGlobalsHandler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/LegacyGlobalsHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/NoodleCompiler.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/NoodleCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/Parser.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/Parser.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/SourceCodeInfo.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/SourceCodeInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/TypeTools.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/VariableScoper.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/VariableScoper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/AssignmentStatement.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/AssignmentStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/BinaryOperation.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/BinaryOperation.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/BlockStatement.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/BlockStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/Call.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/Call.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/Conjunction.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/Conjunction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/Constant.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/Constant.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/ConstructorCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/ConstructorCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/Disjunction.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/Disjunction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/ForStatement.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/ForStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/IfStatement.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/IfStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/InstanceOfCheck.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/InstanceOfCheck.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/IntrinsicCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/IntrinsicCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/LambdaNode.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/LambdaNode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MacroCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MacroCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/MethodCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/NativeCast.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/NativeCast.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/Node.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/Node.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/PopField.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/PopField.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/PushField.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/PushField.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/PushTemporary.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/PushTemporary.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/RawClassLiteral.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/RawClassLiteral.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/ReturnStatement.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/ReturnStatement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/Statement.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/Statement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/TernaryOperation.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/TernaryOperation.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/compiler/ir/UnaryOperation.java
+++ b/src/main/java/sirius/pasta/noodle/compiler/ir/UnaryOperation.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler.ir;

--- a/src/main/java/sirius/pasta/noodle/macros/ApplyMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ApplyMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/Base64Macro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/Base64Macro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/Base64ResourceMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/Base64ResourceMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/BasicMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/BasicMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/BlockwiseMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/BlockwiseMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/ConfigMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ConfigMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/DateComparingBaseMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/DateComparingBaseMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/EnumValuesMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EnumValuesMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/EnvironmentModeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EnvironmentModeMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/EpochTimeInDaysMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EpochTimeInDaysMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/EscapeJsMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/EscapeJsMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/ExpandMessagesMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ExpandMessagesMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/FormatDateMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatDateMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/FormatDateTimeWithoutSecondsMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatDateTimeWithoutSecondsMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/FormatIsoMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatIsoMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/FormatMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/FormatSizeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatSizeMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/FormatTimeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/FormatTimeMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/HelperMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/HelperMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/I18nMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/I18nMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/InlineResourceMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/InlineResourceMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/InlineSvgMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/InlineSvgMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/InlineSvgResourceMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/InlineSvgResourceMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsAfterMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsAfterMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsBeforeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsBeforeMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsDevelopmentMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsDevelopmentMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsFilledMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsFilledMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsFrameworkEnabledMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsFrameworkEnabledMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsProductionMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsProductionMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/IsStagingMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/IsStagingMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/JoinMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/JoinMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/JsonMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/JsonMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/LeftPadMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/LeftPadMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/LimitMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/LimitMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/LinkBuilderMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/LinkBuilderMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/Macro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/Macro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/MonthNameMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/MonthNameMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/NowMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/NowMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/PartMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/PartMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/RightPadMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/RightPadMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/SmartTranslateMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/SmartTranslateMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/SvgMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/SvgMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/SvgResourceMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/SvgResourceMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/ToListMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToListMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/ToMachineStringMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToMachineStringMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/ToSpokenDateMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToSpokenDateMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/ToUserStringMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/ToUserStringMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/TodayMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/TodayMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/UrlEncodeMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/UrlEncodeMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/UserMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/UserMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/XmlMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/XmlMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/macros/XmlProcessingMacro.java
+++ b/src/main/java/sirius/pasta/noodle/macros/XmlProcessingMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros;

--- a/src/main/java/sirius/pasta/noodle/sandbox/NoodleSandbox.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/NoodleSandbox.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/Sandbox.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/main/java/sirius/pasta/noodle/sandbox/SandboxDetector.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/SandboxDetector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/main/java/sirius/pasta/noodle/sandbox/SandboxMode.java
+++ b/src/main/java/sirius/pasta/noodle/sandbox/SandboxMode.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
+++ b/src/main/java/sirius/pasta/tagliatelle/Tagliatelle.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/main/java/sirius/pasta/tagliatelle/TagliatelleController.java
+++ b/src/main/java/sirius/pasta/tagliatelle/TagliatelleController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/main/java/sirius/pasta/tagliatelle/Template.java
+++ b/src/main/java/sirius/pasta/tagliatelle/Template.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/main/java/sirius/pasta/tagliatelle/TemplateArgument.java
+++ b/src/main/java/sirius/pasta/tagliatelle/TemplateArgument.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/main/java/sirius/pasta/tagliatelle/TemplateExtension.java
+++ b/src/main/java/sirius/pasta/tagliatelle/TemplateExtension.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/main/java/sirius/pasta/tagliatelle/TemplateReference.java
+++ b/src/main/java/sirius/pasta/tagliatelle/TemplateReference.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/AttributeExpressionHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/AttributeExpressionHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/EvalExpressionHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/EvalExpressionHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/ExpressionHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/ExpressionHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/ForHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/ForHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/IfHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/IfHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/IncludeHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/IncludeHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/InvokeHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/InvokeHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/RawHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/RawHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompilationContext.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompilationContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/compiler/TemplateCompiler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.compiler;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/AttributeExpressionEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/AttributeExpressionEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/BlockEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/BlockEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/CompositeEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ConditionalEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ConditionalEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ConstantEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/DynamicInvokeTemplateEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/DynamicInvokeTemplateEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/Emitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/Emitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ExpressionEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ExpressionEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/ExtraBlockEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/ExtraBlockEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/InvokeTemplateEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/InvokeTemplateEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/LoopEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/LoopEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/LoopState.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/LoopState.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/PushLocalEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/PushLocalEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/RawEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/RawEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/emitter/SwitchEmitter.java
+++ b/src/main/java/sirius/pasta/tagliatelle/emitter/SwitchEmitter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.emitter;

--- a/src/main/java/sirius/pasta/tagliatelle/macros/CurrentRenderContextMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/CurrentRenderContextMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.macros;

--- a/src/main/java/sirius/pasta/tagliatelle/macros/GenerateIdMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/GenerateIdMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.macros;

--- a/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/IfNotDefinedMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.macros;

--- a/src/main/java/sirius/pasta/tagliatelle/macros/RenderBlockMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/RenderBlockMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.macros;

--- a/src/main/java/sirius/pasta/tagliatelle/macros/StaticAssetUriMacro.java
+++ b/src/main/java/sirius/pasta/tagliatelle/macros/StaticAssetUriMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.macros;

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/GlobalRenderContext.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/GlobalRenderContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.rendering;

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/LocalRenderContext.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/LocalRenderContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.rendering;

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/RenderCall.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/RenderCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.rendering;

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/RenderException.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/RenderException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.rendering;

--- a/src/main/java/sirius/pasta/tagliatelle/rendering/StackAllocator.java
+++ b/src/main/java/sirius/pasta/tagliatelle/rendering/StackAllocator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.rendering;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ArgTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/BlockTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DefineTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/DynamicInvokeTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ElseTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ElseTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtensionsTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ExtraBlockTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/ForTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IfTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/IncludeTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/InvokeTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/InvokeTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/LocalTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/PragmaTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/RawTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/RawTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/RenderEmitterCall.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/RenderEmitterCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/RenderTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SassTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/SwitchTag.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TagHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TagHandlerFactory.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TagHandlerFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/pasta/tagliatelle/tags/TaglibTagHandler.java
+++ b/src/main/java/sirius/pasta/tagliatelle/tags/TaglibTagHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle.tags;

--- a/src/main/java/sirius/web/ErrorCodeException.java
+++ b/src/main/java/sirius/web/ErrorCodeException.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web;

--- a/src/main/java/sirius/web/controller/AutocompleteHelper.java
+++ b/src/main/java/sirius/web/controller/AutocompleteHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/BasicController.java
+++ b/src/main/java/sirius/web/controller/BasicController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Controller.java
+++ b/src/main/java/sirius/web/controller/Controller.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/ControllerDispatcher.java
+++ b/src/main/java/sirius/web/controller/ControllerDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/DefaultRoute.java
+++ b/src/main/java/sirius/web/controller/DefaultRoute.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/ErrorMessageTransformer.java
+++ b/src/main/java/sirius/web/controller/ErrorMessageTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Facet.java
+++ b/src/main/java/sirius/web/controller/Facet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/FacetItem.java
+++ b/src/main/java/sirius/web/controller/FacetItem.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/HttpMethod.java
+++ b/src/main/java/sirius/web/controller/HttpMethod.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Interceptor.java
+++ b/src/main/java/sirius/web/controller/Interceptor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Message.java
+++ b/src/main/java/sirius/web/controller/Message.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/MessageExpander.java
+++ b/src/main/java/sirius/web/controller/MessageExpander.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/MessageExpanders.java
+++ b/src/main/java/sirius/web/controller/MessageExpanders.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Page.java
+++ b/src/main/java/sirius/web/controller/Page.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/PreserveErrorMessageTransformer.java
+++ b/src/main/java/sirius/web/controller/PreserveErrorMessageTransformer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Route.java
+++ b/src/main/java/sirius/web/controller/Route.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/Routed.java
+++ b/src/main/java/sirius/web/controller/Routed.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/controller/SubScope.java
+++ b/src/main/java/sirius/web/controller/SubScope.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/main/java/sirius/web/data/CSVProcessor.java
+++ b/src/main/java/sirius/web/data/CSVProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/data/ExcelExport.java
+++ b/src/main/java/sirius/web/data/ExcelExport.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/data/LineBasedProcessor.java
+++ b/src/main/java/sirius/web/data/LineBasedProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/data/RowProcessor.java
+++ b/src/main/java/sirius/web/data/RowProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/data/SheetBasedRowProcessor.java
+++ b/src/main/java/sirius/web/data/SheetBasedRowProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/data/XLSProcessor.java
+++ b/src/main/java/sirius/web/data/XLSProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/data/XLSXProcessor.java
+++ b/src/main/java/sirius/web/data/XLSXProcessor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data;

--- a/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/AssetsDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch;

--- a/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/DefaultDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch;

--- a/src/main/java/sirius/web/dispatch/HelpDispatcher.java
+++ b/src/main/java/sirius/web/dispatch/HelpDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch;

--- a/src/main/java/sirius/web/dispatch/SassFunction.java
+++ b/src/main/java/sirius/web/dispatch/SassFunction.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch;

--- a/src/main/java/sirius/web/dispatch/SiriusSassGenerator.java
+++ b/src/main/java/sirius/web/dispatch/SiriusSassGenerator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch;

--- a/src/main/java/sirius/web/dispatch/package-info.java
+++ b/src/main/java/sirius/web/dispatch/package-info.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /**

--- a/src/main/java/sirius/web/event/TemplateInvocationHandler.java
+++ b/src/main/java/sirius/web/event/TemplateInvocationHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.event;

--- a/src/main/java/sirius/web/health/CachingLoadInfoProvider.java
+++ b/src/main/java/sirius/web/health/CachingLoadInfoProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/Cluster.java
+++ b/src/main/java/sirius/web/health/Cluster.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/ClusterManager.java
+++ b/src/main/java/sirius/web/health/ClusterManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/LoadInfo.java
+++ b/src/main/java/sirius/web/health/LoadInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/LoadInfoProvider.java
+++ b/src/main/java/sirius/web/health/LoadInfoProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/NodeInfo.java
+++ b/src/main/java/sirius/web/health/NodeInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/SystemController.java
+++ b/src/main/java/sirius/web/health/SystemController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health;

--- a/src/main/java/sirius/web/health/console/ConsoleController.java
+++ b/src/main/java/sirius/web/health/console/ConsoleController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health.console;

--- a/src/main/java/sirius/web/health/console/HTTPCommand.java
+++ b/src/main/java/sirius/web/health/console/HTTPCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health.console;

--- a/src/main/java/sirius/web/health/console/RoutesCommand.java
+++ b/src/main/java/sirius/web/health/console/RoutesCommand.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health.console;

--- a/src/main/java/sirius/web/health/console/package-info.java
+++ b/src/main/java/sirius/web/health/console/package-info.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /**

--- a/src/main/java/sirius/web/health/package-info.java
+++ b/src/main/java/sirius/web/health/package-info.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /**

--- a/src/main/java/sirius/web/http/ActiveHTTPConnection.java
+++ b/src/main/java/sirius/web/http/ActiveHTTPConnection.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/CSRFHelper.java
+++ b/src/main/java/sirius/web/http/CSRFHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/ChunkedOutputStream.java
+++ b/src/main/java/sirius/web/http/ChunkedOutputStream.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/ContentHandler.java
+++ b/src/main/java/sirius/web/http/ContentHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/DispatcherPipeline.java
+++ b/src/main/java/sirius/web/http/DispatcherPipeline.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/DistributedUserMessageCache.java
+++ b/src/main/java/sirius/web/http/DistributedUserMessageCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/Firewall.java
+++ b/src/main/java/sirius/web/http/Firewall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/HttpPipeliningHandler.java
+++ b/src/main/java/sirius/web/http/HttpPipeliningHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/IPRange.java
+++ b/src/main/java/sirius/web/http/IPRange.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/InputStreamHandler.java
+++ b/src/main/java/sirius/web/http/InputStreamHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/LangHelper.java
+++ b/src/main/java/sirius/web/http/LangHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/Limited.java
+++ b/src/main/java/sirius/web/http/Limited.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/LowLevelHandler.java
+++ b/src/main/java/sirius/web/http/LowLevelHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/MimeHelper.java
+++ b/src/main/java/sirius/web/http/MimeHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/QueryString.java
+++ b/src/main/java/sirius/web/http/QueryString.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/Response.java
+++ b/src/main/java/sirius/web/http/Response.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/SSLWebServerInitializer.java
+++ b/src/main/java/sirius/web/http/SSLWebServerInitializer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/SendFile.java
+++ b/src/main/java/sirius/web/http/SendFile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/SessionSecretComputer.java
+++ b/src/main/java/sirius/web/http/SessionSecretComputer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/SmartHttpContentCompressor.java
+++ b/src/main/java/sirius/web/http/SmartHttpContentCompressor.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/TunnelHandler.java
+++ b/src/main/java/sirius/web/http/TunnelHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/Unlimited.java
+++ b/src/main/java/sirius/web/http/Unlimited.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/UserAgent.java
+++ b/src/main/java/sirius/web/http/UserAgent.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/UserMessagesCache.java
+++ b/src/main/java/sirius/web/http/UserMessagesCache.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebContext.java
+++ b/src/main/java/sirius/web/http/WebContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 package sirius.web.http;
 

--- a/src/main/java/sirius/web/http/WebDispatcher.java
+++ b/src/main/java/sirius/web/http/WebDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebServer.java
+++ b/src/main/java/sirius/web/http/WebServer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebServerHandler.java
+++ b/src/main/java/sirius/web/http/WebServerHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebServerInitializer.java
+++ b/src/main/java/sirius/web/http/WebServerInitializer.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebsocketDispatcher.java
+++ b/src/main/java/sirius/web/http/WebsocketDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebsocketHandler.java
+++ b/src/main/java/sirius/web/http/WebsocketHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/WebsocketSession.java
+++ b/src/main/java/sirius/web/http/WebsocketSession.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/main/java/sirius/web/http/package-info.java
+++ b/src/main/java/sirius/web/http/package-info.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /**

--- a/src/main/java/sirius/web/mails/Attachment.java
+++ b/src/main/java/sirius/web/mails/Attachment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/BufferedAttachment.java
+++ b/src/main/java/sirius/web/mails/BufferedAttachment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/MailLog.java
+++ b/src/main/java/sirius/web/mails/MailLog.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/MailSender.java
+++ b/src/main/java/sirius/web/mails/MailSender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/Mails.java
+++ b/src/main/java/sirius/web/mails/Mails.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/ResourceAttachment.java
+++ b/src/main/java/sirius/web/mails/ResourceAttachment.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/SMTPConfiguration.java
+++ b/src/main/java/sirius/web/mails/SMTPConfiguration.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/mails/SendMailTask.java
+++ b/src/main/java/sirius/web/mails/SendMailTask.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/main/java/sirius/web/resources/ClasspathCustomizationResolver.java
+++ b/src/main/java/sirius/web/resources/ClasspathCustomizationResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.resources;

--- a/src/main/java/sirius/web/resources/ClasspathResolver.java
+++ b/src/main/java/sirius/web/resources/ClasspathResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.resources;

--- a/src/main/java/sirius/web/resources/LocalPathResolver.java
+++ b/src/main/java/sirius/web/resources/LocalPathResolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.resources;

--- a/src/main/java/sirius/web/resources/Resolver.java
+++ b/src/main/java/sirius/web/resources/Resolver.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.resources;

--- a/src/main/java/sirius/web/resources/Resource.java
+++ b/src/main/java/sirius/web/resources/Resource.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.resources;

--- a/src/main/java/sirius/web/resources/Resources.java
+++ b/src/main/java/sirius/web/resources/Resources.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.resources;

--- a/src/main/java/sirius/web/sass/Functions.java
+++ b/src/main/java/sirius/web/sass/Functions.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/main/java/sirius/web/sass/Generator.java
+++ b/src/main/java/sirius/web/sass/Generator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/main/java/sirius/web/sass/Output.java
+++ b/src/main/java/sirius/web/sass/Output.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/main/java/sirius/web/sass/Parser.java
+++ b/src/main/java/sirius/web/sass/Parser.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/main/java/sirius/web/sass/Scope.java
+++ b/src/main/java/sirius/web/sass/Scope.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/main/java/sirius/web/sass/ast/Attribute.java
+++ b/src/main/java/sirius/web/sass/ast/Attribute.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Color.java
+++ b/src/main/java/sirius/web/sass/ast/Color.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Expression.java
+++ b/src/main/java/sirius/web/sass/ast/Expression.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/FunctionCall.java
+++ b/src/main/java/sirius/web/sass/ast/FunctionCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/MediaFilter.java
+++ b/src/main/java/sirius/web/sass/ast/MediaFilter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Mixin.java
+++ b/src/main/java/sirius/web/sass/ast/Mixin.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/MixinReference.java
+++ b/src/main/java/sirius/web/sass/ast/MixinReference.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/NamedParameter.java
+++ b/src/main/java/sirius/web/sass/ast/NamedParameter.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Number.java
+++ b/src/main/java/sirius/web/sass/ast/Number.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Operation.java
+++ b/src/main/java/sirius/web/sass/ast/Operation.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/RawCondition.java
+++ b/src/main/java/sirius/web/sass/ast/RawCondition.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Section.java
+++ b/src/main/java/sirius/web/sass/ast/Section.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Stylesheet.java
+++ b/src/main/java/sirius/web/sass/ast/Stylesheet.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Value.java
+++ b/src/main/java/sirius/web/sass/ast/Value.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/ValueList.java
+++ b/src/main/java/sirius/web/sass/ast/ValueList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/Variable.java
+++ b/src/main/java/sirius/web/sass/ast/Variable.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/sass/ast/VariableReference.java
+++ b/src/main/java/sirius/web/sass/ast/VariableReference.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/main/java/sirius/web/security/GenericUserManager.java
+++ b/src/main/java/sirius/web/security/GenericUserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/Helper.java
+++ b/src/main/java/sirius/web/security/Helper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/HelperConfig.java
+++ b/src/main/java/sirius/web/security/HelperConfig.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/HelperFactory.java
+++ b/src/main/java/sirius/web/security/HelperFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/LoginRequired.java
+++ b/src/main/java/sirius/web/security/LoginRequired.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/MaintenanceInfo.java
+++ b/src/main/java/sirius/web/security/MaintenanceInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/MessageProvider.java
+++ b/src/main/java/sirius/web/security/MessageProvider.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/NotPermission.java
+++ b/src/main/java/sirius/web/security/NotPermission.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/NotPermissionList.java
+++ b/src/main/java/sirius/web/security/NotPermissionList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/OTPVerifier.java
+++ b/src/main/java/sirius/web/security/OTPVerifier.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/Permission.java
+++ b/src/main/java/sirius/web/security/Permission.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/PermissionList.java
+++ b/src/main/java/sirius/web/security/PermissionList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/Permissions.java
+++ b/src/main/java/sirius/web/security/Permissions.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/Profile.java
+++ b/src/main/java/sirius/web/security/Profile.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/PublicUserManager.java
+++ b/src/main/java/sirius/web/security/PublicUserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/ScopeDefaultConfigController.java
+++ b/src/main/java/sirius/web/security/ScopeDefaultConfigController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/ScopeDetector.java
+++ b/src/main/java/sirius/web/security/ScopeDetector.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/ScopeInfo.java
+++ b/src/main/java/sirius/web/security/ScopeInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/UserContext.java
+++ b/src/main/java/sirius/web/security/UserContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/UserInfo.java
+++ b/src/main/java/sirius/web/security/UserInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/UserManager.java
+++ b/src/main/java/sirius/web/security/UserManager.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/UserManagerFactory.java
+++ b/src/main/java/sirius/web/security/UserManagerFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/UserSettings.java
+++ b/src/main/java/sirius/web/security/UserSettings.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/main/java/sirius/web/security/oauth/OAuth.java
+++ b/src/main/java/sirius/web/security/oauth/OAuth.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security.oauth;

--- a/src/main/java/sirius/web/security/oauth/OAuthAuthentication.java
+++ b/src/main/java/sirius/web/security/oauth/OAuthAuthentication.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security.oauth;

--- a/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
+++ b/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security.oauth;

--- a/src/main/java/sirius/web/services/ApiController.java
+++ b/src/main/java/sirius/web/services/ApiController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ApiPayloadCodec.java
+++ b/src/main/java/sirius/web/services/ApiPayloadCodec.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ApiResponsesFrom.java
+++ b/src/main/java/sirius/web/services/ApiResponsesFrom.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ApiResponsesFromList.java
+++ b/src/main/java/sirius/web/services/ApiResponsesFromList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/DefaultErrorResponsesJson.java
+++ b/src/main/java/sirius/web/services/DefaultErrorResponsesJson.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/DefaultErrorResponsesXml.java
+++ b/src/main/java/sirius/web/services/DefaultErrorResponsesXml.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/Format.java
+++ b/src/main/java/sirius/web/services/Format.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/InternalService.java
+++ b/src/main/java/sirius/web/services/InternalService.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/JSONCall.java
+++ b/src/main/java/sirius/web/services/JSONCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/JSONServiceCall.java
+++ b/src/main/java/sirius/web/services/JSONServiceCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/JSONStructuredOutput.java
+++ b/src/main/java/sirius/web/services/JSONStructuredOutput.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/JsonApiPayloadCodec.java
+++ b/src/main/java/sirius/web/services/JsonApiPayloadCodec.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ParametersFrom.java
+++ b/src/main/java/sirius/web/services/ParametersFrom.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ParametersFromList.java
+++ b/src/main/java/sirius/web/services/ParametersFromList.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/PublicApiInfo.java
+++ b/src/main/java/sirius/web/services/PublicApiInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/PublicApiSectionInfo.java
+++ b/src/main/java/sirius/web/services/PublicApiSectionInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/PublicService.java
+++ b/src/main/java/sirius/web/services/PublicService.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/PublicServiceInfo.java
+++ b/src/main/java/sirius/web/services/PublicServiceInfo.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/PublicServices.java
+++ b/src/main/java/sirius/web/services/PublicServices.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/RawServiceCall.java
+++ b/src/main/java/sirius/web/services/RawServiceCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ServiceCall.java
+++ b/src/main/java/sirius/web/services/ServiceCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/ServiceDispatcher.java
+++ b/src/main/java/sirius/web/services/ServiceDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/SharedParameters.java
+++ b/src/main/java/sirius/web/services/SharedParameters.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/SharedResponses.java
+++ b/src/main/java/sirius/web/services/SharedResponses.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/StructuredService.java
+++ b/src/main/java/sirius/web/services/StructuredService.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/services/XMLServiceCall.java
+++ b/src/main/java/sirius/web/services/XMLServiceCall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services;

--- a/src/main/java/sirius/web/templates/ClosedChannelHelper.java
+++ b/src/main/java/sirius/web/templates/ClosedChannelHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/ContentHandler.java
+++ b/src/main/java/sirius/web/templates/ContentHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/Generator.java
+++ b/src/main/java/sirius/web/templates/Generator.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/GlobalContextExtender.java
+++ b/src/main/java/sirius/web/templates/GlobalContextExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/LegacyDefaultGlobalsHandler.java
+++ b/src/main/java/sirius/web/templates/LegacyDefaultGlobalsHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/TagliatelleContentHandler.java
+++ b/src/main/java/sirius/web/templates/TagliatelleContentHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/Templates.java
+++ b/src/main/java/sirius/web/templates/Templates.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates;

--- a/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
+++ b/src/main/java/sirius/web/templates/pdf/AsyncLoadedImageElement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf;

--- a/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
+++ b/src/main/java/sirius/web/templates/pdf/ImageReplacedElementFactory.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf;

--- a/src/main/java/sirius/web/templates/pdf/InlinedSvgElement.java
+++ b/src/main/java/sirius/web/templates/pdf/InlinedSvgElement.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf;

--- a/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
+++ b/src/main/java/sirius/web/templates/pdf/SemaphoreContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf;

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePDFContentHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf;

--- a/src/main/java/sirius/web/templates/pdf/TagliatellePdfViaGotenbergChromiumContentHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/TagliatellePdfViaGotenbergChromiumContentHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf;

--- a/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/BarcodePdfReplaceHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf.handlers;

--- a/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/HttpPdfReplaceHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf.handlers;

--- a/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/PdfReplaceHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf.handlers;

--- a/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/QrCodePdfReplaceHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf.handlers;

--- a/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
+++ b/src/main/java/sirius/web/templates/pdf/handlers/ResourcePdfReplaceHandler.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf.handlers;

--- a/src/main/java/sirius/web/util/BarcodeController.java
+++ b/src/main/java/sirius/web/util/BarcodeController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.util;

--- a/src/main/java/sirius/web/util/IdGeneratorContext.java
+++ b/src/main/java/sirius/web/util/IdGeneratorContext.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.util;

--- a/src/main/java/sirius/web/util/LicenseController.java
+++ b/src/main/java/sirius/web/util/LicenseController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.util;

--- a/src/main/java/sirius/web/util/LinkBuilder.java
+++ b/src/main/java/sirius/web/util/LinkBuilder.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.util;

--- a/src/main/resources/assets/images/icons/up-right-from-square.svg
+++ b/src/main/resources/assets/images/icons/up-right-from-square.svg
@@ -1,9 +1,9 @@
 <!--
   - Made with all the love in the world
-  - by scireum in Remshalden, Germany
+  - by scireum in Stuttgart, Germany
   -
   - Copyright by scireum GmbH
-  - http://www.scireum.de - info@scireum.de
+  - https://www.scireum.de - info@scireum.de
   -->
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/src/main/resources/component-065-web.conf
+++ b/src/main/resources/component-065-web.conf
@@ -1,9 +1,9 @@
 #
 # Made with all the love in the world
-# by scireum in Remshalden, Germany
+# by scireum in Stuttgart, Germany
 #
 # Copyright by scireum GmbH
-# http://www.scireum.de - info@scireum.de
+# https://www.scireum.de - info@scireum.de
 #
 
 sirius {

--- a/src/main/resources/default/assets/tycho/styles/border.scss
+++ b/src/main/resources/default/assets/tycho/styles/border.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .bl-gray {

--- a/src/main/resources/default/assets/tycho/styles/buttons.scss
+++ b/src/main/resources/default/assets/tycho/styles/buttons.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .card, .flex-column, .flex-column-reverse {

--- a/src/main/resources/default/assets/tycho/styles/card.scss
+++ b/src/main/resources/default/assets/tycho/styles/card.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .card {

--- a/src/main/resources/default/assets/tycho/styles/colors.scss
+++ b/src/main/resources/default/assets/tycho/styles/colors.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 // Colors

--- a/src/main/resources/default/assets/tycho/styles/forms.scss
+++ b/src/main/resources/default/assets/tycho/styles/forms.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 

--- a/src/main/resources/default/assets/tycho/styles/misc.scss
+++ b/src/main/resources/default/assets/tycho/styles/misc.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .cursor-pointer {

--- a/src/main/resources/default/assets/tycho/styles/modal.scss
+++ b/src/main/resources/default/assets/tycho/styles/modal.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .modal-header {

--- a/src/main/resources/default/assets/tycho/styles/page.scss
+++ b/src/main/resources/default/assets/tycho/styles/page.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 body {

--- a/src/main/resources/default/assets/tycho/styles/sidebar.scss
+++ b/src/main/resources/default/assets/tycho/styles/sidebar.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .nav-header {

--- a/src/main/resources/default/assets/tycho/styles/sirius-colors.scss
+++ b/src/main/resources/default/assets/tycho/styles/sirius-colors.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 $sirius-accent: #f1c40f;

--- a/src/main/resources/default/assets/tycho/styles/tables.scss
+++ b/src/main/resources/default/assets/tycho/styles/tables.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .table-sm {

--- a/src/main/resources/default/assets/tycho/styles/tag.scss
+++ b/src/main/resources/default/assets/tycho/styles/tag.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .tycho-tag {

--- a/src/main/resources/default/assets/tycho/styles/tycho.scss
+++ b/src/main/resources/default/assets/tycho/styles/tycho.scss
@@ -1,9 +1,9 @@
 /*!
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 @import "/assets/common/styles/overlay";

--- a/src/main/resources/default/assets/wondergem/autocomplete/autocomplete.css
+++ b/src/main/resources/default/assets/wondergem/autocomplete/autocomplete.css
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .autocomplete-wrapper {

--- a/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
+++ b/src/main/resources/default/assets/wondergem/autocomplete/multiselect.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 var multiSelect = function (args) {

--- a/src/main/resources/default/assets/wondergem/datetimepicker/js/bootstrap-datetimepicker.js
+++ b/src/main/resources/default/assets/wondergem/datetimepicker/js/bootstrap-datetimepicker.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 /*global define:false */

--- a/src/main/resources/default/assets/wondergem/sparklines/sparkline.js
+++ b/src/main/resources/default/assets/wondergem/sparklines/sparkline.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  *
  * Inspired by https://github.com/eanbowman/sparkline.js
  */

--- a/src/main/resources/default/assets/wondergem/stylesheets/alerts.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/alerts.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/application.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/application.scss
@@ -2,10 +2,10 @@
 
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 // Core Variables

--- a/src/main/resources/default/assets/wondergem/stylesheets/breadcrumb.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/breadcrumb.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/buttons.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/buttons.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/carousel.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/carousel.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/code.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/code.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/dropdowns.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/dropdowns.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/filterbox.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/filterbox.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 .well.filter-box {

--- a/src/main/resources/default/assets/wondergem/stylesheets/footer.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/footer.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/forms.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/forms.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/help.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/help.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 // --------------------------------------------------

--- a/src/main/resources/default/assets/wondergem/stylesheets/labels-badges.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/labels-badges.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/navs.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/navs.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/opensans.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/opensans.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 @font-face {
   font-family: 'Open Sans';

--- a/src/main/resources/default/assets/wondergem/stylesheets/pagination.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/pagination.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/plugins.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/plugins.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 // --------------------------------------------------

--- a/src/main/resources/default/assets/wondergem/stylesheets/scaffolding.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/scaffolding.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/search.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/search.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/sprites.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/sprites.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/statistics.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/statistics.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/tables.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/tables.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/type.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/type.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/utilities.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/utilities.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/variables.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/variables.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/stylesheets/wells.scss
+++ b/src/main/resources/default/assets/wondergem/stylesheets/wells.scss
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 //

--- a/src/main/resources/default/assets/wondergem/tycho-history.js
+++ b/src/main/resources/default/assets/wondergem/tycho-history.js
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 function currentUri() {

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleExample.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleTestBase.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleTestBase.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleTestRef.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleTestRef.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/test/java/sirius/pasta/noodle/compiler/NoodleTestRefBase.java
+++ b/src/test/java/sirius/pasta/noodle/compiler/NoodleTestRefBase.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler;

--- a/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample.java
+++ b/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample2.java
+++ b/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample2.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample3.java
+++ b/src/test/java/sirius/pasta/noodle/sandbox/SandboxExample3.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox;

--- a/src/test/java/sirius/pasta/tagliatelle/DeprecatedMacro.java
+++ b/src/test/java/sirius/pasta/tagliatelle/DeprecatedMacro.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/ExampleHelper.java
+++ b/src/test/java/sirius/pasta/tagliatelle/ExampleHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/GenericTestObject.java
+++ b/src/test/java/sirius/pasta/tagliatelle/GenericTestObject.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/InnerClassTestObject.java
+++ b/src/test/java/sirius/pasta/tagliatelle/InnerClassTestObject.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/ReportBrokenTemplates.java
+++ b/src/test/java/sirius/pasta/tagliatelle/ReportBrokenTemplates.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/TestGlobalContextExtender.java
+++ b/src/test/java/sirius/pasta/tagliatelle/TestGlobalContextExtender.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/TestHelper.java
+++ b/src/test/java/sirius/pasta/tagliatelle/TestHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/pasta/tagliatelle/TestObject.java
+++ b/src/test/java/sirius/pasta/tagliatelle/TestObject.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle;

--- a/src/test/java/sirius/web/controller/GreetInput.java
+++ b/src/test/java/sirius/web/controller/GreetInput.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/test/java/sirius/web/controller/GreetResult.java
+++ b/src/test/java/sirius/web/controller/GreetResult.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/test/java/sirius/web/controller/TestController.java
+++ b/src/test/java/sirius/web/controller/TestController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller;

--- a/src/test/java/sirius/web/dispatch/TestDispatcher.java
+++ b/src/test/java/sirius/web/dispatch/TestDispatcher.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch;

--- a/src/test/java/sirius/web/http/CompletionPromiseTestController.java
+++ b/src/test/java/sirius/web/http/CompletionPromiseTestController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestController.java
+++ b/src/test/java/sirius/web/http/TestController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestFirewall.java
+++ b/src/test/java/sirius/web/http/TestFirewall.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestPipeliningController.java
+++ b/src/test/java/sirius/web/http/TestPipeliningController.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestRequest.java
+++ b/src/test/java/sirius/web/http/TestRequest.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/http/TestResponse.java
+++ b/src/test/java/sirius/web/http/TestResponse.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http;

--- a/src/test/java/sirius/web/mails/MailsMock.java
+++ b/src/test/java/sirius/web/mails/MailsMock.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails;

--- a/src/test/java/sirius/web/sass/ReportBrokenStylesheets.java
+++ b/src/test/java/sirius/web/sass/ReportBrokenStylesheets.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/test/java/sirius/web/sass/SassTest.java
+++ b/src/test/java/sirius/web/sass/SassTest.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass;

--- a/src/test/java/sirius/web/sass/ast/ColorTest.java
+++ b/src/test/java/sirius/web/sass/ast/ColorTest.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.sass.ast;

--- a/src/test/java/sirius/web/security/AnotherExampleHelper.java
+++ b/src/test/java/sirius/web/security/AnotherExampleHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/test/java/sirius/web/security/ExampleHelper.java
+++ b/src/test/java/sirius/web/security/ExampleHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/test/java/sirius/web/security/FactoryExampleHelper.java
+++ b/src/test/java/sirius/web/security/FactoryExampleHelper.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security;

--- a/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
+++ b/src/test/java/sirius/web/service/JSONStructuredOutputTest.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.service;

--- a/src/test/java/sirius/web/util/LinkBuilderTest.java
+++ b/src/test/java/sirius/web/util/LinkBuilderTest.java
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.util;

--- a/src/test/kotlin/sirius/pasta/noodle/CompilationContextTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/CompilationContextTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle

--- a/src/test/kotlin/sirius/pasta/noodle/compiler/CompilerTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/compiler/CompilerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler

--- a/src/test/kotlin/sirius/pasta/noodle/compiler/ParserTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/compiler/ParserTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.compiler

--- a/src/test/kotlin/sirius/pasta/noodle/macros/Base64ResourceMacroTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/macros/Base64ResourceMacroTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros

--- a/src/test/kotlin/sirius/pasta/noodle/macros/I18nMacroTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/macros/I18nMacroTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros

--- a/src/test/kotlin/sirius/pasta/noodle/macros/InlineSvgResourceMacroTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/macros/InlineSvgResourceMacroTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros

--- a/src/test/kotlin/sirius/pasta/noodle/macros/SvgResourceMacroTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/macros/SvgResourceMacroTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros

--- a/src/test/kotlin/sirius/pasta/noodle/macros/XmlMacroTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/macros/XmlMacroTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.macros

--- a/src/test/kotlin/sirius/pasta/noodle/sandbox/SandboxTest.kt
+++ b/src/test/kotlin/sirius/pasta/noodle/sandbox/SandboxTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.noodle.sandbox

--- a/src/test/kotlin/sirius/pasta/tagliatelle/CompilerTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/CompilerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle

--- a/src/test/kotlin/sirius/pasta/tagliatelle/DebugTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/DebugTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle

--- a/src/test/kotlin/sirius/pasta/tagliatelle/LocalScopeTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/LocalScopeTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle

--- a/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
+++ b/src/test/kotlin/sirius/pasta/tagliatelle/WondergemUploadTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.pasta.tagliatelle

--- a/src/test/kotlin/sirius/web/controller/ApplicationSCSSTest.kt
+++ b/src/test/kotlin/sirius/web/controller/ApplicationSCSSTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.controller

--- a/src/test/kotlin/sirius/web/controller/PageTest.kt
+++ b/src/test/kotlin/sirius/web/controller/PageTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 

--- a/src/test/kotlin/sirius/web/data/ExcelExportNightlyTest.kt
+++ b/src/test/kotlin/sirius/web/data/ExcelExportNightlyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data

--- a/src/test/kotlin/sirius/web/data/ExcelExportTest.kt
+++ b/src/test/kotlin/sirius/web/data/ExcelExportTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.data

--- a/src/test/kotlin/sirius/web/dispatch/AssetDispatcherTest.kt
+++ b/src/test/kotlin/sirius/web/dispatch/AssetDispatcherTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.dispatch

--- a/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
+++ b/src/test/kotlin/sirius/web/health/ConsoleControllerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health

--- a/src/test/kotlin/sirius/web/health/SystemControllerTest.kt
+++ b/src/test/kotlin/sirius/web/health/SystemControllerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.health

--- a/src/test/kotlin/sirius/web/http/CSRFTokenTest.kt
+++ b/src/test/kotlin/sirius/web/http/CSRFTokenTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/CorsTest.kt
+++ b/src/test/kotlin/sirius/web/http/CorsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/FirewallTest.kt
+++ b/src/test/kotlin/sirius/web/http/FirewallTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/IPRangeTest.kt
+++ b/src/test/kotlin/sirius/web/http/IPRangeTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 package sirius.web.http
 

--- a/src/test/kotlin/sirius/web/http/QueryStringTest.kt
+++ b/src/test/kotlin/sirius/web/http/QueryStringTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/TestChannelTracker.kt
+++ b/src/test/kotlin/sirius/web/http/TestChannelTracker.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/UploadTest.kt
+++ b/src/test/kotlin/sirius/web/http/UploadTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/UserAgentTest.kt
+++ b/src/test/kotlin/sirius/web/http/UserAgentTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/WebContextTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebContextTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerNightlyTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.http

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 @file:Suppress("DANGEROUS_CHARACTERS")
@@ -155,7 +155,7 @@ class WebServerTest {
         val data = callAndRead(uri, headers, expectedHeaders)
 
         // URLConnection does not understand GZIP and therefore does not unzip... :-(
-        assertEquals(1298, data.length)
+        assertEquals(1317, data.length)
     }
 
     @Test
@@ -168,7 +168,7 @@ class WebServerTest {
         val data = callAndRead(uri, headers, expectedHeaders)
 
         // URLConnection does not understand GZIP and therefore does not unzip... :-(
-        assertEquals(1298, data.length)
+        assertEquals(1317, data.length)
     }
 
     @Test

--- a/src/test/kotlin/sirius/web/mails/MailsTest.kt
+++ b/src/test/kotlin/sirius/web/mails/MailsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.mails

--- a/src/test/kotlin/sirius/web/security/OTPVerifierTest.kt
+++ b/src/test/kotlin/sirius/web/security/OTPVerifierTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security

--- a/src/test/kotlin/sirius/web/security/PermissionsRouteTest.kt
+++ b/src/test/kotlin/sirius/web/security/PermissionsRouteTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security

--- a/src/test/kotlin/sirius/web/security/PermissionsTest.kt
+++ b/src/test/kotlin/sirius/web/security/PermissionsTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security

--- a/src/test/kotlin/sirius/web/security/ProfileTest.kt
+++ b/src/test/kotlin/sirius/web/security/ProfileTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security

--- a/src/test/kotlin/sirius/web/security/ScopeInfoTest.kt
+++ b/src/test/kotlin/sirius/web/security/ScopeInfoTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security

--- a/src/test/kotlin/sirius/web/security/UserContextHelper.kt
+++ b/src/test/kotlin/sirius/web/security/UserContextHelper.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.security

--- a/src/test/kotlin/sirius/web/service/JsonOutputTest.kt
+++ b/src/test/kotlin/sirius/web/service/JsonOutputTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.service

--- a/src/test/kotlin/sirius/web/service/MappedServiceTest.kt
+++ b/src/test/kotlin/sirius/web/service/MappedServiceTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 @file:Suppress("DANGEROUS_CHARACTERS")

--- a/src/test/kotlin/sirius/web/service/SchemaFieldInfoTest.kt
+++ b/src/test/kotlin/sirius/web/service/SchemaFieldInfoTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 @file:Suppress("DANGEROUS_CHARACTERS")

--- a/src/test/kotlin/sirius/web/services/JsonOutputEquivalenceTest.kt
+++ b/src/test/kotlin/sirius/web/services/JsonOutputEquivalenceTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.services

--- a/src/test/kotlin/sirius/web/templates/LineBasedProcessorTest.kt
+++ b/src/test/kotlin/sirius/web/templates/LineBasedProcessorTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates

--- a/src/test/kotlin/sirius/web/templates/TemplatesTest.kt
+++ b/src/test/kotlin/sirius/web/templates/TemplatesTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates

--- a/src/test/kotlin/sirius/web/templates/pdf/handlers/PdfReplaceHandlerTest.kt
+++ b/src/test/kotlin/sirius/web/templates/pdf/handlers/PdfReplaceHandlerTest.kt
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 package sirius.web.templates.pdf.handlers

--- a/src/test/resources/assets/test_large.css
+++ b/src/test/resources/assets/test_large.css
@@ -1,9 +1,9 @@
 /*
  * Made with all the love in the world
- * by scireum in Remshalden, Germany
+ * by scireum in Stuttgart, Germany
  *
  * Copyright by scireum GmbH
- * http://www.scireum.de - info@scireum.de
+ * https://www.scireum.de - info@scireum.de
  */
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.


### PR DESCRIPTION
### Description

scireum sits in Stuttgart, but 484 files still credited Remshalden and linked the website over plain `http`. The files added over the last while already carry the current header, so the repository disagreed with itself - and since the outdated variant was the overwhelming majority, "copy the header from the file next door" reliably produced the wrong one. That is exactly how a file added this week ended up with Remshalden again, which is what prompted this.

Afterwards no occurrence of Remshalden is left anywhere in the repository: not in tracked text files, not in tracked binaries, not in untracked or ignored files in the tree. 508 files now carry the current header - the 484 changed here plus the 24 that already had it.

**Scope.** The replacement is mechanical and covers all three comment styles in use: the block comments of the Java, Kotlin, SCSS, CSS and JavaScript sources, the XML comment of an SVG asset, and the hash comment of `component-065-web.conf`. Exactly two lines per file are touched, and nothing else - every changed line in the diff is one of these four forms:

```
- * by scireum in Remshalden, Germany      + * by scireum in Stuttgart, Germany
- * http://www.scireum.de - info@scireum.de  + * https://www.scireum.de - info@scireum.de
```

### One knock-on change worth a look

`WebServerTest` asserts the exact byte length of a **gzipped** asset, and `test_large.css` carries the header too. The uncompressed size is unchanged - Remshalden loses a character while https gains one - and that assertion still passes at 60314. The compressed stream, however, is 19 bytes longer, so two expectations move from 1298 to 1317.

Those two assertions pin the output length of `java.util.zip.Deflater`. They are stable across a local macOS run and this pipeline, but they are fragile by nature: any future edit to that asset moves the number again, for no reason a reader of the test can guess. Dropping the exact-length check in favour of asserting that the response is shorter than the raw asset would be the better test - happy to raise that separately rather than smuggle it in here.

### Note on formatting

The IntelliJ formatter was deliberately **not** run over these files. The change edits comment text only and cannot violate the code style, whereas formatting 484 otherwise untouched files would bury the change under unrelated hunks. Say the word if you would rather have it run.

### Verification

Full suite green: 419 tests, 0 failures (`mvn clean test -Dtest.excluded.groups=nightly`). The two `WebServerTest` failures caused by the asset change were caught locally before pushing and are addressed above.

### Additional Notes

- This PR fixes or works on following ticket(s): none - housekeeping, split out of #1729 where the stale header was spotted in review
- This PR is related to PR: #1729

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc) - see the note above on why the formatter was not run; **SonarLint was not run** either, as it cannot be executed headlessly
- [x] Patch Tasks: not necessary
