### PR TITLE
Exposes the OAuth token expiry as an instant

### DIFF
--- a/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
+++ b/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
@@ -13,6 +13,7 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Strings;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
@@ -56,9 +57,15 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
         if (OAuth.TOKEN_TYPE_BEARER.equalsIgnoreCase(type)) {
             try {
                 // Try to read the exact refresh token expiration date from the JWT token itself
-                LocalDateTime refreshTokenExpiresAt =
-                        JWT.decode(refreshToken).getExpiresAtAsInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
-                return new ReceivedTokens(accessToken, refreshToken, type, accessTokenExpiresAt, refreshTokenExpiresAt);
+                Instant expiry = JWT.decode(refreshToken).getExpiresAtAsInstant();
+                if (expiry != null) {
+                    return new ReceivedTokens(accessToken,
+                                              refreshToken,
+                                              type,
+                                              accessTokenExpiresAt,
+                                              expiry.atZone(ZoneOffset.UTC).toLocalDateTime());
+                }
+                // The JWT carries no expiration date, fall back to the estimates below
             } catch (JWTDecodeException _) {
                 // No valid JWT, fall back to implementation from OAuth expires_in or the default value
             }

--- a/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
+++ b/src/main/java/sirius/web/security/oauth/ReceivedTokens.java
@@ -14,8 +14,7 @@ import tools.jackson.databind.node.ObjectNode;
 import sirius.kernel.commons.Strings;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Represents the tokens received from an OAuth authorization server. This is used to read the token in a standard
@@ -25,13 +24,15 @@ import java.time.ZoneOffset;
  * @param refreshToken          the refresh token received from the authorization server, might be null if the server
  *                              response contains no refresh token (e.g. when refreshing an access token)
  * @param type                  the type of the tokens received from the authorization server, e.g. "Bearer" or "MAC"
- * @param accessTokenExpiresAt  the date at which the access token expires, might be null if the server response
+ * @param accessTokenExpiresAt  the instant at which the access token expires, might be null if the server response
  *                              contains no information
- * @param refreshTokenExpiresAt the date at which the refresh token expires, might be null if no refresh token was
+ * @param refreshTokenExpiresAt the instant at which the refresh token expires, might be null if no refresh token was
  *                              returned or estimated if no JWT bearer token is given
+ * @apiNote The expiries are instants, not local dates. Rendering one for a user or storing it in a date column
+ * requires an explicit time zone, which is a decision only the caller can make.
  */
-public record ReceivedTokens(String accessToken, String refreshToken, String type, LocalDateTime accessTokenExpiresAt,
-                             LocalDateTime refreshTokenExpiresAt) {
+public record ReceivedTokens(String accessToken, String refreshToken, String type, Instant accessTokenExpiresAt,
+                             Instant refreshTokenExpiresAt) {
 
     private static final long TWO_DAYS_IN_SECONDS = 2 * 24 * 60 * 60L;
     private static final int MINIMUM_REFRESH_EXPIRES_DAYS = 1;
@@ -47,8 +48,8 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
         String refreshToken = response.path(OAuth.REFRESH_TOKEN).asString("");
         String type = response.required(OAuth.TOKEN_TYPE).asString("");
         long accessTokenExpiresIn = response.path(OAuth.EXPIRES_IN).asLong(0L);
-        LocalDateTime accessTokenExpiresAt =
-                accessTokenExpiresIn > 0 ? LocalDateTime.now().plusSeconds(accessTokenExpiresIn) : null;
+        Instant accessTokenExpiresAt =
+                accessTokenExpiresIn > 0 ? Instant.now().plusSeconds(accessTokenExpiresIn) : null;
 
         if (Strings.isEmpty(refreshToken)) {
             return new ReceivedTokens(accessToken, null, type, accessTokenExpiresAt, null);
@@ -59,11 +60,7 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
                 // Try to read the exact refresh token expiration date from the JWT token itself
                 Instant expiry = JWT.decode(refreshToken).getExpiresAtAsInstant();
                 if (expiry != null) {
-                    return new ReceivedTokens(accessToken,
-                                              refreshToken,
-                                              type,
-                                              accessTokenExpiresAt,
-                                              expiry.atZone(ZoneOffset.UTC).toLocalDateTime());
+                    return new ReceivedTokens(accessToken, refreshToken, type, accessTokenExpiresAt, expiry);
                 }
                 // The JWT carries no expiration date, fall back to the estimates below
             } catch (JWTDecodeException _) {
@@ -78,7 +75,7 @@ public record ReceivedTokens(String accessToken, String refreshToken, String typ
         }
 
         // Use default value tomorrow, we expect a refresh token to be valid at least for one more day
-        LocalDateTime expiresDate = LocalDateTime.now().plusDays(MINIMUM_REFRESH_EXPIRES_DAYS);
+        Instant expiresDate = Instant.now().plus(MINIMUM_REFRESH_EXPIRES_DAYS, ChronoUnit.DAYS);
         return new ReceivedTokens(accessToken, refreshToken, type, accessTokenExpiresAt, expiresDate);
     }
 }

--- a/src/test/java/sirius/web/security/oauth/ReceivedTokensTest.java
+++ b/src/test/java/sirius/web/security/oauth/ReceivedTokensTest.java
@@ -16,9 +16,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,7 +32,7 @@ public class ReceivedTokensTest {
 
     @Test
     public void readsRefreshTokenExpiryFromJwtBearerToken() {
-        Instant expiry = Instant.now().plus(30, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+        Instant expiry = Instant.parse("2039-01-15T12:34:56Z");
         ObjectNode response =
                 bearerResponse().put(OAuth.REFRESH_TOKEN, jwtExpiringAt(expiry)).put(OAuth.EXPIRES_IN, 3600);
 
@@ -42,13 +40,29 @@ public class ReceivedTokensTest {
 
         assertEquals("the-access-token", tokens.accessToken());
         assertEquals(OAuth.TOKEN_TYPE_BEARER, tokens.type());
-        assertEquals(LocalDateTime.ofInstant(expiry, ZoneOffset.UTC), tokens.refreshTokenExpiresAt());
+        assertEquals(expiry, tokens.refreshTokenExpiresAt());
         assertCloseToNowPlusSeconds(3600, tokens.accessTokenExpiresAt());
     }
 
     @Test
+    public void readsRefreshTokenExpiryIndependentlyOfTheSystemTimeZone() {
+        Instant expiry = Instant.parse("2039-01-15T12:34:56Z");
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+            ObjectNode response = bearerResponse().put(OAuth.REFRESH_TOKEN, jwtExpiringAt(expiry));
+
+            ReceivedTokens tokens = ReceivedTokens.fromJson(response);
+
+            assertEquals(expiry, tokens.refreshTokenExpiresAt());
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
+
+    @Test
     public void ignoresJwtRefreshTokenOfOtherTokenTypes() {
-        Instant expiry = Instant.now().plus(30, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+        Instant expiry = Instant.parse("2039-01-15T12:34:56Z");
         ObjectNode response = Json.createObject()
                                   .put(OAuth.ACCESS_TOKEN, "the-access-token")
                                   .put(OAuth.TOKEN_TYPE, "MAC")
@@ -155,8 +169,8 @@ public class ReceivedTokensTest {
      * @param seconds the number of seconds the given date is expected to lie in the future
      * @param actual  the date to check
      */
-    private static void assertCloseToNowPlusSeconds(long seconds, LocalDateTime actual) {
-        Duration deviation = Duration.between(LocalDateTime.now().plusSeconds(seconds), actual).abs();
+    private static void assertCloseToNowPlusSeconds(long seconds, Instant actual) {
+        Duration deviation = Duration.between(Instant.now().plusSeconds(seconds), actual).abs();
         assertTrue(deviation.compareTo(MAXIMUM_DEVIATION) < 0,
                    "Expected a date in " + seconds + "s, but was off by " + deviation + ": " + actual);
     }

--- a/src/test/java/sirius/web/security/oauth/ReceivedTokensTest.java
+++ b/src/test/java/sirius/web/security/oauth/ReceivedTokensTest.java
@@ -61,6 +61,17 @@ public class ReceivedTokensTest {
     }
 
     @Test
+    public void fallsBackToTomorrowForJwtRefreshTokensWithoutExpiry() {
+        String jwtWithoutExpiry = JWT.create().sign(Algorithm.none());
+        ObjectNode response = bearerResponse().put(OAuth.REFRESH_TOKEN, jwtWithoutExpiry).put(OAuth.EXPIRES_IN, 3600);
+
+        ReceivedTokens tokens = ReceivedTokens.fromJson(response);
+
+        assertEquals(jwtWithoutExpiry, tokens.refreshToken());
+        assertCloseToNowPlusSeconds(Duration.ofDays(1).toSeconds(), tokens.refreshTokenExpiresAt());
+    }
+
+    @Test
     public void fallsBackToTomorrowForOpaqueRefreshTokens() {
         ObjectNode response =
                 bearerResponse().put(OAuth.REFRESH_TOKEN, "an-opaque-refresh-token").put(OAuth.EXPIRES_IN, 3600);


### PR DESCRIPTION
### Description

> [!WARNING]
> **Breaking:** both expiry fields of `ReceivedTokens` change from `LocalDateTime` to `Instant`. Consumers storing them in a date column or rendering them have to convert explicitly.

Two fixes in `ReceivedTokens.fromJson`, found while writing the tests in #1734:

1. **Crash on JWT refresh tokens without an `exp` claim.** The claim is optional and `getExpiresAtAsInstant()` returns `null`, so the conversion threw a `NullPointerException`. Being no `JWTDecodeException`, it escaped the surrounding `catch` and aborted the token exchange instead of falling back to the usual estimate.

2. **Expiries are instants now.** An expiry is a point in time; turning it into a `LocalDateTime` discards the offset and leaves consumers guessing which zone to read it in. The JWT claim is an `Instant` to begin with, so the conversion only ever existed to satisfy the type of this record. It was also inconsistent: the JWT expiry used UTC while the other date came from the system clock, so a refresh token could look expired hours early or stay valid hours too long, depending on the host.

An earlier revision normalised everything to the system zone instead. That only moved the ambiguity and has been dropped.

### Migration

```java
// before
credentials.setRefreshTokenExpiresAt(tokens.refreshTokenExpiresAt());

// after
credentials.setRefreshTokenExpiresAt(tokens.refreshTokenExpiresAt() == null ?
                                     null :
                                     LocalDateTime.ofInstant(tokens.refreshTokenExpiresAt(), ZoneId.systemDefault()));
```

`ZoneId.systemDefault()` reproduces the previous behaviour. Existing rows need no migration, they are overwritten on the next refresh. Nothing inside sirius-web uses these fields.

### Additional Notes

- This PR fixes or works on following ticket(s): none, found while reviewing #1733.
- This PR is related to PR: #1734, already merged.

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag. — not necessary

IntelliJ formatter reports *Formatted well*; SonarLint cannot run headlessly, so please run *Analyze VCS Changed Files* before merging.

### Verification

Both fixes have regression tests confirmed to fail without them. The suite is green under `TZ=UTC`, `Europe/Berlin`, `America/Anchorage` and `Pacific/Kiritimati`, with one test pinning the result against a forced non-UTC default zone. Fixtures use fixed instants, so they cannot flake on a DST transition.
