### PR TITLE
Verifies the compressed asset instead of its mangled length

### DIFF
--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -44,6 +44,7 @@ import sirius.kernel.health.Log
 import sirius.kernel.health.LogHelper
 import sirius.web.controller.ControllerDispatcher
 import sirius.web.dispatch.TestDispatcher
+import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.Socket
@@ -52,6 +53,8 @@ import java.nio.charset.StandardCharsets
 import java.util.Collections
 import java.util.concurrent.TimeUnit
 import java.util.logging.Level
+import java.util.zip.GZIPInputStream
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -65,18 +68,51 @@ import kotlin.test.assertTrue
 @ExtendWith(SiriusExtension::class)
 class WebServerTest {
     companion object {
+        /**
+         * Asserts that the given response body is `assets/test_large.css` in compressed form.
+         *
+         * Decompressing and comparing is both stronger and steadier than pinning the length of the
+         * compressed body. It rejects a body which is truncated, corrupted or not compressed at all,
+         * while staying indifferent to the exact output of [java.util.zip.Deflater] - which shifts
+         * whenever the asset is edited or the JDK's compression changes, neither of which is a defect.
+         */
+        fun assertGzippedTestLargeCss(data: ByteArray) {
+            val decompressed = GZIPInputStream(ByteArrayInputStream(data)).use { it.readBytes() }
+
+            assertContentEquals(testLargeCss(), decompressed)
+        }
+
+        private fun testLargeCss(): ByteArray =
+            checkNotNull(WebServerTest::class.java.getResourceAsStream("/assets/test_large.css")) {
+                "The asset backing the compression tests is missing"
+            }.use { it.readBytes() }
+
         fun callAndRead(
             uri: String,
             outHeaders: Map<String, String?>? = null,
             expectedHeaders: Map<String, String?>? = null,
             requestMethod: String = "GET"
-        ): String {
+        ): String = String(callAndReadBytes(uri, outHeaders, expectedHeaders, requestMethod), StandardCharsets.UTF_8)
+
+        /**
+         * Requests the given URI and hands back the response body as it arrived.
+         *
+         * [callAndRead] decodes the body as UTF-8, which is lossy for anything but text: a gzipped body
+         * comes out of it as a string full of replacement characters whose length says nothing about the
+         * bytes on the wire. Such a body has to be read here instead.
+         */
+        fun callAndReadBytes(
+            uri: String,
+            outHeaders: Map<String, String?>? = null,
+            expectedHeaders: Map<String, String?>? = null,
+            requestMethod: String = "GET"
+        ): ByteArray {
             val connection = URI("http://localhost:9999$uri").toURL().openConnection() as HttpURLConnection
             connection.setRequestMethod(requestMethod)
 
             outHeaders?.forEach { (key, value) -> connection.addRequestProperty(key, value) }
             connection.connect()
-            val result = String(Streams.toByteArray(connection.inputStream), StandardCharsets.UTF_8)
+            val result = Streams.toByteArray(connection.inputStream)
             expectedHeaders?.forEach { (key, value) ->
                 if ("*" == value) {
                     if (Strings.isEmpty(connection.getHeaderField(key))) {
@@ -152,10 +188,9 @@ class WebServerTest {
         val headers = mapOf("accept-encoding" to "gzip")
         val expectedHeaders = mapOf("content-encoding" to "gzip")
 
-        val data = callAndRead(uri, headers, expectedHeaders)
+        val data = callAndReadBytes(uri, headers, expectedHeaders)
 
-        // URLConnection does not understand GZIP and therefore does not unzip... :-(
-        assertEquals(1317, data.length)
+        assertGzippedTestLargeCss(data)
     }
 
     @Test
@@ -165,10 +200,9 @@ class WebServerTest {
         val headers = mapOf("accept-encoding" to "gzip")
         val expectedHeaders = mapOf("content-encoding" to "gzip")
 
-        val data = callAndRead(uri, headers, expectedHeaders)
+        val data = callAndReadBytes(uri, headers, expectedHeaders)
 
-        // URLConnection does not understand GZIP and therefore does not unzip... :-(
-        assertEquals(1317, data.length)
+        assertGzippedTestLargeCss(data)
     }
 
     @Test

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -69,17 +69,26 @@ import kotlin.test.assertTrue
 class WebServerTest {
     companion object {
         /**
-         * Asserts that the given response body is `assets/test_large.css` in compressed form.
+         * Asserts that the given response body is `assets/test_large.css`, compressed, and correctly so.
          *
-         * Decompressing and comparing is both stronger and steadier than pinning the length of the
-         * compressed body. It rejects a body which is truncated, corrupted or not compressed at all,
-         * while staying indifferent to the exact output of [java.util.zip.Deflater] - which shifts
-         * whenever the asset is edited or the JDK's compression changes, neither of which is a defect.
+         * Both halves are needed: the size shows that compression took place, the comparison shows that
+         * it produced the asset. Together they reject a body which is truncated, corrupted, uncompressed
+         * or merely stored, while staying indifferent to the exact output of [java.util.zip.Deflater] -
+         * which shifts whenever the asset is edited or the JDK's compression changes, neither of which
+         * is a defect.
          */
         fun assertGzippedTestLargeCss(data: ByteArray) {
-            val decompressed = GZIPInputStream(ByteArrayInputStream(data)).use { it.readBytes() }
+            val asset = testLargeCss()
 
-            assertContentEquals(testLargeCss(), decompressed)
+            // decompressing alone would not show that anything was compressed: a gzip stream written with
+            // compression level zero stores its input verbatim, decompresses to the asset just as happily
+            // and is in fact a few bytes larger than it. Hence the size is asserted as well - and it needs
+            // no threshold, as any actual compression of this asset undercuts it by a factor of forty
+            assertTrue(
+                data.size < asset.size,
+                "Expected a compressed response, but its ${data.size} bytes exceed the ${asset.size} of the raw asset"
+            )
+            assertContentEquals(asset, GZIPInputStream(ByteArrayInputStream(data)).use { it.readBytes() })
         }
 
         private fun testLargeCss(): ByteArray =

--- a/src/test/kotlin/sirius/web/http/WebServerTest.kt
+++ b/src/test/kotlin/sirius/web/http/WebServerTest.kt
@@ -112,7 +112,7 @@ class WebServerTest {
 
             outHeaders?.forEach { (key, value) -> connection.addRequestProperty(key, value) }
             connection.connect()
-            val result = Streams.toByteArray(connection.inputStream)
+            val result = connection.inputStream.use { Streams.toByteArray(it) }
             expectedHeaders?.forEach { (key, value) ->
                 if ("*" == value) {
                     if (Strings.isEmpty(connection.getHeaderField(key))) {


### PR DESCRIPTION
### Description

Follow-up to the review of #1731, where Copilot objected to two tests asserting the **exact byte length of a gzipped response**. The first version of this pull request replaced that with an upper bound - and the objection raised against it was right: a bound is vaguer than what it replaced, and a threshold picked out of the air would have passed happily if compression had become three times worse.

Looking closer, the old assertion was not the strong test it appeared to be either. `callAndRead` decodes the body as UTF-8, and gzip bytes are not valid UTF-8, so the number being pinned was **the character count of a lossy string**. Measured locally: 1290 compressed bytes decode to 1225 characters containing 550 replacement characters, and re-encoding them does not reproduce the original bytes. The comment above the assertion admitted the workaround - *"URLConnection does not understand GZIP and therefore does not unzip... :-("* - so the length was what the helper happened to offer, not what the test meant to check.

So both tests now read the body as bytes, decompress it, and compare it to the asset:

```kotlin
val data = callAndReadBytes(uri, headers, expectedHeaders)

assertGzippedTestLargeCss(data)
```

The assertion checks **two** things, and both are needed:

- **that compression took place** - the body must be smaller than the asset
- **that it was correct** - the body must decompress to the asset, byte for byte

Decompressing alone would not cover the first. A gzip stream written with compression level zero stores its input verbatim: it is valid gzip, it decompresses to the asset byte for byte, and it measures 60342 bytes against the asset's 60314. A server that quietly stopped compressing while still announcing `Content-Encoding: gzip` would have passed a decompress-only check. The size assertion needs no threshold precisely because of that: level zero comes out *larger* than its input, while real compression of this asset undercuts it by a factor of forty.

**Taken together this is stronger than the assertion it replaces, not weaker.** A truncated, corrupted, doubly compressed, uncompressed or merely stored body all fail it, where previously any of them could have slipped through by landing on the same character count. And it is steady: the exact deflate output stops mattering, so an edit to the stylesheet or a JDK whose compression differs no longer turns the test red for nothing. The header migration in #1731 moved that number from 1298 to 1317 with no behaviour changing at all.

`callAndRead` keeps its signature and delegates to a new `callAndReadBytes`, so any future test needing an unmangled body has it.

### Verification

`WebServerTest`: 80 tests, 0 failures.

Rather than argue that the new assertion is sensitive, it was verified by breaking things on purpose - each of these was applied in turn and the test caught all three:

| deliberate defect | result |
| --- | --- |
| body served uncompressed (pointed at the non-compressing route) | ✅ caught |
| body stored rather than compressed (valid gzip at level 0) | ✅ caught |
| body truncated to half its length | ✅ caught |
| compared against a different asset | ✅ caught |

Also in here: the helper left every `HttpURLConnection` response stream open, because `Streams.toByteArray` transfers into a `ByteArrayOutputStream` without closing its source. Raised in review, fixed with `use`. It predates this branch and only entered the diff because the refactoring moved the line.

### Additional Notes

- This PR fixes or works on following ticket(s): none - follow-up to review feedback on #1731
- This PR is related to PR: #1731

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc) - **SonarLint was not run**, as it cannot be executed headlessly
- [x] Patch Tasks: not necessary
